### PR TITLE
Do not send content-length for GET request with no content

### DIFF
--- a/Source/NSURLProtocol.m
+++ b/Source/NSURLProtocol.m
@@ -1907,7 +1907,7 @@ typedef struct {
 		      [mm appendData: bytes];
 		    }
 		}
-	      if (l >= 0 && [this->request
+	      if ((l > 0 || (![[this->request HTTPMethod] isEqual: @"GET"] && l >= 0))  && [this->request
 	        valueForHTTPHeaderField: @"Content-Length"] == nil)
 		{
                   s = [NSString stringWithFormat: @"Content-Length: %d\r\n", l];


### PR DESCRIPTION
This prevents the 'content-length' header from being added to HTTP GET requests where there is a content length of 0. (which is the normal case for GET requests). Note that this only prevents the header from being added automatically. It can still be manually added.

This is in accordance with RFC9110
https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6
"A user agent SHOULD NOT send a Content-Length header field when the request message does not contain content and the method semantics do not anticipate such data."

https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.1
"Although request message framing is independent of the method used, content received in a GET request has no generally defined semantics, cannot alter the meaning or target of the request, and might lead some implementations to reject the request and close the connection because of its potential as a request smuggling attack"

The inclusion of the 'content-length' header is causing some servers to reject the GET request.