### PR TITLE
Catch exceptions in `-[NSPropertyList propertyListWithData:options:format:error:]`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-02-26 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSPropertyList.m:
+	Catch exceptions raised by binary plist deserialization in
+	+propertyListWithData:options:format:error: and map exception reasons
+	to NSError output.
+
 2026-02-10 Simon Peter <probono@puredarwin.org>
 
 	* Headers/Foundation/NSZone.h:

--- a/Source/NSPropertyList.m
+++ b/Source/NSPropertyList.m
@@ -2848,15 +2848,27 @@ checkPL(id aPropertyList, NSPropertyListFormat aFormat)
           break;
 
         case NSPropertyListGNUstepBinaryFormat:
-          if (anOption == NSPropertyListImmutable)
+          NS_DURING
             {
-              result = [NSDeserializer deserializePropertyListFromData: data
-                                                     mutableContainers: NO];
+              if (anOption == NSPropertyListImmutable)
+                {
+                  result = [NSDeserializer deserializePropertyListFromData: data
+                                                         mutableContainers: NO];
+                }
+              else
+                {
+                  result = [NSDeserializer deserializePropertyListFromData: data
+                                                         mutableContainers: YES];
+                }
             }
-          else
+          NS_HANDLER
             {
-              result = [NSDeserializer deserializePropertyListFromData: data
-                                                     mutableContainers: YES];
+              errorStr = [localException reason];
+            }
+          NS_ENDHANDLER
+          if (result == nil && errorStr == nil)
+            {
+              errorStr = @"failed to parse binary property list";
             }
           break;
           


### PR DESCRIPTION
Catch exceptions thrown by NSDeserializer and return them as NSError.