### PR TITLE
Limit NSJSONSerialization recursion depth to prevent stack overflow

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,17 @@
+2026-04-13 Todd White <todd.white@thalion.global>
+
+	* Source/NSJSONSerialization.m: cap the JSON parser recursion depth
+	at 512 levels to prevent stack overflow on pathologically nested
+	input. The parser state now tracks current nesting depth; parseArray
+	and parseObject bail out with a parse error when the bound is
+	reached, and decrement the depth counter on every return path so
+	the bound is correctly enforced across mixed array/object nesting.
+	* Tests/base/NSJSONSerialization/depth.m: new regression test that
+	verifies (a) moderately nested documents still parse, (b) documents
+	nested past the bound are rejected with the error out-parameter
+	populated, and (c) the bound applies equally to mixed object/array
+	nesting.
+
 2026-04-08 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Headers/Foundation/NSURL.h: Add newer NSURLComponents methods for

--- a/Source/NSJSONSerialization.m
+++ b/Source/NSJSONSerialization.m
@@ -104,7 +104,37 @@ typedef struct ParserStateStruct
    * Error value, if this parser is currently in an error state, nil otherwise.
    */
   NSError *error;
+  /**
+   * Current nesting depth of arrays/objects on the recursive-descent
+   * stack. Zero before parsing begins and while the parser is outside
+   * any container. Incremented exactly once on successful entry to
+   * parseArray or parseObject (after the depth-guard check has been
+   * passed) and decremented exactly once on every exit path from those
+   * functions, including early returns for parse errors. The invariant
+   * that `depth` mirrors the live container stack is what lets the
+   * depth-guard check at the top of parseArray/parseObject reject
+   * pathologically nested input before the C stack is exhausted.
+   */
+  int depth;
+  /**
+   * Upper bound on `depth`. Parsing fails with an error as soon as
+   * entering another container would cause `depth` to reach this value.
+   * Initialised by the JSONObjectWithData: and JSONObjectWithStream:
+   * class methods to NS_JSON_SERIALIZATION_MAX_DEPTH.
+   */
+  int maxDepth;
 } ParserState;
+
+/**
+ * Default maximum JSON parser nesting depth. Any input that nests
+ * arrays and/or objects more than this deep is rejected before the
+ * recursive-descent parser can exhaust the C stack. 512 is deep enough
+ * to accommodate every realistic JSON document (RFC 8259 recommends
+ * supporting at least 100 levels; most parsers cap in the 100-1000
+ * range) while leaving comfortable head-room below the smallest thread
+ * stack that GNUstep runs on.
+ */
+#define NS_JSON_SERIALIZATION_MAX_DEPTH 512
 
 /**
  * Pulls the next group of characters from a string source.
@@ -581,11 +611,17 @@ parseArray(ParserState *state)
   unichar c = consumeSpace(state);
   NSMutableArray *array;
 
+  if (state->depth >= state->maxDepth)
+    {
+      parseError(state);
+      return nil;
+    }
   if (c != '[')
     {
       parseError(state);
       return nil;
     }
+  state->depth++;
   // Eat the [
   consumeChar(state);
   array = [NSMutableArray new];
@@ -597,6 +633,7 @@ parseArray(ParserState *state)
       if (nil == obj)
         {
           [array release];
+          state->depth--;
           return nil;
         }
       [array addObject: obj];
@@ -610,6 +647,7 @@ parseArray(ParserState *state)
     }
   // Eat the trailing ]
   consumeChar(state);
+  state->depth--;
   if (!state->mutableContainers)
     {
       if (NO == [array makeImmutable])
@@ -629,11 +667,17 @@ parseObject(ParserState *state)
   unichar c = consumeSpace(state);
   NSMutableDictionary *dict;
 
+  if (state->depth >= state->maxDepth)
+    {
+      parseError(state);
+      return nil;
+    }
   if (c != '{')
     {
       parseError(state);
       return nil;
     }
+  state->depth++;
   // Eat the {
   consumeChar(state);
   dict = [NSMutableDictionary new];
@@ -646,6 +690,7 @@ parseObject(ParserState *state)
       if (nil == key)
         {
           [dict release];
+          state->depth--;
           return nil;
         }
       c = consumeSpace(state);
@@ -653,6 +698,7 @@ parseObject(ParserState *state)
         {
           [key release];
           [dict release];
+          state->depth--;
           parseError(state);
           return nil;
         }
@@ -663,6 +709,7 @@ parseObject(ParserState *state)
         {
           [key release];
           [dict release];
+          state->depth--;
           return nil;
         }
       [dict setObject: obj forKey: key];
@@ -677,6 +724,7 @@ parseObject(ParserState *state)
     }
   // Eat the trailing }
   consumeChar(state);
+  state->depth--;
   if (!state->mutableContainers)
     {
       if (NO == [dict makeImmutable])
@@ -1143,6 +1191,8 @@ writeObject(id obj, NSMutableString *output, NSInteger tabs, NSJSONWritingOption
   ParserState p = { 0 };
   id obj;
 
+  p.depth = 0;
+  p.maxDepth = NS_JSON_SERIALIZATION_MAX_DEPTH;
   [data getBytes: BOM length: 4];
   getEncoding(BOM, &p);
   p.source = [[NSString alloc] initWithData: data encoding: p.enc];
@@ -1168,6 +1218,8 @@ writeObject(id obj, NSMutableString *output, NSInteger tabs, NSJSONWritingOption
   ParserState p = { 0 };
   id obj;
 
+  p.depth = 0;
+  p.maxDepth = NS_JSON_SERIALIZATION_MAX_DEPTH;
   // TODO: Handle failure here!
   [stream read: (uint8_t*)BOM maxLength: 4];
   getEncoding(BOM, &p);

--- a/Tests/base/NSJSONSerialization/depth.m
+++ b/Tests/base/NSJSONSerialization/depth.m
@@ -1,0 +1,370 @@
+/*
+ * depth.m - regression test for NSJSONSerialization recursion depth limit.
+ *
+ * The JSON parser uses recursive descent for arrays and objects. Before
+ * the depth limit was added, pathologically nested input (e.g.
+ * [[[...[null]...]]] at a few thousand levels) could exhaust the C stack
+ * and crash the process. The parser now tracks its current nesting depth
+ * through the ParserState struct and rejects input that would cross a
+ * fixed bound with a parse error.
+ *
+ * This file exercises the depth limit across every entry point that
+ * feeds the recursive descent:
+ *
+ *   - moderately nested documents still parse (20 levels of arrays).
+ *   - documents at exactly the default boundary still parse (512 levels).
+ *   - documents one level past the boundary are rejected (513 levels).
+ *   - documents nested far past the boundary are rejected (2000 levels).
+ *   - the bound applies equally to nested objects (not just arrays).
+ *   - the bound applies to mixed object/array nesting.
+ *   - the bound applies to +JSONObjectWithStream: as well as
+ *     +JSONObjectWithData:.
+ *   - deeply nested input that is *also* syntactically invalid still
+ *     reports an error cleanly (the depth check short-circuits before
+ *     the parser dereferences anything that depends on balanced
+ *     brackets).
+ *
+ * The tests are written in ObjC 1.0 syntax - no container literals, no
+ * boxed expressions, no blocks, no libobjc2 runtime extensions - so
+ * they compile on every Objective-C compiler that GNUstep supports.
+ * Each individual assertion is wrapped in an NSAssert so that it
+ * surfaces through the NSJSONDepthTests harness' NS_HANDLER and is
+ * reported by the PASS macro in main().
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+/* Build a string of the form "[[[ ... [inner] ... ]]]" with `levels`
+ * opening brackets, `inner` in the middle, and `levels` closing
+ * brackets.
+ */
+static NSData *
+buildNestedArrayJSON(unsigned levels, NSString *inner)
+{
+  NSMutableString	*s;
+  unsigned		i;
+
+  s = [NSMutableString stringWithCapacity: (2 * levels) + [inner length]];
+  for (i = 0; i < levels; i++)
+    {
+      [s appendString: @"["];
+    }
+  [s appendString: inner];
+  for (i = 0; i < levels; i++)
+    {
+      [s appendString: @"]"];
+    }
+  return [s dataUsingEncoding: NSUTF8StringEncoding];
+}
+
+/* Build a string of the form "{"k":{"k":...{"k":inner}...}}" with
+ * `levels` opening objects, `inner` as the innermost value, and
+ * `levels` closing braces.
+ */
+static NSData *
+buildNestedObjectJSON(unsigned levels, NSString *inner)
+{
+  NSMutableString	*s;
+  unsigned		i;
+
+  s = [NSMutableString stringWithCapacity: 6 * levels + [inner length]];
+  for (i = 0; i < levels; i++)
+    {
+      [s appendString: @"{\"k\":"];
+    }
+  [s appendString: inner];
+  for (i = 0; i < levels; i++)
+    {
+      [s appendString: @"}"];
+    }
+  return [s dataUsingEncoding: NSUTF8StringEncoding];
+}
+
+/* Build a string that alternates an object and an array at each
+ * nesting level: "{"k":[{"k":[ ... ]}]}", with `levels` of each
+ * container type.
+ */
+static NSData *
+buildNestedMixedJSON(unsigned levels, NSString *inner)
+{
+  NSMutableString	*s;
+  unsigned		i;
+
+  s = [NSMutableString stringWithCapacity: 8 * levels + [inner length]];
+  for (i = 0; i < levels; i++)
+    {
+      [s appendString: @"{\"k\":"];
+      [s appendString: @"["];
+    }
+  [s appendString: inner];
+  for (i = 0; i < levels; i++)
+    {
+      [s appendString: @"]"];
+      [s appendString: @"}"];
+    }
+  return [s dataUsingEncoding: NSUTF8StringEncoding];
+}
+
+@interface NSJSONDepthTests : NSObject
+{
+  unsigned	_successes;
+  unsigned	_failures;
+}
+- (BOOL) performTest: (NSString *)name;
+@end
+
+@implementation NSJSONDepthTests
+
+- (BOOL) performTest: (NSString *)name
+{
+  NSAutoreleasePool	*pool = [NSAutoreleasePool new];
+  BOOL			result;
+
+  NS_DURING
+    {
+      [self performSelector: NSSelectorFromString(name)];
+      _successes++;
+      result = YES;
+    }
+  NS_HANDLER
+    {
+      NSLog(@"Test %@ failed: %@", name, [localException reason]);
+      _failures++;
+      result = NO;
+    }
+  NS_ENDHANDLER
+
+  [pool release];
+  return result;
+}
+
+@end
+
+@interface NSJSONDepthTests (Cases)
+@end
+
+@implementation NSJSONDepthTests (Cases)
+
+/* 20 levels of arrays is well under any reasonable depth bound and
+ * must round-trip cleanly through the parser. */
+- (void) moderatelyNestedArrayParses
+{
+  NSData	*data = buildNestedArrayJSON(20, @"42");
+  NSError	*error = nil;
+  id		result;
+
+  result = [NSJSONSerialization JSONObjectWithData: data
+					   options: 0
+					     error: &error];
+  NSAssert(result != nil, @"20-level array returned nil");
+  NSAssert(error == nil, @"20-level array populated error out-parameter");
+}
+
+/* 20 levels of objects is likewise within bounds. */
+- (void) moderatelyNestedObjectParses
+{
+  NSData	*data = buildNestedObjectJSON(20, @"42");
+  NSError	*error = nil;
+  id		result;
+
+  result = [NSJSONSerialization JSONObjectWithData: data
+					   options: 0
+					     error: &error];
+  NSAssert(result != nil, @"20-level object returned nil");
+  NSAssert(error == nil, @"20-level object populated error out-parameter");
+}
+
+/* A document nested exactly at the default limit must still parse.
+ * With NS_JSON_SERIALIZATION_MAX_DEPTH = 512, the parser starts at
+ * depth 0 and accepts container entry while `depth < maxDepth`. An
+ * input with 512 opening brackets therefore drives `depth` from 0 to
+ * 512 across 512 successful entries and is accepted. Test it both for
+ * arrays and for objects so that the boundary is verified for both
+ * recursive paths.
+ */
+- (void) boundaryArrayParses
+{
+  NSData	*data = buildNestedArrayJSON(512, @"null");
+  NSError	*error = nil;
+  id		result;
+
+  result = [NSJSONSerialization JSONObjectWithData: data
+					   options: 0
+					     error: &error];
+  NSAssert(result != nil, @"512-level array at boundary returned nil");
+  NSAssert(error == nil, @"512-level array populated error out-parameter");
+}
+
+- (void) boundaryObjectParses
+{
+  NSData	*data = buildNestedObjectJSON(512, @"null");
+  NSError	*error = nil;
+  id		result;
+
+  result = [NSJSONSerialization JSONObjectWithData: data
+					   options: 0
+					     error: &error];
+  NSAssert(result != nil, @"512-level object at boundary returned nil");
+  NSAssert(error == nil, @"512-level object populated error out-parameter");
+}
+
+/* One level past the default boundary must be rejected with an error.
+ * An input with 513 opening brackets drives `depth` from 0 to 512 on
+ * the first 512 entries and then triggers the guard at the 513th
+ * entry attempt.
+ */
+- (void) justOverBoundaryArrayRejected
+{
+  NSData	*data = buildNestedArrayJSON(513, @"null");
+  NSError	*error = nil;
+  id		result;
+
+  result = [NSJSONSerialization JSONObjectWithData: data
+					   options: 0
+					     error: &error];
+  NSAssert(result == nil, @"513-level array was accepted, not rejected");
+  NSAssert(error != nil,
+    @"513-level array did not populate error out-parameter");
+}
+
+- (void) justOverBoundaryObjectRejected
+{
+  NSData	*data = buildNestedObjectJSON(513, @"null");
+  NSError	*error = nil;
+  id		result;
+
+  result = [NSJSONSerialization JSONObjectWithData: data
+					   options: 0
+					     error: &error];
+  NSAssert(result == nil, @"513-level object was accepted, not rejected");
+  NSAssert(error != nil,
+    @"513-level object did not populate error out-parameter");
+}
+
+/* Far past the boundary: 2000 levels. Regardless of how liberal a
+ * future depth limit might become, this input should still be
+ * rejected.
+ */
+- (void) pathologicallyNestedArrayRejected
+{
+  NSData	*data = buildNestedArrayJSON(2000, @"null");
+  NSError	*error = nil;
+  id		result;
+
+  result = [NSJSONSerialization JSONObjectWithData: data
+					   options: 0
+					     error: &error];
+  NSAssert(result == nil, @"2000-level array was accepted, not rejected");
+  NSAssert(error != nil,
+    @"2000-level array did not populate error out-parameter");
+}
+
+/* The same bound must apply to mixed object/array nesting: 1000 of
+ * each (giving 2000 container levels total) must be rejected.
+ */
+- (void) mixedDeepNestingRejected
+{
+  NSData	*data = buildNestedMixedJSON(1000, @"0");
+  NSError	*error = nil;
+  id		result;
+
+  result = [NSJSONSerialization JSONObjectWithData: data
+					   options: 0
+					     error: &error];
+  NSAssert(result == nil, @"mixed 1000-level nesting was accepted");
+  NSAssert(error != nil,
+    @"mixed 1000-level nesting did not populate error out-parameter");
+}
+
+/* The stream entry point must honour the same bound. Wrap the same
+ * deeply-nested payload in an NSInputStream so that the
+ * +JSONObjectWithStream: path is exercised as well as
+ * +JSONObjectWithData:.
+ */
+- (void) streamInterfaceRespectsDepthLimit
+{
+  NSData		*data = buildNestedArrayJSON(2000, @"null");
+  NSInputStream		*stream;
+  NSError		*error = nil;
+  id			result;
+
+  stream = [NSInputStream inputStreamWithData: data];
+  [stream open];
+  result = [NSJSONSerialization JSONObjectWithStream: stream
+					     options: 0
+					       error: &error];
+  [stream close];
+  NSAssert(result == nil,
+    @"JSONObjectWithStream: accepted 2000-level nesting");
+  NSAssert(error != nil,
+    @"JSONObjectWithStream: did not populate error out-parameter");
+}
+
+/* A document that is both deeply nested AND syntactically invalid
+ * (600 opening brackets with no matching closing brackets) must still
+ * be rejected cleanly via the error out-parameter rather than
+ * crashing or returning garbage. The depth guard and the EOF handling
+ * are both valid rejection points; the test only requires that one of
+ * them fire.
+ */
+- (void) deepAndMalformedRejected
+{
+  NSMutableString	*s;
+  NSData		*data;
+  NSError		*error = nil;
+  id			result;
+  unsigned		i;
+
+  s = [NSMutableString stringWithCapacity: 600];
+  for (i = 0; i < 600; i++)
+    {
+      [s appendString: @"["];
+    }
+  /* Deliberately no closing brackets and no inner value. */
+  data = [s dataUsingEncoding: NSUTF8StringEncoding];
+  result = [NSJSONSerialization JSONObjectWithData: data
+					   options: 0
+					     error: &error];
+  NSAssert(result == nil, @"deeply-nested malformed JSON was accepted");
+  NSAssert(error != nil,
+    @"deeply-nested malformed JSON did not populate error out-parameter");
+}
+
+@end
+
+int
+main(int argc, char *argv[])
+{
+  NSAutoreleasePool	*pool = [NSAutoreleasePool new];
+  NSJSONDepthTests	*tests = [NSJSONDepthTests new];
+
+  START_SET("NSJSONSerialization recursion depth")
+
+  PASS([tests performTest: @"moderatelyNestedArrayParses"],
+    "moderately nested array (20 levels) parses successfully")
+  PASS([tests performTest: @"moderatelyNestedObjectParses"],
+    "moderately nested object (20 levels) parses successfully")
+  PASS([tests performTest: @"boundaryArrayParses"],
+    "array exactly at the boundary (512 levels) still parses")
+  PASS([tests performTest: @"boundaryObjectParses"],
+    "object exactly at the boundary (512 levels) still parses")
+  PASS([tests performTest: @"justOverBoundaryArrayRejected"],
+    "array one level past the boundary (513 levels) is rejected")
+  PASS([tests performTest: @"justOverBoundaryObjectRejected"],
+    "object one level past the boundary (513 levels) is rejected")
+  PASS([tests performTest: @"pathologicallyNestedArrayRejected"],
+    "pathologically nested array (2000 levels) is rejected")
+  PASS([tests performTest: @"mixedDeepNestingRejected"],
+    "deeply nested mixed object/array (1000 levels each) is rejected")
+  PASS([tests performTest: @"streamInterfaceRespectsDepthLimit"],
+    "JSONObjectWithStream: honours the recursion depth limit")
+  PASS([tests performTest: @"deepAndMalformedRejected"],
+    "deeply nested malformed JSON reports error without crashing")
+
+  END_SET("NSJSONSerialization recursion depth")
+
+  [tests release];
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
## Problem

The `NSJSONSerialization` parser uses recursive descent for arrays and objects. Before this change, pathologically nested input — e.g. `[[[...[null]...]]]` at a few thousand levels — could exhaust the C stack and crash the process. There was no depth bound at all, so any caller that accepted untrusted JSON was exposed to a stack-based denial of service.

## Fix

`Source/NSJSONSerialization.m`:

- Add `depth` and `maxDepth` fields to `ParserState`, with doc comments describing the invariant that `depth` mirrors the live container stack (zero at rest, incremented exactly once on successful entry to `parseArray`/`parseObject` after the guard check, decremented exactly once on every exit path including error returns).
- Add a `NS_JSON_SERIALIZATION_MAX_DEPTH` macro (set to 512) with a doc comment explaining the choice: RFC 8259 recommends supporting at least 100 levels, most parsers cap in the 100–1000 range, and 512 leaves comfortable head-room below the smallest thread stack GNUstep runs on.
- `parseArray` and `parseObject` now refuse to descend further once the bound is reached, returning a parse error instead. Both functions maintain the depth invariant on every exit path, including the pre-existing error paths.
- `+JSONObjectWithData:` and `+JSONObjectWithStream:` initialise `p.depth = 0; p.maxDepth = NS_JSON_SERIALIZATION_MAX_DEPTH;` before handing the state to the recursive descent.

## Regression test

`Tests/base/NSJSONSerialization/depth.m` — 10 assertions wrapped in an `NSJSONDepthTests` harness class whose `-performTest:` method catches `NSAssert`-raised exceptions and surfaces them through `PASS()` in `main()`. Matches the style of `Tests/base/NSJSONSerialization/tests00.m`. Written in ObjC 1.0 syntax — no container literals, no boxed expressions, no blocks, no libobjc2 runtime extensions — so it builds with every Objective-C compiler GNUstep supports.

Cases:
- `moderatelyNestedArrayParses` / `moderatelyNestedObjectParses` — 20-level arrays/objects parse cleanly (baseline sanity).
- `boundaryArrayParses` / `boundaryObjectParses` — **512 levels at the exact boundary still parse.** These nail down that the bound is `>=` rather than `>`; any future refactor that changes the comparison will break them immediately.
- `justOverBoundaryArrayRejected` / `justOverBoundaryObjectRejected` — **513 levels are rejected** for both arrays and objects.
- `pathologicallyNestedArrayRejected` — 2000 levels rejected.
- `mixedDeepNestingRejected` — 1000 alternating object/array levels rejected.
- `streamInterfaceRespectsDepthLimit` — `+JSONObjectWithStream:` honours the same bound as `+JSONObjectWithData:`.
- `deepAndMalformedRejected` — 600 `[` with no closing brackets reports an error cleanly (depth guard *or* EOF handling — either is an acceptable rejection point).

## Validation

Built and run against a clang 18.1.3 + libobjc2 stack on Ubuntu 24.04:

| Build | Pass | Fail |
|---|---|---|
| With depth guard (this patch) | **10** | 0 |
| Depth guard replaced with `if (0)` | 5 | 5 |

The 5 failing cases under the negative control are exactly the assertions that depend on the guard (513-array, 513-object, 2000-array, mixed-1000, stream-2000). The 5 passing cases are the ones that shouldn't depend on the guard (20-level pair, 512-boundary pair, deep-malformed caught by EOF handling). No flakes in either direction — each assertion cleanly discriminates the fixed and unfixed build.

## ChangeLog

Entry added in `ChangeLog` matching the repository's GNU-style format.