### PR TITLE
NSJSONSerialization: Fix string parsing

### DIFF
--- a/Source/NSJSONSerialization.m
+++ b/Source/NSJSONSerialization.m
@@ -409,6 +409,13 @@ parseString(ParserState *state)
       next = consumeChar(state);
     }
 
+  if (currentChar(state) != '"')
+  {
+	  [val release];
+	  parseError(state);
+	  return nil;
+  }
+
   if (bufferIndex > 0)
     {
       NSMutableString *str;


### PR DESCRIPTION
When an invalid string is passed to JSONObjectWithData like this

NSError * NSJSONError = nil;
NSString * json_string = [NSString stringWithFormat:@"\"key1"];
NSDictionary * json_object = [NSJSONSerialization JSONObjectWithData:[json_string dataUsingEncoding:NSUTF8StringEncoding] options:0 error:&NSJSONError];

OR like this

NSError * NSJSONError = nil;
NSString * json_string = [NSString stringWithFormat:@"{\"key1"];
NSDictionary * json_object = [NSJSONSerialization JSONObjectWithData:[json_string dataUsingEncoding:NSUTF8StringEncoding] options:0 error:&NSJSONError];

An exception as below is raised

Uncaught exception NSRangeException, reason: in getCharacters:range:, range { 6, 64 } extends beyond size (5)

This happens because the string is starting with double quotes " but not ending with double quotes " and we reach
end of data. So if string is invalid the program should not generate the exception. Instead it should set error to
JSON Parse error. This patch fixes the issue.

Signed-off-by: Abbas Raza <abbas.raza.1707@gmail.com>