### PR TITLE
Add safety to prevent crash due to malformed environment entries

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-02-06 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSProcessInfo.m:
+	Add safety to prevent crash due to malformed environment entries.
+
 2026-01-13 Frederik Seiffert <frederik@algoriddim.com>
 
 	* Headers/Foundation/NSNotification.h:

--- a/Source/NSProcessInfo.m
+++ b/Source/NSProcessInfo.m
@@ -455,8 +455,11 @@ _gnu_process_args(int argc, char *argv[], char *env[])
 		val = [NSString stringWithCharacters: start
 					      length: wenvp - start];
 		wenvp++;	// Skip past variable terminator
-		[keys addObject: key];
-		[values addObject: val];
+		if (key != nil && val != nil)
+		  {
+		    [keys addObject: key];
+		    [values addObject: val];
+		  }
 	      }
 	    FreeEnvironmentStringsW(base);
 	    env = 0;	// Suppress standard code.


### PR DESCRIPTION
We’ve been seeing crashes here on Windows, presumably due to malformed UTF‑16 data for which stringWithCharacters:length: can return nil.