### PR TITLE
Guard Windows symbol lookup to prevent callStackSymbols crash

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2026-02-09 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSException.m:
+	Guard SymFromAddr usage on Windows to avoid crashes when symbol
+	lookup is not initialized.
+
 2026-02-06 Frederik Seiffert <frederik@algoriddim.com>
 
 	* Source/NSProcessInfo.m:

--- a/Source/NSException.m
+++ b/Source/NSException.m
@@ -1269,7 +1269,7 @@ GSPrivateReturnAddresses(NSUInteger **returns)
         {
           NSUInteger	addr = (NSUInteger)*ptrs++; 
 
-          if ((fromSym)(hProcess, (DWORD64)addr, 0, symbol))
+          if (fromSym && (fromSym)(hProcess, (DWORD64)addr, 0, symbol))
             {
               syms[i] = [NSString stringWithFormat:
                 @"%s - %lx", symbol->Name, (unsigned long)addr];


### PR DESCRIPTION
We’ve seen crashes here due to `fromSym` not being initialized, presumably because it couldn’t be loaded from dbghelp.dll (e.g. missing from the system or blocked).