### PR TITLE
Use posix_spawn on modern glibc to avoid NSTask fork deadlocks

### DIFF
--- a/Tests/base/NSTask/Helpers/GNUmakefile
+++ b/Tests/base/NSTask/Helpers/GNUmakefile
@@ -1,7 +1,7 @@
 
 include $(GNUSTEP_MAKEFILES)/common.make
 
-TOOL_NAME = NSZombie processgroup testcat testecho testsleep
+TOOL_NAME = NSZombie processgroup testcat testecho testsleep testpwd teststdio testenvvar testsimple
 
 NEEDS_GUI = NO
 
@@ -14,6 +14,14 @@ testcat_C_FILES = testcat.c
 testecho_OBJC_FILES = testecho.m
 
 testsleep_OBJC_FILES = testsleep.m
+
+testpwd_OBJC_FILES = testpwd.m
+
+teststdio_OBJC_FILES = teststdio.m
+
+testenvvar_OBJC_FILES = testenvvar.m
+
+testsimple_OBJC_FILES = testsimple.m
 
 -include GNUmakefile.preamble
 include $(GNUSTEP_MAKEFILES)/tool.make

--- a/Tests/base/NSTask/Helpers/testenvvar.m
+++ b/Tests/base/NSTask/Helpers/testenvvar.m
@@ -1,0 +1,43 @@
+#import <Foundation/Foundation.h>
+
+/* Helper program that checks for a specific environment variable
+ * Usage: testenvvar VARNAME [expected_value]
+ * Exit code 0 if variable exists (and matches expected value if provided)
+ * Exit code 1 otherwise
+ */
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  int result = 1;
+  
+  if (argc >= 2)
+    {
+      NSString *varName = [NSString stringWithUTF8String: argv[1]];
+      NSDictionary *env = [[NSProcessInfo processInfo] environment];
+      NSString *value = [env objectForKey: varName];
+      
+      if (value != nil)
+        {
+          GSPrintf(stdout, @"%@=%@\n", varName, value);
+          
+          if (argc >= 3)
+            {
+              NSString *expected = [NSString stringWithUTF8String: argv[2]];
+              result = [value isEqualToString: expected] ? 0 : 1;
+            }
+          else
+            {
+              result = 0; // Variable exists
+            }
+        }
+      else
+        {
+          GSPrintf(stdout, @"%@ not found\n", varName);
+        }
+    }
+  
+  fflush(stdout);
+  [arp release];
+  return result;
+}

--- a/Tests/base/NSTask/Helpers/testpwd.m
+++ b/Tests/base/NSTask/Helpers/testpwd.m
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+
+/* Helper program that prints the current working directory
+ * Used to test that setCurrentDirectoryPath works correctly with posix_spawn
+ */
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSFileManager *mgr = [NSFileManager defaultManager];
+  NSString *currentDir = [mgr currentDirectoryPath];
+  
+  GSPrintf(stdout, @"%@\n", currentDir);
+  fflush(stdout);
+  
+  [arp release];
+  return 0;
+}

--- a/Tests/base/NSTask/Helpers/testsimple.m
+++ b/Tests/base/NSTask/Helpers/testsimple.m
@@ -1,0 +1,23 @@
+#import <Foundation/Foundation.h>
+
+/* Simple helper program that exits with a specific code
+ * Usage: testsimple [exit_code]
+ * Default exit code is 0
+ */
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  int exitCode = 0;
+  
+  if (argc >= 2)
+    {
+      exitCode = atoi(argv[1]);
+    }
+  
+  GSPrintf(stdout, @"Exiting with code %d\n", exitCode);
+  fflush(stdout);
+  
+  [arp release];
+  return exitCode;
+}

--- a/Tests/base/NSTask/Helpers/teststdio.m
+++ b/Tests/base/NSTask/Helpers/teststdio.m
@@ -1,0 +1,31 @@
+#import <Foundation/Foundation.h>
+#include <stdio.h>
+
+/* Helper program that tests stdin/stdout/stderr redirection
+ * Reads from stdin and writes to stdout and stderr
+ */
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  char buffer[1024];
+  
+  // Write to stdout
+  GSPrintf(stdout, @"STDOUT: Ready to read\n");
+  fflush(stdout);
+  
+  // Read from stdin
+  if (fgets(buffer, sizeof(buffer), stdin) != NULL)
+    {
+      // Echo to stdout
+      GSPrintf(stdout, @"STDOUT: %s", buffer);
+      fflush(stdout);
+      
+      // Echo to stderr
+      GSPrintf(stderr, @"STDERR: %s", buffer);
+      fflush(stderr);
+    }
+  
+  [arp release];
+  return 0;
+}

--- a/Tests/base/NSTask/posix_spawn_concurrent.m
+++ b/Tests/base/NSTask/posix_spawn_concurrent.m
@@ -1,0 +1,243 @@
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSTask.h>
+#import <Foundation/NSFileHandle.h>
+#import <Foundation/NSFileManager.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSArray.h>
+#import "ObjectTesting.h"
+
+/* Test multiple concurrent NSTask instances
+ * This verifies that posix_spawn can handle multiple tasks running
+ * simultaneously without resource conflicts or race conditions
+ */
+int main()
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSFileManager *mgr;
+  NSString *helpers;
+  NSString *testsimple;
+  NSString *testecho;
+  NSMutableArray *tasks;
+  NSMutableArray *pipes;
+  int i;
+  int j;
+  int numTasks;
+
+#if defined(_WIN32)
+  testsimple = @"testsimple.exe";
+  testecho = @"testecho.exe";
+#else
+  testsimple = @"testsimple";
+  testecho = @"testecho";
+#endif
+
+  mgr = [NSFileManager defaultManager];
+  helpers = [mgr currentDirectoryPath];
+  helpers = [helpers stringByAppendingPathComponent: @"Helpers"];
+  helpers = [helpers stringByAppendingPathComponent: @"obj"];
+
+  /* Test 1: Launch multiple tasks concurrently and wait for all */
+  numTasks = 10;
+  tasks = [NSMutableArray arrayWithCapacity: numTasks];
+  pipes = [NSMutableArray arrayWithCapacity: numTasks];
+  
+  // Launch all tasks
+  for (i = 0; i < numTasks; i++)
+    {
+      NSTask *task = [[NSTask alloc] init];
+      NSPipe *outPipe = [NSPipe pipe];
+      
+      [task setLaunchPath: [helpers stringByAppendingPathComponent: testecho]];
+      [task setArguments: [NSArray arrayWithObjects:
+        [NSString stringWithFormat: @"Task%d", i], nil]];
+      [task setStandardOutput: outPipe];
+      
+      [task launch];
+      
+      [tasks addObject: task];
+      [pipes addObject: outPipe];
+      [task release];
+    }
+  
+  PASS([tasks count] == numTasks, "launched %d concurrent tasks", numTasks);
+  
+  // Wait for all tasks and verify output
+  int successCount = 0;
+  for (i = 0; i < numTasks; i++)
+    {
+      NSTask *task = [tasks objectAtIndex: i];
+      NSPipe *pipe = [pipes objectAtIndex: i];
+      NSFileHandle *handle = [pipe fileHandleForReading];
+      
+      NSData *data = [handle readDataToEndOfFile];
+      [task waitUntilExit];
+      
+      if ([task terminationStatus] == 0)
+        {
+          NSString *output = [[NSString alloc] initWithData: data
+                                                   encoding: NSUTF8StringEncoding];
+          if ([output rangeOfString: [NSString stringWithFormat: @"Task%d", i]].location
+              != NSNotFound)
+            {
+              successCount++;
+            }
+          [output release];
+        }
+    }
+  
+  PASS(successCount == numTasks,
+       "all %d concurrent tasks completed successfully (got %d)",
+       numTasks, successCount);
+
+  /* Test 2: Launch tasks, collect them, then wait in different order */
+  [tasks removeAllObjects];
+  [pipes removeAllObjects];
+  numTasks = 5;
+  
+  for (i = 0; i < numTasks; i++)
+    {
+      NSTask *task = [[NSTask alloc] init];
+      NSPipe *outPipe = [NSPipe pipe];
+      
+      [task setLaunchPath: [helpers stringByAppendingPathComponent: testsimple]];
+      [task setArguments: [NSArray arrayWithObjects: @"0", nil]];
+      [task setStandardOutput: outPipe];
+      
+      [task launch];
+      
+      [tasks addObject: task];
+      [pipes addObject: outPipe];
+      [task release];
+    }
+  
+  // Wait in reverse order
+  successCount = 0;
+  for (i = numTasks - 1; i >= 0; i--)
+    {
+      NSTask *task = [tasks objectAtIndex: i];
+      [task waitUntilExit];
+      
+      if ([task terminationStatus] == 0)
+        {
+          successCount++;
+        }
+    }
+  
+  PASS(successCount == numTasks,
+       "waiting in reverse order works (%d/%d)", successCount, numTasks);
+
+  /* Test 3: Mix of quick and tasks with different arguments */
+  [tasks removeAllObjects];
+  [pipes removeAllObjects];
+  numTasks = 8;
+  
+  for (i = 0; i < numTasks; i++)
+    {
+      NSTask *task = [[NSTask alloc] init];
+      NSPipe *outPipe = [NSPipe pipe];
+      
+      if (i % 2 == 0)
+        {
+          [task setLaunchPath: [helpers stringByAppendingPathComponent: testsimple]];
+          [task setArguments: [NSArray arrayWithObjects:
+            [NSString stringWithFormat: @"%d", i], nil]];
+        }
+      else
+        {
+          [task setLaunchPath: [helpers stringByAppendingPathComponent: testecho]];
+          [task setArguments: [NSArray arrayWithObjects:
+            [NSString stringWithFormat: @"Arg%d", i],
+            @"ExtraArg", nil]];
+        }
+      
+      [task setStandardOutput: outPipe];
+      [task launch];
+      
+      [tasks addObject: task];
+      [pipes addObject: outPipe];
+      [task release];
+    }
+  
+  successCount = 0;
+  for (i = 0; i < numTasks; i++)
+    {
+      NSTask *task = [tasks objectAtIndex: i];
+      NSPipe *pipe = [pipes objectAtIndex: i];
+      NSFileHandle *handle = [pipe fileHandleForReading];
+
+      // Drain the pipe to prevent child process from blocking
+      (void)[handle readDataToEndOfFile];
+      [task waitUntilExit];
+
+      if ([task terminationStatus] == 0 || [task terminationStatus] == i)
+        {
+          successCount++;
+        }
+    }
+  
+  PASS(successCount == numTasks,
+       "mixed task types run concurrently (%d/%d)", successCount, numTasks);
+
+  /* Test 4: Rapid launch and wait cycles */
+  successCount = 0;
+  for (i = 0; i < 20; i++)
+    {
+      NSTask *task = [[NSTask alloc] init];
+      [task setLaunchPath: [helpers stringByAppendingPathComponent: testsimple]];
+      [task setArguments: [NSArray array]];
+      
+      [task launch];
+      [task waitUntilExit];
+      
+      if ([task terminationStatus] == 0)
+        {
+          successCount++;
+        }
+      
+      [task release];
+    }
+  
+  PASS(successCount == 20,
+       "rapid launch/wait cycles work (%d/20)", successCount);
+
+  /* Test 5: Verify process IDs are unique for concurrent tasks */
+  [tasks removeAllObjects];
+  numTasks = 5;
+  NSMutableArray *pids = [NSMutableArray arrayWithCapacity: numTasks];
+  
+  for (i = 0; i < numTasks; i++)
+    {
+      NSTask *task = [[NSTask alloc] init];
+      [task setLaunchPath: [helpers stringByAppendingPathComponent: testsimple]];
+      [task launch];
+      
+      [tasks addObject: task];
+      [pids addObject: [NSNumber numberWithInt: [task processIdentifier]]];
+      [task release];
+    }
+  
+  // Check all PIDs are different
+  BOOL allUnique = YES;
+  for (i = 0; i < [pids count]; i++)
+    {
+      for (j = i + 1; j < [pids count]; j++)
+        {
+          if ([[pids objectAtIndex: i] isEqual: [pids objectAtIndex: j]])
+            {
+              allUnique = NO;
+              break;
+            }
+        }
+    }
+  
+  for (i = 0; i < numTasks; i++)
+    {
+      [[tasks objectAtIndex: i] waitUntilExit];
+    }
+  
+  PASS(allUnique, "all concurrent tasks have unique process IDs");
+
+  [arp release];
+  return 0;
+}

--- a/Tests/base/NSTask/posix_spawn_directory.m
+++ b/Tests/base/NSTask/posix_spawn_directory.m
@@ -1,0 +1,178 @@
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSTask.h>
+#import <Foundation/NSFileHandle.h>
+#import <Foundation/NSFileManager.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSArray.h>
+#import <Foundation/NSError.h>
+#import "ObjectTesting.h"
+
+/* Test setCurrentDirectoryPath with posix_spawn_file_actions_addchdir_np
+ * This is a critical test because it uses a GNU extension (glibc 2.29+)
+ * and is one of the main reasons we require modern glibc for posix_spawn
+ */
+int main()
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSFileManager *mgr;
+  NSString *helpers;
+  NSString *testpwd;
+  NSString *testsimple;
+  NSTask *task;
+  NSPipe *outPipe;
+  NSFileHandle *outHandle;
+  NSData *data;
+  NSString *output;
+  NSString *trimmed;
+  NSString *currentDir;
+  NSString *parentDir;
+  NSString *tmpDir;
+  NSError *error;
+
+#if defined(_WIN32)
+  testpwd = @"testpwd.exe";
+  testsimple = @"testsimple.exe";
+#else
+  testpwd = @"testpwd";
+  testsimple = @"testsimple";
+#endif
+
+  mgr = [NSFileManager defaultManager];
+  currentDir = [mgr currentDirectoryPath];
+  helpers = [currentDir stringByAppendingPathComponent: @"Helpers"];
+  helpers = [helpers stringByAppendingPathComponent: @"obj"];
+  
+  parentDir = [currentDir stringByDeletingLastPathComponent];
+  tmpDir = NSTemporaryDirectory();
+
+  /* Test 1: Task inherits current directory by default */
+  task = [[NSTask alloc] init];
+  outPipe = [NSPipe pipe];
+  [task setLaunchPath: [helpers stringByAppendingPathComponent: testpwd]];
+  [task setStandardOutput: outPipe];
+  outHandle = [outPipe fileHandleForReading];
+  
+  [task launch];
+  data = [outHandle readDataToEndOfFile];
+  [task waitUntilExit];
+  
+  output = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
+  trimmed = [[output stringByTrimmingCharactersInSet: 
+    [NSCharacterSet whitespaceAndNewlineCharacterSet]] copy];
+  DESTROY(output);
+  
+  PASS([trimmed isEqualToString: currentDir],
+       "task inherits current directory (expected '%@', got '%@')",
+       currentDir, trimmed);
+  DESTROY(trimmed);
+  DESTROY(task);
+
+  /* Test 2: setCurrentDirectoryPath to parent directory */
+  task = [[NSTask alloc] init];
+  outPipe = [NSPipe pipe];
+  [task setLaunchPath: [helpers stringByAppendingPathComponent: testpwd]];
+  [task setCurrentDirectoryPath: parentDir];
+  [task setStandardOutput: outPipe];
+  outHandle = [outPipe fileHandleForReading];
+  
+  [task launch];
+  data = [outHandle readDataToEndOfFile];
+  [task waitUntilExit];
+  
+  output = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
+  trimmed = [[output stringByTrimmingCharactersInSet:
+    [NSCharacterSet whitespaceAndNewlineCharacterSet]] copy];
+  DESTROY(output);
+  
+  PASS([trimmed isEqualToString: parentDir],
+       "task runs in parent directory (expected '%@', got '%@')",
+       parentDir, trimmed);
+  DESTROY(trimmed);
+  DESTROY(task);
+
+  /* Test 3: setCurrentDirectoryPath to /tmp */
+  task = [[NSTask alloc] init];
+  outPipe = [NSPipe pipe];
+  [task setLaunchPath: [helpers stringByAppendingPathComponent: testpwd]];
+  [task setCurrentDirectoryPath: tmpDir];
+  [task setStandardOutput: outPipe];
+  outHandle = [outPipe fileHandleForReading];
+  
+  [task launch];
+  data = [outHandle readDataToEndOfFile];
+  [task waitUntilExit];
+  
+  output = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
+  trimmed = [[output stringByTrimmingCharactersInSet:
+    [NSCharacterSet whitespaceAndNewlineCharacterSet]] copy];
+  DESTROY(output);
+  
+  PASS([trimmed isEqualToString: tmpDir] || 
+       [tmpDir hasPrefix: trimmed], // Some systems may resolve symlinks differently
+       "task runs in temp directory (expected '%@', got '%@')",
+       tmpDir, trimmed);
+  DESTROY(trimmed);
+  DESTROY(task);
+
+  /* Test 4: Invalid directory path should fail gracefully */
+  task = [[NSTask alloc] init];
+  [task setLaunchPath: [helpers stringByAppendingPathComponent: testsimple]];
+  [task setCurrentDirectoryPath: @"/nonexistent/directory/path"];
+  
+  error = nil;
+  BOOL launched = [task launchAndReturnError: &error];
+  
+  PASS(launched == NO, "task fails to launch with invalid directory");
+  PASS(error != nil, "error is set for invalid directory");
+  DESTROY(task);
+
+  /* Test 5: Multiple tasks with different directories */
+  NSArray *testDirs = [NSArray arrayWithObjects: 
+    currentDir, parentDir, tmpDir, nil];
+  int i;
+  
+  for (i = 0; i < [testDirs count]; i++)
+    {
+      NSString *testDir = [testDirs objectAtIndex: i];
+      
+      task = [[NSTask alloc] init];
+      outPipe = [NSPipe pipe];
+      [task setLaunchPath: [helpers stringByAppendingPathComponent: testpwd]];
+      [task setCurrentDirectoryPath: testDir];
+      [task setStandardOutput: outPipe];
+      outHandle = [outPipe fileHandleForReading];
+      
+      [task launch];
+      data = [outHandle readDataToEndOfFile];
+      [task waitUntilExit];
+      
+      output = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
+      trimmed = [[output stringByTrimmingCharactersInSet:
+        [NSCharacterSet whitespaceAndNewlineCharacterSet]] copy];
+      DESTROY(output);
+      
+      PASS([trimmed isEqualToString: testDir] || [testDir hasPrefix: trimmed],
+           "sequential task %d runs in correct directory", i);
+      DESTROY(trimmed);
+      DESTROY(task);
+    }
+
+  /* Test 6: Verify directory change doesn't affect parent process */
+  NSString *dirBeforeTest = [mgr currentDirectoryPath];
+  
+  task = [[NSTask alloc] init];
+  [task setLaunchPath: [helpers stringByAppendingPathComponent: testsimple]];
+  [task setCurrentDirectoryPath: tmpDir];
+  [task launch];
+  [task waitUntilExit];
+  DESTROY(task);
+  
+  NSString *dirAfterTest = [mgr currentDirectoryPath];
+  
+  PASS([dirBeforeTest isEqualToString: dirAfterTest],
+       "parent process directory unchanged after child task runs");
+
+  [arp release];
+  return 0;
+}

--- a/Tests/base/NSTask/posix_spawn_environment.m
+++ b/Tests/base/NSTask/posix_spawn_environment.m
@@ -1,0 +1,218 @@
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSTask.h>
+#import <Foundation/NSFileHandle.h>
+#import <Foundation/NSFileManager.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSArray.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSProcessInfo.h>
+#import "ObjectTesting.h"
+
+/* Test environment variable handling with posix_spawn
+ * Ensures that environment variables are correctly passed to spawned processes
+ */
+int main()
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSFileManager *mgr;
+  NSString *helpers;
+  NSString *testenvvar;
+  NSTask *task;
+  NSPipe *outPipe;
+  NSFileHandle *outHandle;
+  NSData *data;
+  NSString *output;
+  NSDictionary *env;
+  NSMutableDictionary *customEnv;
+
+#if defined(_WIN32)
+  testenvvar = @"testenvvar.exe";
+#else
+  testenvvar = @"testenvvar";
+#endif
+
+  mgr = [NSFileManager defaultManager];
+  helpers = [mgr currentDirectoryPath];
+  helpers = [helpers stringByAppendingPathComponent: @"Helpers"];
+  helpers = [helpers stringByAppendingPathComponent: @"obj"];
+
+  env = [[NSProcessInfo processInfo] environment];
+
+  /* Test 1: Task inherits parent environment by default */
+  task = [[NSTask alloc] init];
+  outPipe = [NSPipe pipe];
+  [task setLaunchPath: [helpers stringByAppendingPathComponent: testenvvar]];
+  [task setArguments: [NSArray arrayWithObjects: @"PATH", nil]];
+  [task setStandardOutput: outPipe];
+  outHandle = [outPipe fileHandleForReading];
+  
+  [task launch];
+  data = [outHandle readDataToEndOfFile];
+  [task waitUntilExit];
+  
+  PASS([task terminationStatus] == 0, "task finds inherited PATH variable");
+  
+  output = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
+  PASS([output rangeOfString: @"PATH="].location != NSNotFound,
+       "output contains PATH variable");
+  DESTROY(output);
+  DESTROY(task);
+
+  /* Test 2: Custom environment variable */
+  customEnv = [NSMutableDictionary dictionaryWithDictionary: env];
+  [customEnv setObject: @"TestValue123" forKey: @"CUSTOM_TEST_VAR"];
+  
+  task = [[NSTask alloc] init];
+  outPipe = [NSPipe pipe];
+  [task setLaunchPath: [helpers stringByAppendingPathComponent: testenvvar]];
+  [task setArguments: [NSArray arrayWithObjects: 
+    @"CUSTOM_TEST_VAR", @"TestValue123", nil]];
+  [task setEnvironment: customEnv];
+  [task setStandardOutput: outPipe];
+  outHandle = [outPipe fileHandleForReading];
+  
+  [task launch];
+  data = [outHandle readDataToEndOfFile];
+  [task waitUntilExit];
+  
+  PASS([task terminationStatus] == 0, 
+       "custom environment variable passed correctly");
+  DESTROY(task);
+
+  /* Test 3: Multiple custom environment variables */
+  customEnv = [NSMutableDictionary dictionaryWithDictionary: env];
+  [customEnv setObject: @"Value1" forKey: @"TEST_VAR_1"];
+  [customEnv setObject: @"Value2" forKey: @"TEST_VAR_2"];
+  [customEnv setObject: @"Value3" forKey: @"TEST_VAR_3"];
+  
+  int i;
+  for (i = 1; i <= 3; i++)
+    {
+      task = [[NSTask alloc] init];
+      outPipe = [NSPipe pipe];
+      [task setLaunchPath: [helpers stringByAppendingPathComponent: testenvvar]];
+      [task setArguments: [NSArray arrayWithObjects:
+        [NSString stringWithFormat: @"TEST_VAR_%d", i],
+        [NSString stringWithFormat: @"Value%d", i],
+        nil]];
+      [task setEnvironment: customEnv];
+      [task setStandardOutput: outPipe];
+      outHandle = [outPipe fileHandleForReading];
+      
+      [task launch];
+      data = [outHandle readDataToEndOfFile];
+      [task waitUntilExit];
+      
+      PASS([task terminationStatus] == 0,
+           "environment variable TEST_VAR_%d set correctly", i);
+      DESTROY(task);
+    }
+
+  /* Test 4: Minimal environment (with only required variables for dynamic linking) */
+  customEnv = [NSMutableDictionary dictionary];
+  [customEnv setObject: @"OnlyThis" forKey: @"ONLY_VAR"];
+#if defined(_WIN32)
+  /* On Windows, PATH is needed for finding DLLs */
+  if ([env objectForKey: @"PATH"] != nil)
+    {
+      [customEnv setObject: [env objectForKey: @"PATH"] forKey: @"PATH"];
+    }
+#else
+  /* On Unix-like systems, LD_LIBRARY_PATH is needed for dynamic linking */
+  if ([env objectForKey: @"LD_LIBRARY_PATH"] != nil)
+    {
+      [customEnv setObject: [env objectForKey: @"LD_LIBRARY_PATH"]
+                    forKey: @"LD_LIBRARY_PATH"];
+    }
+#endif
+  
+  task = [[NSTask alloc] init];
+  [task setLaunchPath: [helpers stringByAppendingPathComponent: testenvvar]];
+  [task setArguments: [NSArray arrayWithObjects: @"ONLY_VAR", @"OnlyThis", nil]];
+  [task setEnvironment: customEnv];
+  
+  [task launch];
+  [task waitUntilExit];
+  
+  PASS([task terminationStatus] == 0,
+       "task with minimal environment works");
+  DESTROY(task);
+
+#if !defined(_WIN32)
+  /* Test 5: Verify PATH is not inherited when not in custom env
+   * Note: This test is Unix-only because on Windows, PATH is required
+   * for DLL loading, making it impossible to test PATH exclusion.
+   */
+  customEnv = [NSMutableDictionary dictionary];
+  [customEnv setObject: @"test" forKey: @"MYVAR"];
+  /* Need LD_LIBRARY_PATH for dynamic linking, but not PATH */
+  if ([env objectForKey: @"LD_LIBRARY_PATH"] != nil)
+    {
+      [customEnv setObject: [env objectForKey: @"LD_LIBRARY_PATH"]
+                    forKey: @"LD_LIBRARY_PATH"];
+    }
+  
+  task = [[NSTask alloc] init];
+  outPipe = [NSPipe pipe];
+  [task setLaunchPath: [helpers stringByAppendingPathComponent: testenvvar]];
+  [task setArguments: [NSArray arrayWithObjects: @"PATH", nil]];
+  [task setEnvironment: customEnv];
+  [task setStandardOutput: outPipe];
+  outHandle = [outPipe fileHandleForReading];
+  
+  [task launch];
+  data = [outHandle readDataToEndOfFile];
+  [task waitUntilExit];
+  
+  // Should fail because PATH is not in the custom environment
+  PASS([task terminationStatus] != 0,
+       "task doesn't inherit PATH when custom env is set without it");
+  
+  output = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
+  PASS([output rangeOfString: @"not found"].location != NSNotFound,
+       "output indicates PATH not found");
+  DESTROY(output);
+  DESTROY(task);
+#endif
+
+  /* Test 6: Environment with special characters */
+  customEnv = [NSMutableDictionary dictionaryWithDictionary: env];
+  [customEnv setObject: @"Value with spaces and = signs" 
+                forKey: @"SPECIAL_VAR"];
+  
+  task = [[NSTask alloc] init];
+  [task setLaunchPath: [helpers stringByAppendingPathComponent: testenvvar]];
+  [task setArguments: [NSArray arrayWithObjects: @"SPECIAL_VAR", nil]];
+  [task setEnvironment: customEnv];
+  
+  [task launch];
+  [task waitUntilExit];
+  
+  PASS([task terminationStatus] == 0,
+       "environment variable with special characters works");
+  DESTROY(task);
+
+  /* Test 7: Large environment */
+  customEnv = [NSMutableDictionary dictionaryWithDictionary: env];
+  for (i = 0; i < 50; i++)
+    {
+      [customEnv setObject: [NSString stringWithFormat: @"LargeValue%d", i]
+                    forKey: [NSString stringWithFormat: @"LARGE_VAR_%d", i]];
+    }
+  
+  task = [[NSTask alloc] init];
+  [task setLaunchPath: [helpers stringByAppendingPathComponent: testenvvar]];
+  [task setArguments: [NSArray arrayWithObjects: @"LARGE_VAR_25", nil]];
+  [task setEnvironment: customEnv];
+  
+  [task launch];
+  [task waitUntilExit];
+  
+  PASS([task terminationStatus] == 0,
+       "task with large environment works");
+  DESTROY(task);
+
+  [arp release];
+  return 0;
+}

--- a/Tests/base/NSTask/posix_spawn_multithread.m
+++ b/Tests/base/NSTask/posix_spawn_multithread.m
@@ -1,0 +1,156 @@
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSTask.h>
+#import <Foundation/NSFileManager.h>
+#import <Foundation/NSThread.h>
+#import <Foundation/NSArray.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSLock.h>
+#import "ObjectTesting.h"
+
+/* Test NSTask in a multithreaded environment
+ * This is critical because posix_spawn() is thread-safe unlike fork()
+ * which can cause deadlocks in multithreaded applications
+ */
+
+static NSLock *lock = nil;
+static int successCount = 0;
+static int failureCount = 0;
+
+@interface TaskRunner : NSObject
+{
+  NSString *helperPath;
+  int threadId;
+}
+- (id) initWithHelperPath: (NSString *)path threadId: (int)tid;
+- (void) runTask: (id)arg;
+@end
+
+@implementation TaskRunner
+
+- (id) initWithHelperPath: (NSString *)path threadId: (int)tid
+{
+  self = [super init];
+  if (self)
+    {
+      helperPath = [path retain];
+      threadId = tid;
+    }
+  return self;
+}
+
+- (void) dealloc
+{
+  [helperPath release];
+  [super dealloc];
+}
+
+- (void) runTask: (id)arg
+{
+  NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+  NSTask *task;
+  int i;
+  
+  /* Each thread launches multiple tasks */
+  for (i = 0; i < 3; i++)
+    {
+      task = [[NSTask alloc] init];
+      [task setLaunchPath: helperPath];
+      [task setArguments: [NSArray arrayWithObjects: @"0", nil]];
+
+      [task launch];
+      [task waitUntilExit];
+
+      if ([task terminationStatus] == 0)
+        {
+          [lock lock];
+          successCount++;
+          [lock unlock];
+        }
+      else
+        {
+          [lock lock];
+          failureCount++;
+          [lock unlock];
+        }
+
+      [task release];
+    }
+  
+  [pool release];
+}
+
+@end
+
+int main()
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSFileManager *mgr;
+  NSString *helpers;
+  NSString *testsimple;
+  NSMutableArray *threads;
+  int i;
+  int numThreads = 5;
+
+#if defined(_WIN32)
+  testsimple = @"testsimple.exe";
+#else
+  testsimple = @"testsimple";
+#endif
+
+  mgr = [NSFileManager defaultManager];
+  helpers = [mgr currentDirectoryPath];
+  helpers = [helpers stringByAppendingPathComponent: @"Helpers"];
+  helpers = [helpers stringByAppendingPathComponent: @"obj"];
+  helpers = [helpers stringByAppendingPathComponent: testsimple];
+
+  lock = [[NSLock alloc] init];
+  threads = [NSMutableArray arrayWithCapacity: numThreads];
+
+  /* Test 1: Launch tasks from multiple threads concurrently */
+  for (i = 0; i < numThreads; i++)
+    {
+      TaskRunner *runner = [[TaskRunner alloc] initWithHelperPath: helpers
+                                                          threadId: i];
+      NSThread *thread = [[NSThread alloc] initWithTarget: runner
+                                                 selector: @selector(runTask:)
+                                                   object: nil];
+      [threads addObject: thread];
+      [thread start];
+      [runner release];
+    }
+
+  /* Wait for all threads to complete */
+  for (i = 0; i < [threads count]; i++)
+    {
+      NSThread *thread = [threads objectAtIndex: i];
+      while ([thread isExecuting])
+        {
+          [[NSRunLoop currentRunLoop] runMode: NSDefaultRunLoopMode
+                                   beforeDate: [NSDate dateWithTimeIntervalSinceNow: 0.1]];
+        }
+    }
+
+  /* Verify results */
+  int expectedSuccess = numThreads * 3; // Each thread runs 3 tasks
+  
+  PASS(failureCount == 0, 
+    "no failures in multithreaded task execution (failures: %d)", failureCount);
+  PASS(successCount == expectedSuccess,
+    "all %d tasks succeeded in multithreaded execution (got %d)", 
+    expectedSuccess, successCount);
+
+  /* Test 2: Verify we can still launch tasks from main thread after 
+   * multithreaded execution */
+  NSTask *task = [[NSTask alloc] init];
+  [task setLaunchPath: helpers];
+  [task setArguments: [NSArray array]];
+  [task launch];
+  [task waitUntilExit];
+  PASS([task terminationStatus] == 0,
+    "can launch task from main thread after multithreaded execution");
+  DESTROY(task);
+
+  [lock release];
+  [arp release];
+  return 0;
+}

--- a/Tests/base/NSTask/posix_spawn_single.m
+++ b/Tests/base/NSTask/posix_spawn_single.m
@@ -1,0 +1,108 @@
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSTask.h>
+#import <Foundation/NSFileHandle.h>
+#import <Foundation/NSFileManager.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSArray.h>
+#import "ObjectTesting.h"
+
+/* Test basic NSTask functionality in a single-threaded context
+ * This ensures posix_spawn() works correctly for simple cases
+ */
+int main()
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSFileManager *mgr;
+  NSString *helpers;
+  NSString *testsimple;
+  NSTask *task;
+  NSPipe *outPipe;
+  NSFileHandle *outHandle;
+  NSData *data;
+  NSString *output;
+
+#if defined(_WIN32)
+  testsimple = @"testsimple.exe";
+#else
+  testsimple = @"testsimple";
+#endif
+
+  mgr = [NSFileManager defaultManager];
+  helpers = [mgr currentDirectoryPath];
+  helpers = [helpers stringByAppendingPathComponent: @"Helpers"];
+  helpers = [helpers stringByAppendingPathComponent: @"obj"];
+
+  /* Test 1: Launch a simple task that exits with code 0 */
+  task = [[NSTask alloc] init];
+  [task setLaunchPath: [helpers stringByAppendingPathComponent: testsimple]];
+  [task setArguments: [NSArray arrayWithObjects: @"0", nil]];
+  [task launch];
+  [task waitUntilExit];
+  PASS([task terminationStatus] == 0, 
+    "simple task exits with code 0");
+  PASS([task terminationReason] == NSTaskTerminationReasonExit,
+    "simple task has correct termination reason");
+  DESTROY(task);
+
+  /* Test 2: Launch a simple task that exits with code 42 */
+  task = [[NSTask alloc] init];
+  [task setLaunchPath: [helpers stringByAppendingPathComponent: testsimple]];
+  [task setArguments: [NSArray arrayWithObjects: @"42", nil]];
+  [task launch];
+  [task waitUntilExit];
+  PASS([task terminationStatus] == 42,
+    "simple task exits with custom code 42");
+  DESTROY(task);
+
+  /* Test 3: Launch task and capture output */
+  task = [[NSTask alloc] init];
+  outPipe = [NSPipe pipe];
+  [task setLaunchPath: [helpers stringByAppendingPathComponent: testsimple]];
+  [task setArguments: [NSArray arrayWithObjects: @"0", nil]];
+  [task setStandardOutput: outPipe];
+  outHandle = [outPipe fileHandleForReading];
+  
+  [task launch];
+  data = [outHandle readDataToEndOfFile];
+  [task waitUntilExit];
+  
+  PASS([data length] > 0, "captured output from simple task");
+  output = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
+  PASS([output rangeOfString: @"Exiting with code 0"].location != NSNotFound,
+    "output contains expected text");
+  DESTROY(output);
+  DESTROY(task);
+
+  /* Test 4: Verify task state changes correctly */
+  task = [[NSTask alloc] init];
+  [task setLaunchPath: [helpers stringByAppendingPathComponent: testsimple]];
+  [task setArguments: [NSArray array]];
+  
+  PASS([task isRunning] == NO, "task not running before launch");
+  
+  [task launch];
+  // Note: Task might finish very quickly, so we can't reliably test isRunning == YES
+  [task waitUntilExit];
+  
+  PASS([task isRunning] == NO, "task not running after waitUntilExit");
+  PASS([task processIdentifier] > 0, "task has valid process identifier");
+  DESTROY(task);
+
+  /* Test 5: Verify we can launch multiple tasks sequentially */
+  int i;
+  for (i = 0; i < 5; i++)
+    {
+      task = [[NSTask alloc] init];
+      [task setLaunchPath: [helpers stringByAppendingPathComponent: testsimple]];
+      [task setArguments: [NSArray array]];
+      [task launch];
+      [task waitUntilExit];
+      PASS([task terminationStatus] == 0,
+        "sequential task %d completed successfully", i);
+      DESTROY(task);
+    }
+
+  [arp release];
+  return 0;
+}

--- a/Tests/base/NSTask/posix_spawn_stdio.m
+++ b/Tests/base/NSTask/posix_spawn_stdio.m
@@ -1,0 +1,160 @@
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSTask.h>
+#import <Foundation/NSFileHandle.h>
+#import <Foundation/NSFileManager.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSArray.h>
+#import "ObjectTesting.h"
+
+/* Test stdin/stdout/stderr redirection with posix_spawn
+ * Ensures that posix_spawn_file_actions_adddup2 works correctly
+ */
+int main()
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSFileManager *mgr;
+  NSString *helpers;
+  NSString *teststdio;
+  NSString *testecho;
+  NSTask *task;
+  NSPipe *inPipe, *outPipe, *errPipe;
+  NSFileHandle *inHandle, *outHandle, *errHandle;
+  NSData *data;
+  NSString *output;
+  NSString *testInput = @"Hello from stdin\n";
+
+#if defined(_WIN32)
+  teststdio = @"teststdio.exe";
+  testecho = @"testecho.exe";
+#else
+  teststdio = @"teststdio";
+  testecho = @"testecho";
+#endif
+
+  mgr = [NSFileManager defaultManager];
+  helpers = [mgr currentDirectoryPath];
+  helpers = [helpers stringByAppendingPathComponent: @"Helpers"];
+  helpers = [helpers stringByAppendingPathComponent: @"obj"];
+
+  /* Test 1: Basic stdout capture */
+  task = [[NSTask alloc] init];
+  outPipe = [NSPipe pipe];
+  [task setLaunchPath: [helpers stringByAppendingPathComponent: testecho]];
+  [task setArguments: [NSArray arrayWithObjects: @"Test", @"Output", nil]];
+  [task setStandardOutput: outPipe];
+  outHandle = [outPipe fileHandleForReading];
+  
+  [task launch];
+  data = [outHandle readDataToEndOfFile];
+  [task waitUntilExit];
+  
+  PASS([data length] > 0, "captured stdout from task");
+  output = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
+  PASS([output rangeOfString: @"Test"].location != NSNotFound &&
+       [output rangeOfString: @"Output"].location != NSNotFound,
+       "stdout contains expected arguments");
+  DESTROY(output);
+  DESTROY(task);
+
+  /* Test 2: stdin -> stdout redirection */
+  task = [[NSTask alloc] init];
+  inPipe = [NSPipe pipe];
+  outPipe = [NSPipe pipe];
+  [task setLaunchPath: [helpers stringByAppendingPathComponent: teststdio]];
+  [task setStandardInput: inPipe];
+  [task setStandardOutput: outPipe];
+  
+  inHandle = [inPipe fileHandleForWriting];
+  outHandle = [outPipe fileHandleForReading];
+  
+  [task launch];
+  
+  // Write to stdin
+  [inHandle writeData: [testInput dataUsingEncoding: NSUTF8StringEncoding]];
+  [inHandle closeFile];
+  
+  // Read from stdout
+  data = [outHandle readDataToEndOfFile];
+  [task waitUntilExit];
+  
+  PASS([data length] > 0, "captured output after writing to stdin");
+  output = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
+  PASS([output rangeOfString: @"Hello from stdin"].location != NSNotFound,
+       "stdout echoed stdin input correctly");
+  DESTROY(output);
+  DESTROY(task);
+
+  /* Test 3: Separate stdout and stderr capture */
+  task = [[NSTask alloc] init];
+  inPipe = [NSPipe pipe];
+  outPipe = [NSPipe pipe];
+  errPipe = [NSPipe pipe];
+  
+  [task setLaunchPath: [helpers stringByAppendingPathComponent: teststdio]];
+  [task setStandardInput: inPipe];
+  [task setStandardOutput: outPipe];
+  [task setStandardError: errPipe];
+  
+  inHandle = [inPipe fileHandleForWriting];
+  outHandle = [outPipe fileHandleForReading];
+  errHandle = [errPipe fileHandleForReading];
+  
+  [task launch];
+  
+  // Write to stdin
+  NSString *testMsg = @"Test stderr\n";
+  [inHandle writeData: [testMsg dataUsingEncoding: NSUTF8StringEncoding]];
+  [inHandle closeFile];
+  
+  // Read from both stdout and stderr
+  NSData *outData = [outHandle readDataToEndOfFile];
+  NSData *errData = [errHandle readDataToEndOfFile];
+  [task waitUntilExit];
+  
+  PASS([outData length] > 0, "captured stdout with separate stderr");
+  PASS([errData length] > 0, "captured stderr separately from stdout");
+  
+  NSString *outStr = [[NSString alloc] initWithData: outData 
+                                            encoding: NSUTF8StringEncoding];
+  NSString *errStr = [[NSString alloc] initWithData: errData 
+                                            encoding: NSUTF8StringEncoding];
+  
+  PASS([outStr rangeOfString: @"STDOUT"].location != NSNotFound,
+       "stdout contains STDOUT marker");
+  PASS([errStr rangeOfString: @"STDERR"].location != NSNotFound,
+       "stderr contains STDERR marker");
+  PASS([errStr rangeOfString: @"Test stderr"].location != NSNotFound,
+       "stderr contains expected input text");
+  
+  DESTROY(outStr);
+  DESTROY(errStr);
+  DESTROY(task);
+
+  /* Test 4: Multiple tasks with different stdio configurations */
+  int i;
+  for (i = 0; i < 3; i++)
+    {
+      task = [[NSTask alloc] init];
+      outPipe = [NSPipe pipe];
+      [task setLaunchPath: [helpers stringByAppendingPathComponent: testecho]];
+      [task setArguments: [NSArray arrayWithObjects: 
+        [NSString stringWithFormat: @"Task%d", i], nil]];
+      [task setStandardOutput: outPipe];
+      outHandle = [outPipe fileHandleForReading];
+      
+      [task launch];
+      data = [outHandle readDataToEndOfFile];
+      [task waitUntilExit];
+      
+      output = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
+      NSRange range = [output rangeOfString: [NSString stringWithFormat: @"Task%d", i]];
+      PASS(range.location != NSNotFound,
+           "task %d stdio redirection works correctly", i);
+      DESTROY(output);
+      DESTROY(task);
+    }
+
+  [arp release];
+  return 0;
+}


### PR DESCRIPTION
This change updates NSTask on Linux to use posix_spawn() instead of fork() when running on glibc 2.29 or newer. The old fork() path was unsafe in multi‑threaded applications and could deadlock before calling exec(), especially on newer distributions like Ubuntu 22.04. The new implementation uses posix_spawn_file_actions to set up stdin/stdout/stderr, PTY handling, signal defaults, file‑descriptor cleanup, and working‑directory changes through the glibc addchdir_np() extension. This keeps all setup work in the parent and ensures the child immediately executes the target program without touching unsafe APIs. Systems with glibc older than 2.29 continue using the existing fork() implementation. This improves reliability, avoids multi‑threaded deadlocks, and matches modern best practices without changing NSTask’s external behavior.