### PR TITLE
NSNumber: Rewrite hashing method

### DIFF
--- a/Tests/base/NSNumber/test01.m
+++ b/Tests/base/NSNumber/test01.m
@@ -113,6 +113,60 @@ int main()
       PASS([zero compare: n] == NSOrderedDescending, "zero greater than -1.01")
 
     END_SET("zero checks")
+
+    START_SET("hashing")
+      // Consistency - a number's hash should be the same every time.
+      NSNumber *n = [NSNumber numberWithInt:42];
+      PASS([n hash] == [n hash], "hashing is consistent for int");
+      n = [NSNumber numberWithFloat:M_PI];
+      PASS([n hash] == [n hash], "hashing is consistent for float");
+      n = [NSNumber numberWithDouble:M_PI];
+      PASS([n hash] == [n hash], "hashing is consistent for double");
+
+      // Equality - equal numbers should have the same hash.
+      NSNumber *a = [NSNumber numberWithInt:42];
+      NSNumber *b = [NSNumber numberWithInt:42];
+      PASS([a hash] == [b hash], "equal int numbers have same hash");
+      a = [NSNumber numberWithFloat:42.0f];
+      b = [NSNumber numberWithDouble:42.0];
+      PASS([a hash] == [b hash], "42.0f and 42.0dd have the same hash");
+      a = [NSNumber numberWithLongLong:LLONG_MAX];
+      b = [NSNumber numberWithUnsignedLongLong:LLONG_MAX];
+      PASS([a hash] == [b hash], "LLONG_MAX and ULLONG_MAX-ish have same hash");
+
+      // Floating point numbers with zero fractional component.
+      a = [NSNumber numberWithDouble:42.0];
+      b = [NSNumber numberWithInt:42];
+      PASS([a hash] == [b hash], "double with zero fractional part hashes like int");
+      a = [NSNumber numberWithFloat:123.0f];
+      b = [NSNumber numberWithInt:123];
+      PASS([a hash] == [b hash], "float with zero fractional part hashes like int");
+
+      // Special Cases - Zero and NaN.
+      a = [NSNumber numberWithDouble:0.0];
+      PASS([a hash] == 0, "hash for 0.0 is 0");
+      a = [NSNumber numberWithDouble:-0.0];
+      PASS([a hash] == 0, "hash for -0.0 is 0");
+      a = [NSNumber numberWithFloat:0.0f];
+      PASS([a hash] == 0, "hash for 0.0f is 0");
+      a = [NSDecimalNumber notANumber];
+      PASS([a hash] == 0, "hash for NaN is 0");
+      
+      // Verify different numbers have different hashes.
+      NSNumber *n1 = [NSNumber numberWithInt:1];
+      NSNumber *n2 = [NSNumber numberWithInt:2];
+      PASS([n1 hash] != [n2 hash], "different integers have different hashes");
+      
+      NSNumber *f1 = [NSNumber numberWithFloat:1.0f];
+      NSNumber *f2 = [NSNumber numberWithFloat:1.1f];
+      PASS([f1 hash] != [f2 hash], "different floats have different hashes");
+      
+      NSNumber *d1 = [NSNumber numberWithDouble:3.14159];
+      NSNumber *d2 = [NSNumber numberWithDouble:3.14158];
+      PASS([d1 hash] != [d2 hash], "different doubles have different hashes");
+
+    END_SET("hashing")
+
   END_SET("NSNumber")
 
   return 0;


### PR DESCRIPTION
`-[NSNumber hash]` currently converts the number to a double value and casts it to an NSUInteger. The problem with this approach is that fractional numbers with the same integral part, but different fractional part are treated as being equal.

I looked into using a proper, still non-cryptographic hash function, such as the ones proposed here (https://nullprogram.com/blog/2018/07/31/), but this is overkill for the hash method.

Apple's implementation uses the magic `0x9e3779b1` and does an integer multiplication with the numbers unsigned integer value. `0x9e3779b1` is the closest prime to `0x9e3779b9` which is the integral part of the Golden Ratio's fractional part. https://lkml.org/lkml/2016/4/29/838 features a great discussion to why this is not a great idea.

If there is a need (I still do not understand the purpose of -[NSNumber hash]) for a hash function with good scattering properties, I'd recommend we instead use [SplitMix64](https://xoshiro.di.unimi.it/splitmix64.c).