### PR TITLE
Add safety in -[NSBundle assetDirForPath:]

### DIFF
--- a/Source/NSBundle.m
+++ b/Source/NSBundle.m
@@ -3433,7 +3433,7 @@ IF_NO_ARC(
     {
       NSString *resourcePath = [_mainBundle resourcePath];
 
-      if ([path hasPrefix: resourcePath])
+      if (resourcePath && [path hasPrefix: resourcePath])
 	{
 	  NSString *assetPath = @"";
 


### PR DESCRIPTION
We’re seeing the following crashes on some Android devices when initially loading the main bundle:

```
objc_exception_throw (eh_personality.c:258)
_i_NSException__raise (NSException.m:1615)
_c_NSException__raise_format_arguments_ (NSException.m:1494)
_c_NSException__raise_format_ (NSException.m:1479)
_i_NSString__rangeOfString_options_range_locale_ (NSString.m:2563)
_i_NSString__hasPrefix_ (NSString.m:3143)
_c_NSBundle_GNUstep_assetDirForPath_ (NSBundle.m:3482)
_i_NSDirectoryEnumerator__initWithDirectoryPath_recurseIntoSubdirectories_followSymlinks_justContents_skipHidden_errorHandler_for_ (NSFileManager.m:2780)
_i_NSDirectoryEnumerator__initWithDirectoryPath_recurseIntoSubdirectories_followSymlinks_justContents_for_ (NSFileManager.m:2821)
_i_NSFileManager__directoryContentsAtPath_ (NSFileManager.m:2517)
bundle_directory_readable (NSBundle.m:677)
_i_NSBundle__initWithPath_ (NSBundle.m:2158)
_c_NSBundle__mainBundle (NSBundle.m:1882)
```

The actual issue is probably a bit deeper, but I think it still makes sense to add this safety here. We’re also already doing the same in `-assetForPath:withMode:` right above.