### PR TITLE
Add missing export declarations required by libs-gui on Windows MSVC

### DIFF
--- a/Headers/Foundation/NSDistributedNotificationCenter.h
+++ b/Headers/Foundation/NSDistributedNotificationCenter.h
@@ -78,6 +78,7 @@ GS_EXPORT NSString* const GSPublicNotificationCenterType;
 GS_EXPORT NSString* const GSNetworkNotificationCenterType;
 #endif
 
+GS_EXPORT_CLASS
 @interface	NSDistributedNotificationCenter : NSNotificationCenter
 {
 #if	GS_EXPOSE(NSDistributedNotificationCenter)

--- a/Headers/Foundation/NSSpellServer.h
+++ b/Headers/Foundation/NSSpellServer.h
@@ -163,6 +163,12 @@ findMisspelledWordInString: (NSString *)stringToCheck
 
 @end
 
+#if	!NO_GNUSTEP
+// Function to create name for spell server
+GS_EXPORT NSString*
+GSSpellServerName(NSString *vendor, NSString *language);
+#endif
+
 #if     defined(__cplusplus)
 }
 #endif

--- a/Headers/GNUstepBase/GSLock.h
+++ b/Headers/GNUstepBase/GSLock.h
@@ -42,6 +42,7 @@ extern "C" {
 
 @class NSNotification;
 
+GS_EXPORT_CLASS
 @interface	GSLazyLock : NSLock
 {
   int	locked;
@@ -49,6 +50,7 @@ extern "C" {
 - (void) _becomeThreaded: (NSNotification*)n;
 @end
 
+GS_EXPORT_CLASS
 @interface	GSLazyRecursiveLock : NSRecursiveLock
 {
   int	counter;

--- a/Source/NSSpellServer.m
+++ b/Source/NSSpellServer.m
@@ -46,7 +46,7 @@ static NSConnection *spellServerConnection = nil;
 static NSString *GNU_UserDictionariesDir = @"Dictionaries";
 
 // Function to create name for spell server....
-NSString*
+GS_DECLARE NSString*
 GSSpellServerName(NSString *vendor, NSString *language)
 {
   NSString *serverName = nil;


### PR DESCRIPTION
A couple small tweaks that are required to fix build errors in libs-gui when building for Windows MSVC.