### PR TITLE
Make writeDictionary and setPermissions public methods of NSUserDefaults

### DIFF
--- a/Headers/Foundation/NSUserDefaults.h
+++ b/Headers/Foundation/NSUserDefaults.h
@@ -523,6 +523,18 @@ GS_EXPORT_CLASS
  * available thereafter.
  */
 - (void) registerDefaults: (NSDictionary*)newVals;
+
+/**
+ * Set appropriate file permissions
+*/
+- (void) setPermissions: (NSString *) file;
+
+/**
+ * Writes dictionary to a file or removes empty defaults dictionary if
+ * supplied dictioonary is nil.
+*/
+- (BOOL) writeDictionary: (NSDictionary*)dict
+                  toFile: (NSString*)file;
 @end
 
 #if	defined(__cplusplus)

--- a/Source/NSUserDefaults.m
+++ b/Source/NSUserDefaults.m
@@ -322,80 +322,6 @@ updateCache(NSUserDefaults *self)
     }
 }
 
-static void
-setPermissions(NSString *file)
-{
-  NSFileManager	*mgr = [NSFileManager defaultManager];
-  NSDictionary	*attr;
-  uint32_t	desired;
-  uint32_t	attributes;
-
-  attr = [mgr fileAttributesAtPath: file
-		      traverseLink: YES];
-  attributes = [attr filePosixPermissions];
-#if	!(defined(S_IRUSR) && defined(S_IWUSR))
-  desired = 0600;
-#else
-  desired = (S_IRUSR|S_IWUSR);
-#endif
-  if (attributes != desired)
-    {
-      NSMutableDictionary	*enforced_attributes;
-      NSNumber			*permissions;
-
-      enforced_attributes
-	= [NSMutableDictionary dictionaryWithDictionary:
-	[mgr fileAttributesAtPath: file
-		     traverseLink: YES]];
-
-      permissions = [NSNumberClass numberWithUnsignedLong: desired];
-      [enforced_attributes setObject: permissions
-			      forKey: NSFilePosixPermissions];
-
-      [mgr changeFileAttributes: enforced_attributes
-			 atPath: file];
-    }
-}
-
-static BOOL
-writeDictionary(NSDictionary *dict, NSString *file)
-{
-  if ([file length] == 0)
-    {
-      NSLog(@"Defaults database filename is empty when writing");
-    }
-  else if (nil == dict)
-    {
-      NSFileManager	*mgr = [NSFileManager defaultManager];
-
-      return [mgr removeFileAtPath: file handler: nil];
-    }
-  else
-    {
-      NSData	*data;
-      NSString	*err;
-
-      err = nil;
-      data = [NSPropertyListSerialization dataFromPropertyList: dict
-	       format: NSPropertyListXMLFormat_v1_0
-	       errorDescription: &err];
-      if (data == nil)
-	{
-	  NSLog(@"Failed to serialize defaults database for writing: %@", err);
-	}
-      else if ([data writeToFile: file atomically: YES] == NO)
-	{
-	  NSLog(@"Failed to write defaults database to file: %@", file);
-	}
-      else
-	{
-	  setPermissions(file);
-	  return YES;
-	}
-    }
-  return NO;
-}
-
 /**
  * Returns the list of languages retrieved from the operating system, in
  * decreasing order of preference. Returns an empty array if the information
@@ -2389,6 +2315,78 @@ static BOOL isPlistObject(id o)
   NS_ENDHANDLER
 }
 
+- (void) setPermissions: (NSString *) file
+{
+  NSFileManager	*mgr = [NSFileManager defaultManager];
+  NSDictionary	*attr;
+  uint32_t	desired;
+  uint32_t	attributes;
+
+  attr = [mgr fileAttributesAtPath: file
+		      traverseLink: YES];
+  attributes = [attr filePosixPermissions];
+#if	!(defined(S_IRUSR) && defined(S_IWUSR))
+  desired = 0600;
+#else
+  desired = (S_IRUSR|S_IWUSR);
+#endif
+  if (attributes != desired)
+    {
+      NSMutableDictionary	*enforced_attributes;
+      NSNumber			*permissions;
+
+      enforced_attributes
+	= [NSMutableDictionary dictionaryWithDictionary:
+	[mgr fileAttributesAtPath: file
+		     traverseLink: YES]];
+
+      permissions = [NSNumberClass numberWithUnsignedLong: desired];
+      [enforced_attributes setObject: permissions
+			      forKey: NSFilePosixPermissions];
+
+      [mgr changeFileAttributes: enforced_attributes
+			 atPath: file];
+    }
+}
+
+- (BOOL) writeDictionary: (NSDictionary*)dict
+                  toFile: (NSString*)file
+{
+  if ([file length] == 0)
+    {
+      NSLog(@"Defaults database filename is empty when writing");
+    }
+  else if (nil == dict)
+    {
+      NSFileManager	*mgr = [NSFileManager defaultManager];
+
+      return [mgr removeFileAtPath: file handler: nil];
+    }
+  else
+    {
+      NSData	*data;
+      NSString	*err;
+
+      err = nil;
+      data = [NSPropertyListSerialization dataFromPropertyList: dict
+	       format: NSPropertyListXMLFormat_v1_0
+	       errorDescription: &err];
+      if (data == nil)
+	{
+	  NSLog(@"Failed to serialize defaults database for writing: %@", err);
+	}
+      else if ([data writeToFile: file atomically: YES] == NO)
+	{
+	  NSLog(@"Failed to write defaults database to file: %@", file);
+	}
+      else
+	{
+	  [self setPermissions: file];
+	  return YES;
+	}
+    }
+  return NO;
+}
 @end
 
 int
@@ -3022,13 +3020,13 @@ static BOOL isLocked = NO;
                     {
                       /* Remove empty defaults dictionary.
                        */
-                      written = writeDictionary(nil, path);
+                      written = [owner writeDictionary: nil toFile: path];
                     }
                   else
                     {
                       /* Write dictionary to file.
                        */
-                      written = writeDictionary(contents, path);
+                      written = [owner writeDictionary: contents toFile: path];
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/gnustep/libs-base/issues/555

Make writeDictionary public so it can be overridden in a category. setPermissions is used by writeDictionary so I made it public as well so it can be used by any overridden writeDictionary (allows copy and paste of original method and changing of format rather than having to duplicate or reimplement setPermissions). This allows overriding like this:

```
// NSUserDefaults+Override.h
#import <Foundation/NSUserDefaults.h>

@interface NSUserDefaults (Override)

- (BOOL) writeDictionary: (NSDictionary*)dict
                  toFile: (NSString*)file;
@end

// NSUserDefaults+Override.m
#import "NSUserDefaults+Override.h"
#import <Foundation/NSData.h>
#import <Foundation/NSFileManager.h>
#import <Foundation/NSPropertyList.h>

@implementation NSUserDefaults (Override)

- (BOOL) writeDictionary: (NSDictionary*)dict
                  toFile: (NSString*)file
{
  if ([file length] == 0)
    {
      NSLog(@"Defaults database filename is empty when writing");
    }
  else if (nil == dict)
    {
      NSFileManager	*mgr = [NSFileManager defaultManager];

      return [mgr removeFileAtPath: file handler: nil];
    }
  else
    {
      NSData	*data;
      NSString	*err;

      err = nil;
      data = [NSPropertyListSerialization dataFromPropertyList: dict
	       format: NSPropertyListOpenStepFormat
	       errorDescription: &err];
      if (data == nil)
	{
	  NSLog(@"Failed to serialize defaults database for writing: %@", err);
	}
      else if ([data writeToFile: file atomically: YES] == NO)
	{
	  NSLog(@"Failed to write defaults database to file: %@", file);
	}
      else
	{
	  [self setPermissions: file];
	  return YES;
	}
    }
  return NO;
}
@end

```