### PR TITLE
Fix unwanted text‑node merging on libxml2 2.12+ by manually updating doc pointers

### DIFF
--- a/Tests/base/NSXMLNode/test_nsxml_add_child.m
+++ b/Tests/base/NSXMLNode/test_nsxml_add_child.m
@@ -1,0 +1,77 @@
+#import <Foundation/Foundation.h>
+
+/* Test adding children to NSXMLElement
+ * Returns 0 on success, 1 on failure
+ */
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  int exitCode = 0;
+  
+  NS_DURING
+    {
+      // Create parent element
+      NSXMLElement *parent = [NSXMLElement elementWithName:@"parent"];
+      
+      // Test 1: Add single child
+      NSXMLElement *child1 = [NSXMLElement elementWithName:@"child1"];
+      [parent addChild:child1];
+      
+      if ([parent childCount] != 1)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 1 child, got %lu\n", 
+                   (unsigned long)[parent childCount]);
+          exitCode = 1;
+        }
+      
+      // Test 2: Verify child is correct
+      NSXMLNode *retrieved = [parent childAtIndex:0];
+      if (![[retrieved name] isEqualToString:@"child1"])
+        {
+          GSPrintf(stderr, @"ERROR: Wrong child name: %@\n", [retrieved name]);
+          exitCode = 1;
+        }
+      
+      // Test 3: Add second child
+      NSXMLElement *child2 = [NSXMLElement elementWithName:@"child2"];
+      [parent addChild:child2];
+      
+      if ([parent childCount] != 2)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 2 children, got %lu\n", 
+                   (unsigned long)[parent childCount]);
+          exitCode = 1;
+        }
+      
+      // Test 4: Verify order
+      NSArray *children = [parent children];
+      if (![[children objectAtIndex:0] isEqual:child1] ||
+          ![[children objectAtIndex:1] isEqual:child2])
+        {
+          GSPrintf(stderr, @"ERROR: Children in wrong order\n");
+          exitCode = 1;
+        }
+      
+      // Test 5: Verify parent links
+      if ([child1 parent] != parent || [child2 parent] != parent)
+        {
+          GSPrintf(stderr, @"ERROR: Parent links incorrect\n");
+          exitCode = 1;
+        }
+      
+      if (exitCode == 0)
+        {
+          GSPrintf(stdout, @"PASS: Add child tests passed\n");
+        }
+    }
+  NS_HANDLER
+    {
+      GSPrintf(stderr, @"EXCEPTION: %@: %@\n", [localException name], [localException reason]);
+      exitCode = 1;
+    }
+  NS_ENDHANDLER
+  
+  [arp release];
+  return exitCode;
+}

--- a/Tests/base/NSXMLNode/test_nsxml_attributes.m
+++ b/Tests/base/NSXMLNode/test_nsxml_attributes.m
@@ -1,0 +1,92 @@
+#import <Foundation/Foundation.h>
+
+/* Test attribute handling on NSXMLElement
+ * Returns 0 on success, 1 on failure
+ */
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  int exitCode = 0;
+  
+  NS_DURING
+    {
+      NSXMLElement *elem = [NSXMLElement elementWithName:@"element"];
+      
+      // Test 1: Add attribute
+      NSXMLNode *attr1 = [NSXMLNode attributeWithName:@"id" stringValue:@"test"];
+      [elem addAttribute:attr1];
+      
+      NSArray *attributes = [elem attributes];
+      if ([attributes count] != 1)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 1 attribute, got %lu\n",
+                   (unsigned long)[attributes count]);
+          exitCode = 1;
+        }
+      
+      // Test 2: Get attribute by name
+      NSXMLNode *retrieved = [elem attributeForName:@"id"];
+      if (retrieved == nil || ![[retrieved stringValue] isEqualToString:@"test"])
+        {
+          GSPrintf(stderr, @"ERROR: Couldn't retrieve attribute\n");
+          exitCode = 1;
+        }
+      
+      // Test 3: Add another attribute
+      NSXMLNode *attr2 = [NSXMLNode attributeWithName:@"class" stringValue:@"main"];
+      [elem addAttribute:attr2];
+      
+      if ([[elem attributes] count] != 2)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 2 attributes\n");
+          exitCode = 1;
+        }
+      
+      // Test 4: Remove attribute
+      [elem removeAttributeForName:@"id"];
+      
+      if ([[elem attributes] count] != 1)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 1 attribute after remove\n");
+          exitCode = 1;
+        }
+      
+      if ([elem attributeForName:@"id"] != nil)
+        {
+          GSPrintf(stderr, @"ERROR: Attribute should be removed\n");
+          exitCode = 1;
+        }
+      
+      // Test 5: Set attributes array
+      NSXMLNode *newAttr1 = [NSXMLNode attributeWithName:@"name" stringValue:@"value1"];
+      NSXMLNode *newAttr2 = [NSXMLNode attributeWithName:@"type" stringValue:@"value2"];
+      [elem setAttributes:[NSArray arrayWithObjects:newAttr1, newAttr2, nil]];
+      
+      if ([[elem attributes] count] != 2)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 2 attributes after setAttributes\n");
+          exitCode = 1;
+        }
+      
+      if ([elem attributeForName:@"class"] != nil)
+        {
+          GSPrintf(stderr, @"ERROR: Old attribute should be gone\n");
+          exitCode = 1;
+        }
+      
+      if (exitCode == 0)
+        {
+          GSPrintf(stdout, @"PASS: Attribute tests passed\n");
+        }
+    }
+  NS_HANDLER
+    {
+      GSPrintf(stderr, @"EXCEPTION: %@: %@\n", [localException name], [localException reason]);
+      exitCode = 1;
+    }
+  NS_ENDHANDLER
+  
+  [arp release];
+  return exitCode;
+}

--- a/Tests/base/NSXMLNode/test_nsxml_basic.m
+++ b/Tests/base/NSXMLNode/test_nsxml_basic.m
@@ -1,0 +1,36 @@
+#import "ObjectTesting.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSXMLNode.h>
+#import "GNUstepBase/GSConfig.h"
+
+int main()
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  START_SET("NSXMLNode basic creation")
+#if !GS_USE_LIBXML
+    SKIP("library built without libxml2")
+#else
+
+  // Test 1: Create element node
+  NSXMLElement *elem = [NSXMLElement elementWithName:@"root"];
+  PASS(elem != nil, "Created element node");
+  
+  // Test 2: Check kind
+  PASS([elem kind] == NSXMLElementKind, "Element has correct kind");
+  
+  // Test 3: Check name
+  PASS_EQUAL([elem name], @"root", "Element has correct name");
+  
+  // Test 4: Create text node
+  NSXMLNode *text = [NSXMLNode textWithStringValue:@"Hello"];
+  PASS(text != nil, "Created text node");
+  
+  // Test 5: Check text node kind and value
+  PASS([text kind] == NSXMLTextKind, "Text node has correct kind");
+  PASS_EQUAL([text stringValue], @"Hello", "Text node has correct value");
+
+#endif
+  END_SET("NSXMLNode basic creation")
+  [arp release];
+  return 0;
+}

--- a/Tests/base/NSXMLNode/test_nsxml_complex_tree.m
+++ b/Tests/base/NSXMLNode/test_nsxml_complex_tree.m
@@ -1,0 +1,136 @@
+#import <Foundation/Foundation.h>
+
+/* Test complex tree operations with multiple levels
+ * Returns 0 on success, 1 on failure
+ */
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  int exitCode = 0;
+  
+  NS_DURING
+    {
+      // Create a complex tree structure
+      NSXMLElement *root = [NSXMLElement elementWithName:@"root"];
+      NSXMLElement *section1 = [NSXMLElement elementWithName:@"section"];
+      NSXMLElement *section2 = [NSXMLElement elementWithName:@"section"];
+      
+      [root addChild:section1];
+      [root addChild:section2];
+      
+      // Add text and elements to section1
+      NSXMLNode *text1 = [NSXMLNode textWithStringValue:@"Intro: "];
+      NSXMLElement *para1 = [NSXMLElement elementWithName:@"para"];
+      NSXMLNode *paraText1 = [NSXMLNode textWithStringValue:@"First paragraph"];
+      
+      [section1 addChild:text1];
+      [section1 addChild:para1];
+      [para1 addChild:paraText1];
+      
+      // Add multiple text nodes to section2
+      NSXMLNode *textA = [NSXMLNode textWithStringValue:@"A"];
+      NSXMLNode *textB = [NSXMLNode textWithStringValue:@"B"];
+      NSXMLNode *textC = [NSXMLNode textWithStringValue:@"C"];
+      
+      [section2 addChild:textA];
+      [section2 addChild:textB];
+      [section2 addChild:textC];
+      
+      // Test 1: Verify structure
+      if ([root childCount] != 2)
+        {
+          GSPrintf(stderr, @"ERROR: Root should have 2 children\n");
+          exitCode = 1;
+        }
+      
+      if ([section1 childCount] != 2)
+        {
+          GSPrintf(stderr, @"ERROR: Section1 should have 2 children\n");
+          exitCode = 1;
+        }
+      
+      if ([section2 childCount] != 3)
+        {
+          GSPrintf(stderr, @"ERROR: Section2 should have 3 children, got %lu\n",
+                   (unsigned long)[section2 childCount]);
+          exitCode = 1;
+        }
+      
+      // Test 2: Verify text nodes in section2 didn't merge
+      NSArray *section2Children = [section2 children];
+      if ([section2Children count] != 3)
+        {
+          GSPrintf(stderr, @"ERROR: Text nodes merged in section2\n");
+          exitCode = 1;
+        }
+      
+      if (![[section2Children objectAtIndex:0] isEqual:textA] ||
+          ![[section2Children objectAtIndex:1] isEqual:textB] ||
+          ![[section2Children objectAtIndex:2] isEqual:textC])
+        {
+          GSPrintf(stderr, @"ERROR: Section2 children are wrong\n");
+          exitCode = 1;
+        }
+      
+      // Test 3: Move para1 to section2
+      [para1 detach];
+      [section2 insertChild:para1 atIndex:1];
+      
+      if ([section1 childCount] != 1)
+        {
+          GSPrintf(stderr, @"ERROR: Section1 should have 1 child after detach\n");
+          exitCode = 1;
+        }
+      
+      if ([section2 childCount] != 4)
+        {
+          GSPrintf(stderr, @"ERROR: Section2 should have 4 children after insert\n");
+          exitCode = 1;
+        }
+      
+      if ([para1 parent] != section2)
+        {
+          GSPrintf(stderr, @"ERROR: para1 should have section2 as parent\n");
+          exitCode = 1;
+        }
+      
+      // Test 4: Verify nested child still intact
+      if ([para1 childCount] != 1)
+        {
+          GSPrintf(stderr, @"ERROR: para1 should still have its child\n");
+          exitCode = 1;
+        }
+      
+      if (![[para1 childAtIndex:0] isEqual:paraText1])
+        {
+          GSPrintf(stderr, @"ERROR: para1's child is wrong\n");
+          exitCode = 1;
+        }
+      
+      // Test 5: Insert element between text nodes
+      NSXMLElement *span = [NSXMLElement elementWithName:@"span"];
+      [section2 insertChild:span atIndex:1];
+      
+      // Should be: textA, span, para1, textB, textC
+      if ([section2 childCount] != 5)
+        {
+          GSPrintf(stderr, @"ERROR: Section2 should have 5 children\n");
+          exitCode = 1;
+        }
+      
+      if (exitCode == 0)
+        {
+          GSPrintf(stdout, @"PASS: Complex tree tests passed\n");
+        }
+    }
+  NS_HANDLER
+    {
+      GSPrintf(stderr, @"EXCEPTION: %@: %@\n", [localException name], [localException reason]);
+      exitCode = 1;
+    }
+  NS_ENDHANDLER
+  
+  [arp release];
+  return exitCode;
+}

--- a/Tests/base/NSXMLNode/test_nsxml_detach.m
+++ b/Tests/base/NSXMLNode/test_nsxml_detach.m
@@ -1,0 +1,93 @@
+#import <Foundation/Foundation.h>
+
+/* Test detaching nodes from their parents
+ * Returns 0 on success, 1 on failure
+ */
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  int exitCode = 0;
+  
+  NS_DURING
+    {
+      NSXMLElement *parent = [NSXMLElement elementWithName:@"parent"];
+      NSXMLElement *child1 = [NSXMLElement elementWithName:@"child1"];
+      NSXMLElement *child2 = [NSXMLElement elementWithName:@"child2"];
+      NSXMLElement *child3 = [NSXMLElement elementWithName:@"child3"];
+      
+      [parent addChild:child1];
+      [parent addChild:child2];
+      [parent addChild:child3];
+      
+      // Test 1: Detach middle child
+      [child2 detach];
+      
+      if ([parent childCount] != 2)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 2 children after detach, got %lu\n",
+                   (unsigned long)[parent childCount]);
+          exitCode = 1;
+        }
+      
+      if ([child2 parent] != nil)
+        {
+          GSPrintf(stderr, @"ERROR: Detached child still has parent\n");
+          exitCode = 1;
+        }
+      
+      // Test 2: Verify remaining children
+      if (![[parent childAtIndex:0] isEqual:child1] ||
+          ![[parent childAtIndex:1] isEqual:child3])
+        {
+          GSPrintf(stderr, @"ERROR: Wrong children after detach\n");
+          exitCode = 1;
+        }
+      
+      // Test 3: Reattach detached child
+      [parent insertChild:child2 atIndex:1];
+      
+      if ([parent childCount] != 3)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 3 children after reattach\n");
+          exitCode = 1;
+        }
+      
+      if ([child2 parent] != parent)
+        {
+          GSPrintf(stderr, @"ERROR: Reattached child has wrong parent\n");
+          exitCode = 1;
+        }
+      
+      // Test 4: Detach and add to different parent
+      NSXMLElement *newParent = [NSXMLElement elementWithName:@"newParent"];
+      [child1 detach];
+      [newParent addChild:child1];
+      
+      if ([child1 parent] != newParent)
+        {
+          GSPrintf(stderr, @"ERROR: Child not properly moved to new parent\n");
+          exitCode = 1;
+        }
+      
+      if ([parent childCount] != 2)
+        {
+          GSPrintf(stderr, @"ERROR: Original parent still has detached child\n");
+          exitCode = 1;
+        }
+      
+      if (exitCode == 0)
+        {
+          GSPrintf(stdout, @"PASS: Detach tests passed\n");
+        }
+    }
+  NS_HANDLER
+    {
+      GSPrintf(stderr, @"EXCEPTION: %@: %@\n", [localException name], [localException reason]);
+      exitCode = 1;
+    }
+  NS_ENDHANDLER
+  
+  [arp release];
+  return exitCode;
+}

--- a/Tests/base/NSXMLNode/test_nsxml_insert_child.m
+++ b/Tests/base/NSXMLNode/test_nsxml_insert_child.m
@@ -1,0 +1,85 @@
+#import <Foundation/Foundation.h>
+
+/* Test inserting children at specific positions
+ * Returns 0 on success, 1 on failure
+ */
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  int exitCode = 0;
+  
+  NS_DURING
+    {
+      NSXMLElement *parent = [NSXMLElement elementWithName:@"parent"];
+      
+      // Test 1: Insert at index 0 (empty parent)
+      NSXMLElement *child1 = [NSXMLElement elementWithName:@"child1"];
+      [parent insertChild:child1 atIndex:0];
+      
+      if ([parent childCount] != 1 || ![[parent childAtIndex:0] isEqual:child1])
+        {
+          GSPrintf(stderr, @"ERROR: Insert at index 0 failed\n");
+          exitCode = 1;
+        }
+      
+      // Test 2: Insert at index 0 (prepend)
+      NSXMLElement *child0 = [NSXMLElement elementWithName:@"child0"];
+      [parent insertChild:child0 atIndex:0];
+      
+      if ([parent childCount] != 2)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 2 children after prepend\n");
+          exitCode = 1;
+        }
+      
+      if (![[parent childAtIndex:0] isEqual:child0] || 
+          ![[parent childAtIndex:1] isEqual:child1])
+        {
+          GSPrintf(stderr, @"ERROR: Wrong order after prepend\n");
+          exitCode = 1;
+        }
+      
+      // Test 3: Insert in middle
+      NSXMLElement *child05 = [NSXMLElement elementWithName:@"child05"];
+      [parent insertChild:child05 atIndex:1];
+      
+      if ([parent childCount] != 3)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 3 children after middle insert\n");
+          exitCode = 1;
+        }
+      
+      if (![[parent childAtIndex:0] isEqual:child0] || 
+          ![[parent childAtIndex:1] isEqual:child05] ||
+          ![[parent childAtIndex:2] isEqual:child1])
+        {
+          GSPrintf(stderr, @"ERROR: Wrong order after middle insert\n");
+          exitCode = 1;
+        }
+      
+      // Test 4: Insert at end (append)
+      NSXMLElement *child2 = [NSXMLElement elementWithName:@"child2"];
+      [parent insertChild:child2 atIndex:3];
+      
+      if ([parent childCount] != 4 || ![[parent childAtIndex:3] isEqual:child2])
+        {
+          GSPrintf(stderr, @"ERROR: Insert at end failed\n");
+          exitCode = 1;
+        }
+      
+      if (exitCode == 0)
+        {
+          GSPrintf(stdout, @"PASS: Insert child tests passed\n");
+        }
+    }
+  NS_HANDLER
+    {
+      GSPrintf(stderr, @"EXCEPTION: %@: %@\n", [localException name], [localException reason]);
+      exitCode = 1;
+    }
+  NS_ENDHANDLER
+  
+  [arp release];
+  return exitCode;
+}

--- a/Tests/base/NSXMLNode/test_nsxml_mixed_content.m
+++ b/Tests/base/NSXMLNode/test_nsxml_mixed_content.m
@@ -1,0 +1,98 @@
+#import <Foundation/Foundation.h>
+
+/* Test mixed content (elements and text nodes)
+ * Returns 0 on success, 1 on failure
+ */
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  int exitCode = 0;
+  
+  NS_DURING
+    {
+      // Test 1: Create element with mixed content
+      NSXMLElement *parent = [NSXMLElement elementWithName:@"p"];
+      NSXMLNode *text1 = [NSXMLNode textWithStringValue:@"Hello "];
+      NSXMLElement *bold = [NSXMLElement elementWithName:@"b"];
+      NSXMLNode *boldText = [NSXMLNode textWithStringValue:@"world"];
+      NSXMLNode *text2 = [NSXMLNode textWithStringValue:@"!"];
+      
+      [parent addChild:text1];
+      [parent addChild:bold];
+      [bold addChild:boldText];
+      [parent addChild:text2];
+      
+      // Test 2: Verify structure
+      if ([parent childCount] != 3)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 3 children in mixed content, got %lu\n",
+                   (unsigned long)[parent childCount]);
+          exitCode = 1;
+        }
+      
+      // Test 3: Verify each child
+      NSXMLNode *firstChild = [parent childAtIndex:0];
+      NSXMLNode *secondChild = [parent childAtIndex:1];
+      NSXMLNode *thirdChild = [parent childAtIndex:2];
+      
+      if ([firstChild kind] != NSXMLTextKind ||
+          ![[firstChild stringValue] isEqualToString:@"Hello "])
+        {
+          GSPrintf(stderr, @"ERROR: First child incorrect\n");
+          exitCode = 1;
+        }
+      
+      if ([secondChild kind] != NSXMLElementKind ||
+          ![[secondChild name] isEqualToString:@"b"])
+        {
+          GSPrintf(stderr, @"ERROR: Second child incorrect\n");
+          exitCode = 1;
+        }
+      
+      if ([thirdChild kind] != NSXMLTextKind ||
+          ![[thirdChild stringValue] isEqualToString:@"!"])
+        {
+          GSPrintf(stderr, @"ERROR: Third child incorrect\n");
+          exitCode = 1;
+        }
+      
+      // Test 4: Insert text between text and element
+      NSXMLNode *insertedText = [NSXMLNode textWithStringValue:@"dear "];
+      [parent insertChild:insertedText atIndex:1];
+      
+      if ([parent childCount] != 4)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 4 children after insert, got %lu\n",
+                   (unsigned long)[parent childCount]);
+          exitCode = 1;
+        }
+      
+      // Test 5: Verify no unwanted merging occurred
+      NSXMLNode *first = [parent childAtIndex:0];
+      NSXMLNode *second = [parent childAtIndex:1];
+      
+      if (![[first stringValue] isEqualToString:@"Hello "] ||
+          ![[second stringValue] isEqualToString:@"dear "])
+        {
+          GSPrintf(stderr, @"ERROR: Text nodes merged when they shouldn't\n");
+          GSPrintf(stderr, @"       First: %@, Second: %@\n", 
+                   [first stringValue], [second stringValue]);
+          exitCode = 1;
+        }
+      
+      if (exitCode == 0)
+        {
+          GSPrintf(stdout, @"PASS: Mixed content tests passed\n");
+        }
+    }
+  NS_HANDLER
+    {
+      GSPrintf(stderr, @"EXCEPTION: %@: %@\n", [localException name], [localException reason]);
+      exitCode = 1;
+    }
+  NS_ENDHANDLER
+  
+  [arp release];
+  return exitCode;
+}

--- a/Tests/base/NSXMLNode/test_nsxml_namespace.m
+++ b/Tests/base/NSXMLNode/test_nsxml_namespace.m
@@ -1,0 +1,78 @@
+#import <Foundation/Foundation.h>
+
+/* Test namespace handling on NSXMLElement
+ * Returns 0 on success, 1 on failure
+ */
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  int exitCode = 0;
+  
+  NS_DURING
+    {
+      // Test 1: Create element with namespace
+      NSXMLElement *elem = [NSXMLElement elementWithName:@"root"];
+      NSXMLNode *ns = [NSXMLNode namespaceWithName:@"h" 
+                                       stringValue:@"http://www.w3.org/1999/xhtml"];
+      
+      [elem addNamespace:ns];
+      
+      NSArray *namespaces = [elem namespaces];
+      if ([namespaces count] != 1)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 1 namespace, got %lu\n",
+                   (unsigned long)[namespaces count]);
+          exitCode = 1;
+        }
+      
+      // Test 2: Get namespace by prefix
+      NSXMLNode *retrieved = [elem namespaceForPrefix:@"h"];
+      if (retrieved == nil)
+        {
+          GSPrintf(stderr, @"ERROR: Couldn't retrieve namespace\n");
+          exitCode = 1;
+        }
+      
+      // Test 3: Resolve namespace URI
+      NSXMLNode *resolved = [elem resolveNamespaceForName:@"h:body"];
+      if (resolved == nil)
+        {
+          GSPrintf(stderr, @"ERROR: Couldn't resolve namespace\n");
+          exitCode = 1;
+        }
+      
+      // Test 4: Add element in namespace
+      NSXMLElement *child = [NSXMLElement elementWithName:@"h:body"];
+      [elem addChild:child];
+      
+      if ([elem childCount] != 1)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 1 child\n");
+          exitCode = 1;
+        }
+      
+      // Test 5: Remove namespace
+      [elem removeNamespaceForPrefix:@"h"];
+      
+      if ([[elem namespaces] count] != 0)
+        {
+          GSPrintf(stderr, @"ERROR: Namespace should be removed\n");
+          exitCode = 1;
+        }
+      
+      if (exitCode == 0)
+        {
+          GSPrintf(stdout, @"PASS: Namespace tests passed\n");
+        }
+    }
+  NS_HANDLER
+    {
+      GSPrintf(stderr, @"EXCEPTION: %@: %@\n", [localException name], [localException reason]);
+      exitCode = 1;
+    }
+  NS_ENDHANDLER
+  
+  [arp release];
+  return exitCode;
+}

--- a/Tests/base/NSXMLNode/test_nsxml_remove_child.m
+++ b/Tests/base/NSXMLNode/test_nsxml_remove_child.m
@@ -1,0 +1,79 @@
+#import <Foundation/Foundation.h>
+
+/* Test removing children from NSXMLElement
+ * Returns 0 on success, 1 on failure
+ */
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  int exitCode = 0;
+  
+  NS_DURING
+    {
+      NSXMLElement *parent = [NSXMLElement elementWithName:@"parent"];
+      NSXMLElement *child1 = [NSXMLElement elementWithName:@"child1"];
+      NSXMLElement *child2 = [NSXMLElement elementWithName:@"child2"];
+      NSXMLElement *child3 = [NSXMLElement elementWithName:@"child3"];
+      
+      [parent addChild:child1];
+      [parent addChild:child2];
+      [parent addChild:child3];
+      
+      // Test 1: Remove middle child
+      [parent removeChildAtIndex:1];
+      
+      if ([parent childCount] != 2)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 2 children after remove, got %lu\n",
+                   (unsigned long)[parent childCount]);
+          exitCode = 1;
+        }
+      
+      if (![[parent childAtIndex:0] isEqual:child1] ||
+          ![[parent childAtIndex:1] isEqual:child3])
+        {
+          GSPrintf(stderr, @"ERROR: Wrong children remain after remove\n");
+          exitCode = 1;
+        }
+      
+      // Test 2: Verify removed child has no parent
+      if ([child2 parent] != nil)
+        {
+          GSPrintf(stderr, @"ERROR: Removed child still has parent\n");
+          exitCode = 1;
+        }
+      
+      // Test 3: Remove first child
+      [parent removeChildAtIndex:0];
+      
+      if ([parent childCount] != 1 || ![[parent childAtIndex:0] isEqual:child3])
+        {
+          GSPrintf(stderr, @"ERROR: Wrong child after removing first\n");
+          exitCode = 1;
+        }
+      
+      // Test 4: Remove last child
+      [parent removeChildAtIndex:0];
+      
+      if ([parent childCount] != 0)
+        {
+          GSPrintf(stderr, @"ERROR: Parent should have no children\n");
+          exitCode = 1;
+        }
+      
+      if (exitCode == 0)
+        {
+          GSPrintf(stdout, @"PASS: Remove child tests passed\n");
+        }
+    }
+  NS_HANDLER
+    {
+      GSPrintf(stderr, @"EXCEPTION: %@: %@\n", [localException name], [localException reason]);
+      exitCode = 1;
+    }
+  NS_ENDHANDLER
+  
+  [arp release];
+  return exitCode;
+}

--- a/Tests/base/NSXMLNode/test_nsxml_replace_child.m
+++ b/Tests/base/NSXMLNode/test_nsxml_replace_child.m
@@ -1,0 +1,75 @@
+#import <Foundation/Foundation.h>
+
+/* Test replacing children in NSXMLElement
+ * Returns 0 on success, 1 on failure
+ */
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  int exitCode = 0;
+  
+  NS_DURING
+    {
+      NSXMLElement *parent = [NSXMLElement elementWithName:@"parent"];
+      NSXMLElement *child1 = [NSXMLElement elementWithName:@"child1"];
+      NSXMLElement *child2 = [NSXMLElement elementWithName:@"child2"];
+      NSXMLElement *child3 = [NSXMLElement elementWithName:@"child3"];
+      
+      [parent addChild:child1];
+      [parent addChild:child2];
+      [parent addChild:child3];
+      
+      // Test 1: Replace middle child
+      NSXMLElement *newChild = [NSXMLElement elementWithName:@"newChild"];
+      [parent replaceChildAtIndex:1 withNode:newChild];
+      
+      if ([parent childCount] != 3)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 3 children after replace\n");
+          exitCode = 1;
+        }
+      
+      if (![[parent childAtIndex:1] isEqual:newChild])
+        {
+          GSPrintf(stderr, @"ERROR: Child not replaced correctly\n");
+          exitCode = 1;
+        }
+      
+      // Test 2: Verify order preserved
+      if (![[parent childAtIndex:0] isEqual:child1] ||
+          ![[parent childAtIndex:2] isEqual:child3])
+        {
+          GSPrintf(stderr, @"ERROR: Other children affected by replacement\n");
+          exitCode = 1;
+        }
+      
+      // Test 3: Verify old child detached
+      if ([child2 parent] != nil)
+        {
+          GSPrintf(stderr, @"ERROR: Replaced child still has parent\n");
+          exitCode = 1;
+        }
+      
+      // Test 4: Verify new child has correct parent
+      if ([newChild parent] != parent)
+        {
+          GSPrintf(stderr, @"ERROR: New child doesn't have correct parent\n");
+          exitCode = 1;
+        }
+      
+      if (exitCode == 0)
+        {
+          GSPrintf(stdout, @"PASS: Replace child tests passed\n");
+        }
+    }
+  NS_HANDLER
+    {
+      GSPrintf(stderr, @"EXCEPTION: %@: %@\n", [localException name], [localException reason]);
+      exitCode = 1;
+    }
+  NS_ENDHANDLER
+  
+  [arp release];
+  return exitCode;
+}

--- a/Tests/base/NSXMLNode/test_nsxml_set_children.m
+++ b/Tests/base/NSXMLNode/test_nsxml_set_children.m
@@ -1,0 +1,97 @@
+#import <Foundation/Foundation.h>
+
+/* Test setting children array on NSXMLElement
+ * Returns 0 on success, 1 on failure
+ */
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  int exitCode = 0;
+  
+  NS_DURING
+    {
+      NSXMLElement *parent = [NSXMLElement elementWithName:@"parent"];
+      NSXMLElement *oldChild1 = [NSXMLElement elementWithName:@"old1"];
+      NSXMLElement *oldChild2 = [NSXMLElement elementWithName:@"old2"];
+      
+      [parent addChild:oldChild1];
+      [parent addChild:oldChild2];
+      
+      // Test 1: Replace all children with new array
+      NSXMLElement *newChild1 = [NSXMLElement elementWithName:@"new1"];
+      NSXMLElement *newChild2 = [NSXMLElement elementWithName:@"new2"];
+      NSXMLElement *newChild3 = [NSXMLElement elementWithName:@"new3"];
+      
+      NSArray *newChildren = [NSArray arrayWithObjects:newChild1, newChild2, newChild3, nil];
+      [parent setChildren:newChildren];
+      
+      if ([parent childCount] != 3)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 3 children after setChildren, got %lu\n",
+                   (unsigned long)[parent childCount]);
+          exitCode = 1;
+        }
+      
+      // Test 2: Verify new children
+      if (![[parent childAtIndex:0] isEqual:newChild1] ||
+          ![[parent childAtIndex:1] isEqual:newChild2] ||
+          ![[parent childAtIndex:2] isEqual:newChild3])
+        {
+          GSPrintf(stderr, @"ERROR: Wrong children after setChildren\n");
+          exitCode = 1;
+        }
+      
+      // Test 3: Verify old children are detached
+      if ([oldChild1 parent] != nil || [oldChild2 parent] != nil)
+        {
+          GSPrintf(stderr, @"ERROR: Old children still have parent\n");
+          exitCode = 1;
+        }
+      
+      // Test 4: Set children to empty array
+      [parent setChildren:[NSArray array]];
+      
+      if ([parent childCount] != 0)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 0 children after setting empty array\n");
+          exitCode = 1;
+        }
+      
+      // Test 5: Set children with text nodes
+      NSXMLNode *text1 = [NSXMLNode textWithStringValue:@"Text1"];
+      NSXMLNode *text2 = [NSXMLNode textWithStringValue:@"Text2"];
+      NSArray *textChildren = [NSArray arrayWithObjects:text1, text2, nil];
+      
+      [parent setChildren:textChildren];
+      
+      if ([parent childCount] != 2)
+        {
+          GSPrintf(stderr, @"ERROR: Expected 2 text children, got %lu\n",
+                   (unsigned long)[parent childCount]);
+          exitCode = 1;
+        }
+      
+      // Test 6: Verify text nodes didn't merge
+      if (![[parent childAtIndex:0] isEqual:text1] ||
+          ![[parent childAtIndex:1] isEqual:text2])
+        {
+          GSPrintf(stderr, @"ERROR: Text nodes merged in setChildren\n");
+          exitCode = 1;
+        }
+      
+      if (exitCode == 0)
+        {
+          GSPrintf(stdout, @"PASS: Set children tests passed\n");
+        }
+    }
+  NS_HANDLER
+    {
+      GSPrintf(stderr, @"EXCEPTION: %@: %@\n", [localException name], [localException reason]);
+      exitCode = 1;
+    }
+  NS_ENDHANDLER
+  
+  [arp release];
+  return exitCode;
+}

--- a/Tests/base/NSXMLNode/test_nsxml_text_nodes.m
+++ b/Tests/base/NSXMLNode/test_nsxml_text_nodes.m
@@ -1,0 +1,58 @@
+#import "ObjectTesting.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSXMLNode.h>
+#import "GNUstepBase/GSConfig.h"
+
+/* Test text node handling - specifically that they DON'T merge unintentionally
+ * This is the critical test for the libxml2 2.12.0+ fix
+ */
+int main()
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  START_SET("NSXMLNode text node handling (no merging)")
+#if !GS_USE_LIBXML
+    SKIP("library built without libxml2")
+#else
+
+  // Create parent element
+  NSXMLElement *parent = [NSXMLElement elementWithName:@"parent"];
+  
+  // Test 1: Add multiple text nodes - they should NOT merge automatically
+  NSXMLNode *text1 = [NSXMLNode textWithStringValue:@"Hello"];
+  NSXMLNode *text2 = [NSXMLNode textWithStringValue:@"World"];
+  
+  [parent addChild:text1];
+  [parent addChild:text2];
+  
+  NSUInteger childCount = [parent childCount];
+  PASS(childCount == 2, "Two adjacent text nodes remain separate (no automatic merging)");
+  
+  // Test 2: Verify each text node has correct value
+  NSXMLNode *retrieved1 = [parent childAtIndex:0];
+  NSXMLNode *retrieved2 = [parent childAtIndex:1];
+  
+  PASS_EQUAL([retrieved1 stringValue], @"Hello", "First text node has correct value");
+  PASS_EQUAL([retrieved2 stringValue], @"World", "Second text node has correct value");
+  
+  // Test 3: Insert text node between two others
+  NSXMLElement *parent2 = [NSXMLElement elementWithName:@"parent2"];
+  NSXMLNode *textA = [NSXMLNode textWithStringValue:@"A"];
+  NSXMLNode *textB = [NSXMLNode textWithStringValue:@"B"];
+  NSXMLNode *textC = [NSXMLNode textWithStringValue:@"C"];
+  
+  [parent2 addChild:textA];
+  [parent2 addChild:textC];
+  [parent2 insertChild:textB atIndex:1];
+  
+  PASS([parent2 childCount] == 3, "Three text nodes after insertion (no merging)");
+  
+  // Test 4: Verify order after insertion
+  PASS([[parent2 childAtIndex:0] isEqual:textA], "First text node in correct position");
+  PASS([[parent2 childAtIndex:1] isEqual:textB], "Inserted text node in correct position");
+  PASS([[parent2 childAtIndex:2] isEqual:textC], "Last text node in correct position");
+
+#endif
+  END_SET("NSXMLNode text node handling (no merging)")
+  [arp release];
+  return 0;
+}


### PR DESCRIPTION
This change updates our libxml2 integration to correctly handle node adoption and manual linking when building against libxml2 2.12.0 or newer. In 2.12.x, libxml2 rewrote significant portions of its tree-manipulation code, including adding internal normalization during both xmlSetTreeDoc and manual node linking. Previously, manually linking child nodes avoided automatic text‑node merging, but in 2.12.x the library now performs merging internally even when bypassing xmlSetTreeDoc. To prevent unwanted normalization, this update adds a manual doc‑update routine for subtree nodes that sets the doc pointer without triggering merges, ensures every text node receives a unique name pointer so libxml2 will not merge them based on pointer equality, updates attributes and namespace nodes safely, and applies these updates before assigning the parent to avoid libxml2 normalization during insertion. For older libxml2 versions we continue to use xmlDOMWrapAdoptNode or xmlSetTreeDoc as before. This fixes text‑node coalescing introduced by libxml2’s internal changes and restores the expected behavior for manually linked XML nodes.