### PR TITLE
Don't return NSXMLDTD objects

### DIFF
--- a/Source/NSXMLNode.m
+++ b/Source/NSXMLNode.m
@@ -379,8 +379,8 @@ isEqualTree(xmlNodePtr nodeA, xmlNodePtr nodeB)
 		kind = NSXMLElementKind;
 		break;
 	      case XML_DTD_NODE:
-		cls = [NSXMLDTD class];
-		kind = NSXMLDTDKind;
+		//DTD Node causes crashes 
+    return nil;
 		break;
 	      case XML_ATTRIBUTE_DECL: 
 		cls = [NSXMLDTDNode class];

--- a/Source/NSXMLNode.m
+++ b/Source/NSXMLNode.m
@@ -383,8 +383,8 @@ isEqualTree(xmlNodePtr nodeA, xmlNodePtr nodeB)
 		kind = NSXMLDTDKind;
 		break;
 	      case XML_ATTRIBUTE_DECL: 
-		// DTD nodes are not handled correctly and cause crashes. This just ignores them until a proper way to deal with them is found
-        return nil;
+		cls = [NSXMLDTDNode class];
+		kind = NSXMLAttributeDeclarationKind;
 		break;
 	      case XML_ELEMENT_DECL: 
 		cls = [NSXMLDTDNode class];

--- a/Source/NSXMLNode.m
+++ b/Source/NSXMLNode.m
@@ -383,8 +383,8 @@ isEqualTree(xmlNodePtr nodeA, xmlNodePtr nodeB)
 		kind = NSXMLDTDKind;
 		break;
 	      case XML_ATTRIBUTE_DECL: 
-		cls = [NSXMLDTDNode class];
-		kind = NSXMLAttributeDeclarationKind;
+		// DTD nodes are not handled correctly and cause crashes. This just ignores them until a proper way to deal with them is found
+        return nil;
 		break;
 	      case XML_ELEMENT_DECL: 
 		cls = [NSXMLDTDNode class];


### PR DESCRIPTION
Creating this PR for a patch. No need to merge this in.

GNUstep does not deal correctly with DTD nodes, which causes crashes. Just disable their creation until this is properly dealt with.