### PR TITLE
Fix Android assets support for bundle directories

### DIFF
--- a/Source/NSBundle.m
+++ b/Source/NSBundle.m
@@ -2237,7 +2237,9 @@ IF_NO_GC(
     subPath: subPath localization: nil] objectEnumerator];
   while ((path = [pathlist nextObject]) != nil)
     {
-      if (YES == [mgr isReadableFileAtPath: path])
+      NSString *lastPathComponent = [path lastPathComponent];
+      if ([lastPathComponent isEqualToString:file]
+        && [mgr isReadableFileAtPath: path])
         {
           return path;
         }


### PR DESCRIPTION
Fixes an bug in #137 where paths such as `<bundle>/Resources/en.lproj` would be incorrectly returned when calling `-pathForResource:ofType:` with a non-existent filename.