### PR TITLE
icu pkg-config flag issues

### DIFF
--- a/configure
+++ b/configure
@@ -661,8 +661,10 @@ HAVE_NEWKVO
 HAVE_LIBDISPATCH_RUNLOOP
 HAVE_LIBDISPATCH
 HAVE_ICU
-ICU_LIBS
-ICU_CFLAGS
+ICU_UC_LIBS
+ICU_UC_CFLAGS
+ICU_I18N_LIBS
+ICU_I18N_CFLAGS
 HAVE_AVAHI
 HAVE_MDNS
 HAVE_GNUTLS
@@ -880,8 +882,10 @@ XML_CFLAGS
 XML_LIBS
 XSLT_CFLAGS
 XSLT_LIBS
-ICU_CFLAGS
-ICU_LIBS
+ICU_I18N_CFLAGS
+ICU_I18N_LIBS
+ICU_UC_CFLAGS
+ICU_UC_LIBS
 DOT'
 
 
@@ -1647,8 +1651,13 @@ Some influential environment variables:
   XML_LIBS    linker flags for XML, overriding pkg-config
   XSLT_CFLAGS C compiler flags for XSLT, overriding pkg-config
   XSLT_LIBS   linker flags for XSLT, overriding pkg-config
-  ICU_CFLAGS  C compiler flags for ICU, overriding pkg-config
-  ICU_LIBS    linker flags for ICU, overriding pkg-config
+  ICU_I18N_CFLAGS
+              C compiler flags for ICU_I18N, overriding pkg-config
+  ICU_I18N_LIBS
+              linker flags for ICU_I18N, overriding pkg-config
+  ICU_UC_CFLAGS
+              C compiler flags for ICU_UC, overriding pkg-config
+  ICU_UC_LIBS linker flags for ICU_UC, overriding pkg-config
   DOT         The name or full path of the graphviz dot command.
 
 Use these variables to override the choices made by 'configure' or to help
@@ -5902,18 +5911,18 @@ then :
 fi
 if test "$enable_largefile,$enable_year2038" != no,no
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CPPFLAGS option for large files" >&5
-printf %s "checking for $CPPFLAGS option for large files... " >&6; }
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option to enable large file support" >&5
+printf %s "checking for $CC option to enable large file support... " >&6; }
 if test ${ac_cv_sys_largefile_opts+y}
 then :
   printf %s "(cached) " >&6
 else case e in #(
-  e) ac_save_CPPFLAGS=$CPPFLAGS
+  e) ac_save_CC="$CC"
   ac_opt_found=no
-  for ac_opt in "none needed" "-D_FILE_OFFSET_BITS=64" "-D_LARGE_FILES=1"; do
+  for ac_opt in "none needed" "-D_FILE_OFFSET_BITS=64" "-D_LARGE_FILES=1" "-n32"; do
     if test x"$ac_opt" != x"none needed"
 then :
-  CPPFLAGS="$ac_save_CPPFLAGS $ac_opt"
+  CC="$ac_save_CC $ac_opt"
 fi
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -5942,12 +5951,12 @@ then :
   if test x"$ac_opt" = x"none needed"
 then :
   # GNU/Linux s390x and alpha need _FILE_OFFSET_BITS=64 for wide ino_t.
-	 CPPFLAGS="$CPPFLAGS -DFTYPE=ino_t"
+	 CC="$CC -DFTYPE=ino_t"
 	 if ac_fn_c_try_compile "$LINENO"
 then :
 
 else case e in #(
-  e) CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=64"
+  e) CC="$CC -D_FILE_OFFSET_BITS=64"
 	    if ac_fn_c_try_compile "$LINENO"
 then :
   ac_opt='-D_FILE_OFFSET_BITS=64'
@@ -5963,7 +5972,7 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
     test $ac_opt_found = no || break
   done
-  CPPFLAGS=$ac_save_CPPFLAGS
+  CC="$ac_save_CC"
 
   test $ac_opt_found = yes || ac_cv_sys_largefile_opts="support not detected" ;;
 esac
@@ -5987,14 +5996,16 @@ printf "%s\n" "#define _FILE_OFFSET_BITS 64" >>confdefs.h
 
 printf "%s\n" "#define _LARGE_FILES 1" >>confdefs.h
  ;; #(
+  "-n32") :
+    CC="$CC -n32" ;; #(
   *) :
     as_fn_error $? "internal error: bad value for \$ac_cv_sys_largefile_opts" "$LINENO" 5 ;;
 esac
 
 if test "$enable_year2038" != no
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CPPFLAGS option for timestamps after 2038" >&5
-printf %s "checking for $CPPFLAGS option for timestamps after 2038... " >&6; }
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option for timestamps after 2038" >&5
+printf %s "checking for $CC option for timestamps after 2038... " >&6; }
 if test ${ac_cv_sys_year2038_opts+y}
 then :
   printf %s "(cached) " >&6
@@ -14921,11 +14932,11 @@ printf "%s\n" "$as_me: Using system-provided ICU DLL (requires Windows 10 versio
   if test $HAVE_ICU = 0; then
 
 pkg_failed=no
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ICU" >&5
-printf %s "checking for ICU... " >&6; }
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ICU_I18N" >&5
+printf %s "checking for ICU_I18N... " >&6; }
 
-if test -n "$ICU_CFLAGS"; then
-    pkg_cv_ICU_CFLAGS="$ICU_CFLAGS"
+if test -n "$ICU_I18N_CFLAGS"; then
+    pkg_cv_ICU_I18N_CFLAGS="$ICU_I18N_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"icu-i18n > 49.0\""; } >&5
@@ -14933,7 +14944,7 @@ if test -n "$ICU_CFLAGS"; then
   ac_status=$?
   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_ICU_CFLAGS=`$PKG_CONFIG --cflags "icu-i18n > 49.0" 2>/dev/null`
+  pkg_cv_ICU_I18N_CFLAGS=`$PKG_CONFIG --cflags "icu-i18n > 49.0" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -14941,8 +14952,8 @@ fi
  else
     pkg_failed=untried
 fi
-if test -n "$ICU_LIBS"; then
-    pkg_cv_ICU_LIBS="$ICU_LIBS"
+if test -n "$ICU_I18N_LIBS"; then
+    pkg_cv_ICU_I18N_LIBS="$ICU_I18N_LIBS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"icu-i18n > 49.0\""; } >&5
@@ -14950,7 +14961,7 @@ if test -n "$ICU_LIBS"; then
   ac_status=$?
   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_ICU_LIBS=`$PKG_CONFIG --libs "icu-i18n > 49.0" 2>/dev/null`
+  pkg_cv_ICU_I18N_LIBS=`$PKG_CONFIG --libs "icu-i18n > 49.0" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -14971,25 +14982,25 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        ICU_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "icu-i18n > 49.0" 2>&1`
+	        ICU_I18N_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "icu-i18n > 49.0" 2>&1`
         else
-	        ICU_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "icu-i18n > 49.0" 2>&1`
+	        ICU_I18N_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "icu-i18n > 49.0" 2>&1`
         fi
 	# Put the nasty error message in config.log where it belongs
-	echo "$ICU_PKG_ERRORS" >&5
+	echo "$ICU_I18N_PKG_ERRORS" >&5
 
-	HAVE_ICU=0
+	HAVE_ICU_I81N=0
 elif test $pkg_failed = untried; then
      	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
-	HAVE_ICU=0
+	HAVE_ICU_I81N=0
 else
-	ICU_CFLAGS=$pkg_cv_ICU_CFLAGS
-	ICU_LIBS=$pkg_cv_ICU_LIBS
+	ICU_I18N_CFLAGS=$pkg_cv_ICU_I18N_CFLAGS
+	ICU_I18N_LIBS=$pkg_cv_ICU_I18N_LIBS
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 
-             for ac_header in unicode/uloc.h unicode/ulocdata.h unicode/ucol.h unicode/ucurr.h unicode/uregex.h unicode/ucal.h unicode/unorm2.h unicode/unum.h unicode/udat.h unicode/udatpg.h unicode/ustring.h unicode/usearch.h unicode/ucnv.h unicode/utext.h unicode/ubrk.h unicode/utypes.h
+             for ac_header in unicode/uloc.h unicode/ulocdata.h unicode/ucol.h unicode/ucurr.h unicode/uregex.h unicode/ucal.h unicode/unorm2.h unicode/unum.h unicode/udat.h unicode/udatpg.h unicode/ustring.h unicode/usearch.h unicode/ucnv.h unicode/ubrk.h unicode/utypes.h
 do :
   as_ac_Header=`printf "%s\n" "ac_cv_header_$ac_header" | sed "$as_sed_sh"`
 ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
@@ -14998,11 +15009,96 @@ then :
   cat >>confdefs.h <<_ACEOF
 #define `printf "%s\n" "HAVE_$ac_header" | sed "$as_sed_cpp"` 1
 _ACEOF
- HAVE_ICU=1
+ HAVE_ICU_I18N=1
 fi
 
 done
 fi
+
+pkg_failed=no
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ICU_UC" >&5
+printf %s "checking for ICU_UC... " >&6; }
+
+if test -n "$ICU_UC_CFLAGS"; then
+    pkg_cv_ICU_UC_CFLAGS="$ICU_UC_CFLAGS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"icu-uc > 49.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "icu-uc > 49.0") 2>&5
+  ac_status=$?
+  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_ICU_UC_CFLAGS=`$PKG_CONFIG --cflags "icu-uc > 49.0" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+if test -n "$ICU_UC_LIBS"; then
+    pkg_cv_ICU_UC_LIBS="$ICU_UC_LIBS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"icu-uc > 49.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "icu-uc > 49.0") 2>&5
+  ac_status=$?
+  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_ICU_UC_LIBS=`$PKG_CONFIG --libs "icu-uc > 49.0" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+
+
+
+if test $pkg_failed = yes; then
+   	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        ICU_UC_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "icu-uc > 49.0" 2>&1`
+        else
+	        ICU_UC_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "icu-uc > 49.0" 2>&1`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$ICU_UC_PKG_ERRORS" >&5
+
+	HAVE_ICU_UC=0
+elif test $pkg_failed = untried; then
+     	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+	HAVE_ICU_UC=0
+else
+	ICU_UC_CFLAGS=$pkg_cv_ICU_UC_CFLAGS
+	ICU_UC_LIBS=$pkg_cv_ICU_UC_LIBS
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+
+             for ac_header in unicode/utext.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "unicode/utext.h" "ac_cv_header_unicode_utext_h" "$ac_includes_default"
+if test "x$ac_cv_header_unicode_utext_h" = xyes
+then :
+  printf "%s\n" "#define HAVE_UNICODE_UTEXT_H 1" >>confdefs.h
+ HAVE_ICU_UC=1
+fi
+
+done
+fi
+    if test $HAVE_ICU_I18N = 1; then
+      ICU_LIBS="$ICU_I18N_LIBS $ICU_UC_LIBS"
+      HAVE_ICU=1
+    fi
   fi
   if test $HAVE_ICU = 0; then
     as_fn_error $? "No useable ICU installation found" "$LINENO" 5

--- a/configure.ac
+++ b/configure.ac
@@ -3617,9 +3617,16 @@ AS_IF([test "x$enable_icu" = "xyes"], [
     ;;
   esac
   if test $HAVE_ICU = 0; then
-    PKG_CHECK_MODULES([ICU], [icu-i18n > 49.0], [
-      AC_CHECK_HEADERS([unicode/uloc.h unicode/ulocdata.h unicode/ucol.h unicode/ucurr.h unicode/uregex.h unicode/ucal.h unicode/unorm2.h unicode/unum.h unicode/udat.h unicode/udatpg.h unicode/ustring.h unicode/usearch.h unicode/ucnv.h unicode/utext.h unicode/ubrk.h unicode/utypes.h],
-        HAVE_ICU=1)], [HAVE_ICU=0])
+    PKG_CHECK_MODULES([ICU_I18N], [icu-i18n > 49.0], [
+      AC_CHECK_HEADERS([unicode/uloc.h unicode/ulocdata.h unicode/ucol.h unicode/ucurr.h unicode/uregex.h unicode/ucal.h unicode/unorm2.h unicode/unum.h unicode/udat.h unicode/udatpg.h unicode/ustring.h unicode/usearch.h unicode/ucnv.h unicode/ubrk.h unicode/utypes.h],
+        HAVE_ICU_I18N=1)], [HAVE_ICU_I81N=0])
+    PKG_CHECK_MODULES([ICU_UC], [icu-uc > 49.0], [
+      AC_CHECK_HEADERS([unicode/utext.h],
+        HAVE_ICU_UC=1)], [HAVE_ICU_UC=0])
+    if test $HAVE_ICU_I18N = 1; then
+      ICU_LIBS="$ICU_I18N_LIBS $ICU_UC_LIBS"
+      HAVE_ICU=1
+    fi
   fi
   if test $HAVE_ICU = 0; then
     AC_MSG_ERROR([No useable ICU installation found])


### PR DESCRIPTION
ICU has different libraries and components, pkg-config apparently does not return always the full link options. On some systems ICU parts may be even different packages


I try to split up the existence and separate I818n and UC checks and join them. I hope it is enough
I just split AC_CHECK_HEADERS into both, it could be made more fine grained, but I don't think we need, because at the end GNUstep needs both i18n and uc, so where the header comes from appears to be irrelevant.