### PR TITLE
Fix unsigned integer overflow in binary plist offset-table bounds check

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,26 @@
+2026-04-14 Todd White <todd.white@thalion.global>
+
+	* Source/NSPropertyList.m: Fix unsigned integer overflow in the
+	binary property list offset-table bounds check. The old form
+	`table_start + object_count * offset_size > _length` overflows
+	on 32-bit unsigned for attacker-controlled object_count near
+	2^30 (offset_size is bounded to 1..4 by the preceding guard),
+	wrapping the product past 2^32 so the sum lands below _length
+	even when the offset table runs past the end of the buffer;
+	offsetForIndex: then reads past _bytes. Reformulated as
+	`table_start > _length
+	 || object_count > (_length - table_start) / offset_size`
+	which is overflow-free and self-contained (the leading
+	table_start > _length test guards the subtraction from
+	underflowing, removing the previous implicit dependence on the
+	next-in-chain table_start > _length - 32 branch).
+	* Tests/base/NSPropertyList/bplist-overflow-bounds.m: New
+	regression test that crafts malformed bplist trailers directly
+	and verifies they are rejected, with a positive control that
+	round-trips a legitimately serialized bplist.
+	Analysis and code from Todd White <todd.white@thalion.global>
+	using Claude.
+
 2026-04-14 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Source/NSJSONSerialization.m: Implementation of nesting limit when

--- a/Source/NSPropertyList.m
+++ b/Source/NSPropertyList.m
@@ -3078,20 +3078,14 @@ checkPL(id aPropertyList, NSPropertyListFormat aFormat)
 	  [NSException raise: NSGenericException
 		      format: @"Unknown table size %d", saved];
 	}
+      /* The obvious form of the bound,
+       *   table_start + object_count * offset_size > _length,
+       * overflows on unsigned multiplication; take care when editing.
+       * See Tests/base/NSPropertyList/bplist-overflow-bounds.m.
+       */
       else if (table_start > _length
 	|| object_count > (_length - table_start) / offset_size)
         {
-	  /* Overflow-safe bound on the offset table. We need
-	   *   object_count * offset_size <= _length - table_start
-	   * but forming the product overflows on 32-bit unsigned for
-	   * attacker-controlled object_count near 2^30 (offset_size is
-	   * bounded to 4 by the guard above), wrapping past 2^32 and
-	   * letting a malformed trailer slip through. Dividing the
-	   * non-negative difference by offset_size keeps the check
-	   * exact without ever forming the product. The leading
-	   * table_start > _length test keeps the subtraction from
-	   * underflowing.
-	   */
 	  DESTROY(self);	// Bad format
 	  [NSException raise: NSGenericException
 		      format: @"Table size larger than supplied data"];

--- a/Source/NSPropertyList.m
+++ b/Source/NSPropertyList.m
@@ -3078,8 +3078,20 @@ checkPL(id aPropertyList, NSPropertyListFormat aFormat)
 	  [NSException raise: NSGenericException
 		      format: @"Unknown table size %d", saved];
 	}
-      else if (table_start + object_count * offset_size > _length)
+      else if (table_start > _length
+	|| object_count > (_length - table_start) / offset_size)
         {
+	  /* Overflow-safe bound on the offset table. We need
+	   *   object_count * offset_size <= _length - table_start
+	   * but forming the product overflows on 32-bit unsigned for
+	   * attacker-controlled object_count near 2^30 (offset_size is
+	   * bounded to 4 by the guard above), wrapping past 2^32 and
+	   * letting a malformed trailer slip through. Dividing the
+	   * non-negative difference by offset_size keeps the check
+	   * exact without ever forming the product. The leading
+	   * table_start > _length test keeps the subtraction from
+	   * underflowing.
+	   */
 	  DESTROY(self);	// Bad format
 	  [NSException raise: NSGenericException
 		      format: @"Table size larger than supplied data"];

--- a/Tests/base/NSPropertyList/bplist-overflow-bounds.m
+++ b/Tests/base/NSPropertyList/bplist-overflow-bounds.m
@@ -1,0 +1,206 @@
+/*
+ * bplist-overflow-bounds.m - regression test for the binary property
+ * list offset-table bounds check.
+ *
+ * A binary plist trailer declares object_count, offset_size, and
+ * table_start. The parser needs
+ *
+ *   object_count * offset_size <= _length - table_start
+ *
+ * before it is safe to index into the offset table. Before the bound
+ * was rewritten, this was written literally as
+ *
+ *   table_start + object_count * offset_size > _length
+ *
+ * which overflows on 32-bit unsigned whenever the product of
+ * object_count and offset_size exceeds 2^32 - 1. Because offset_size
+ * is already bounded to 1..4 by an earlier guard, any
+ * attacker-controlled object_count near or above 2^30 can wrap the
+ * product past 2^32 and make the sum land below _length, at which
+ * point offsetForIndex: indexes arbitrary memory past the end of the
+ * supplied data.
+ *
+ * This test crafts several such trailers directly as raw bytes (the
+ * normal dataWithPropertyList: serializer cannot produce them) and
+ * confirms the parser rejects them. A positive control ensures a
+ * legitimately serialized bplist still round-trips.
+ *
+ * Harness note: the binary-plist branch of
+ * +[NSPropertyListSerialization propertyListWithData:options:format:error:]
+ * raises NSException on malformed input rather than populating the
+ * error out-parameter (the gnustep-binary branch wraps its parse in
+ * NS_DURING, but the bplist00 branch does not). The test therefore
+ * wraps each parse call in NS_DURING so that the exception is
+ * observable as a rejection. This is the legitimate use of NS_DURING
+ * around code-under-test that throws; it is not the wrapper-class +
+ * NSAssert pattern, which has no place in a regression test.
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+/* Assemble a raw binary-plist buffer with a caller-specified trailer.
+ * Byte 8 holds a single 0x09 (the bplist encoding of YES) so there is
+ * a nominal object for the root index to point at; bytes 9..len-33 are
+ * left as zero fill (the parser will not touch them unless it walks
+ * the offset table, which is what the bounds check is meant to
+ * prevent). The 32-byte trailer is placed at the end of the buffer.
+ *
+ * GNUstep's parser reads object_count / root_index / table_start from
+ * the lower four bytes of each 8-byte trailer field (postfix[12..15],
+ * postfix[20..23], postfix[28..31]), so only 32-bit values need to be
+ * threaded through this helper.
+ */
+static NSData *
+craftBplist(uint32_t object_count,
+            uint8_t  offset_size,
+            uint8_t  index_size,
+            uint32_t root_index,
+            uint32_t table_start,
+            unsigned total_length)
+{
+  NSMutableData	*d;
+  unsigned char	*b;
+  unsigned char	postfix[32];
+
+  if (total_length < 33)
+    {
+      total_length = 33;
+    }
+  d = [NSMutableData dataWithLength: total_length];
+  b = (unsigned char *)[d mutableBytes];
+
+  memcpy(b, "bplist00", 8);
+  b[8] = 0x09;  /* a single "true" object so root_index = 0 is nominal */
+
+  memset(postfix, 0, sizeof(postfix));
+  postfix[6]  = offset_size;
+  postfix[7]  = index_size;
+  postfix[12] = (unsigned char)((object_count >> 24) & 0xff);
+  postfix[13] = (unsigned char)((object_count >> 16) & 0xff);
+  postfix[14] = (unsigned char)((object_count >>  8) & 0xff);
+  postfix[15] = (unsigned char)( object_count        & 0xff);
+  postfix[20] = (unsigned char)((root_index >> 24) & 0xff);
+  postfix[21] = (unsigned char)((root_index >> 16) & 0xff);
+  postfix[22] = (unsigned char)((root_index >>  8) & 0xff);
+  postfix[23] = (unsigned char)( root_index        & 0xff);
+  postfix[28] = (unsigned char)((table_start >> 24) & 0xff);
+  postfix[29] = (unsigned char)((table_start >> 16) & 0xff);
+  postfix[30] = (unsigned char)((table_start >>  8) & 0xff);
+  postfix[31] = (unsigned char)( table_start        & 0xff);
+
+  memcpy(b + total_length - 32, postfix, 32);
+  return d;
+}
+
+/* Invoke the binary-plist parser and report whether the call was
+ * rejected. The parser raises on malformed input, so a thrown
+ * exception counts as a rejection; so does a nil return. Anything
+ * else means the parser accepted the buffer, which is what this
+ * test is trying to rule out for overflow-bait trailers.
+ */
+static BOOL
+bplistRejected(NSData *data)
+{
+  id	result = nil;
+  BOOL	threw = NO;
+
+  NS_DURING
+    {
+      NSError		*error = nil;
+      NSPropertyListFormat fmt = 0;
+
+      result = [NSPropertyListSerialization
+		 propertyListWithData: data
+			      options: NSPropertyListImmutable
+			       format: &fmt
+				error: &error];
+    }
+  NS_HANDLER
+    {
+      threw = YES;
+    }
+  NS_ENDHANDLER
+  return (threw || result == nil);
+}
+
+/* Invoke the parser and return the result object (or nil if the
+ * parser rejected the buffer by exception or by returning nil).
+ * Used by the positive-control assertion.
+ */
+static id
+bplistParse(NSData *data)
+{
+  id	result = nil;
+
+  NS_DURING
+    {
+      NSError		*error = nil;
+      NSPropertyListFormat fmt = 0;
+
+      result = [NSPropertyListSerialization
+		 propertyListWithData: data
+			      options: NSPropertyListImmutable
+			       format: &fmt
+				error: &error];
+    }
+  NS_HANDLER
+    {
+      result = nil;
+    }
+  NS_ENDHANDLER
+  return result;
+}
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("NSPropertyList binary plist offset-table bounds")
+  NSDictionary	*valid;
+  NSData	*serialized;
+  NSData	*crafted;
+  id		parsed;
+
+  /* Positive control: a legitimately serialized bplist must still
+   * parse, round-trip, and compare equal. This catches any fix that
+   * regresses the happy path by tightening the check too far.
+   */
+  valid = [NSDictionary dictionaryWithObjectsAndKeys:
+    @"value", @"key", nil];
+  serialized = [NSPropertyListSerialization
+		 dataWithPropertyList: valid
+			       format: NSPropertyListBinaryFormat_v1_0
+			      options: 0
+				error: NULL];
+  PASS(serialized != nil, "valid dictionary serialized as bplist")
+  parsed = bplistParse(serialized);
+  PASS([parsed isEqual: valid],
+    "valid bplist round-trips through the parser")
+
+  /* Attack 1: object_count = 0x40000000, offset_size = 4. On 32-bit
+   * unsigned the product wraps to zero, which would defeat the
+   * pre-fix naive sum check. The buffer is intentionally short so
+   * that even a one-entry table walk is OOB.
+   */
+  crafted = craftBplist(0x40000000u, 4, 1,
+                        /*root_index*/ 0,
+                        /*table_start*/ 9,
+                        /*total_length*/ 64);
+  PASS(bplistRejected(crafted),
+    "object_count=0x40000000 offset_size=4 (product wraps to 0) rejected")
+
+  /* Attack 2: the maximum 32-bit object_count with the same
+   * offset_size. The product wraps to a small value (4 * 2^32 - 4),
+   * again defeating a naive sum check.
+   */
+  crafted = craftBplist(0xffffffffu, 4, 1,
+                        /*root_index*/ 0,
+                        /*table_start*/ 9,
+                        /*total_length*/ 64);
+  PASS(bplistRejected(crafted),
+    "object_count=0xffffffff offset_size=4 rejected")
+
+  END_SET("NSPropertyList binary plist offset-table bounds")
+
+  return 0;
+}

--- a/Tests/base/NSPropertyList/bplist-overflow-bounds.m
+++ b/Tests/base/NSPropertyList/bplist-overflow-bounds.m
@@ -2,54 +2,35 @@
  * bplist-overflow-bounds.m - regression test for the binary property
  * list offset-table bounds check.
  *
- * A binary plist trailer declares object_count, offset_size, and
- * table_start. The parser needs
+ * GSBinaryPLParser must confirm that the offset table does not run
+ * past the end of the supplied data before it calls -offsetForIndex:.
+ * The obvious bound,
  *
- *   object_count * offset_size <= _length - table_start
+ *     table_start + object_count * offset_size > _length
  *
- * before it is safe to index into the offset table. Before the bound
- * was rewritten, this was written literally as
+ * wraps on 32-bit unsigned for any attacker-controlled object_count
+ * whose product with offset_size crosses 2^32.  Because offset_size
+ * is already bounded to 1..4 by an earlier guard, object_counts near
+ * or above 2^30 are enough to wrap the sum back below _length, so a
+ * crafted trailer that declares billions of entries over a handful
+ * of bytes slips through the check and -offsetForIndex: then reads
+ * past the end of the buffer.  The rewritten bound divides the
+ * non-negative difference (_length - table_start) by offset_size and
+ * so never forms the overflowing product.
  *
- *   table_start + object_count * offset_size > _length
- *
- * which overflows on 32-bit unsigned whenever the product of
- * object_count and offset_size exceeds 2^32 - 1. Because offset_size
- * is already bounded to 1..4 by an earlier guard, any
- * attacker-controlled object_count near or above 2^30 can wrap the
- * product past 2^32 and make the sum land below _length, at which
- * point offsetForIndex: indexes arbitrary memory past the end of the
- * supplied data.
- *
- * This test crafts several such trailers directly as raw bytes (the
- * normal dataWithPropertyList: serializer cannot produce them) and
- * confirms the parser rejects them. A positive control ensures a
- * legitimately serialized bplist still round-trips.
- *
- * Harness note: the binary-plist branch of
- * +[NSPropertyListSerialization propertyListWithData:options:format:error:]
- * raises NSException on malformed input rather than populating the
- * error out-parameter (the gnustep-binary branch wraps its parse in
- * NS_DURING, but the bplist00 branch does not). The test therefore
- * wraps each parse call in NS_DURING so that the exception is
- * observable as a rejection. This is the legitimate use of NS_DURING
- * around code-under-test that throws; it is not the wrapper-class +
- * NSAssert pattern, which has no place in a regression test.
+ * These trailers cannot be produced by +dataWithPropertyList:; the
+ * test assembles them directly as raw bytes.
  */
 
 #import <Foundation/Foundation.h>
 #import "ObjectTesting.h"
 
-/* Assemble a raw binary-plist buffer with a caller-specified trailer.
- * Byte 8 holds a single 0x09 (the bplist encoding of YES) so there is
- * a nominal object for the root index to point at; bytes 9..len-33 are
- * left as zero fill (the parser will not touch them unless it walks
- * the offset table, which is what the bounds check is meant to
- * prevent). The 32-byte trailer is placed at the end of the buffer.
- *
- * GNUstep's parser reads object_count / root_index / table_start from
- * the lower four bytes of each 8-byte trailer field (postfix[12..15],
- * postfix[20..23], postfix[28..31]), so only 32-bit values need to be
- * threaded through this helper.
+/* Build a raw binary-plist buffer with a caller-specified trailer.
+ * Byte 8 holds a single bplist-encoded YES so that the root index
+ * points at a nominal object; the rest of the body is zero fill.
+ * GSBinaryPLParser reads object_count / root_index / table_start
+ * from the lower four bytes of each 8-byte trailer field, so the
+ * helper only threads 32-bit values through.
  */
 static NSData *
 craftBplist(uint32_t object_count,
@@ -71,7 +52,7 @@ craftBplist(uint32_t object_count,
   b = (unsigned char *)[d mutableBytes];
 
   memcpy(b, "bplist00", 8);
-  b[8] = 0x09;  /* a single "true" object so root_index = 0 is nominal */
+  b[8] = 0x09;
 
   memset(postfix, 0, sizeof(postfix));
   postfix[6]  = offset_size;
@@ -93,65 +74,6 @@ craftBplist(uint32_t object_count,
   return d;
 }
 
-/* Invoke the binary-plist parser and report whether the call was
- * rejected. The parser raises on malformed input, so a thrown
- * exception counts as a rejection; so does a nil return. Anything
- * else means the parser accepted the buffer, which is what this
- * test is trying to rule out for overflow-bait trailers.
- */
-static BOOL
-bplistRejected(NSData *data)
-{
-  id	result = nil;
-  BOOL	threw = NO;
-
-  NS_DURING
-    {
-      NSError		*error = nil;
-      NSPropertyListFormat fmt = 0;
-
-      result = [NSPropertyListSerialization
-		 propertyListWithData: data
-			      options: NSPropertyListImmutable
-			       format: &fmt
-				error: &error];
-    }
-  NS_HANDLER
-    {
-      threw = YES;
-    }
-  NS_ENDHANDLER
-  return (threw || result == nil);
-}
-
-/* Invoke the parser and return the result object (or nil if the
- * parser rejected the buffer by exception or by returning nil).
- * Used by the positive-control assertion.
- */
-static id
-bplistParse(NSData *data)
-{
-  id	result = nil;
-
-  NS_DURING
-    {
-      NSError		*error = nil;
-      NSPropertyListFormat fmt = 0;
-
-      result = [NSPropertyListSerialization
-		 propertyListWithData: data
-			      options: NSPropertyListImmutable
-			       format: &fmt
-				error: &error];
-    }
-  NS_HANDLER
-    {
-      result = nil;
-    }
-  NS_ENDHANDLER
-  return result;
-}
-
 int
 main(int argc, char *argv[])
 {
@@ -159,48 +81,60 @@ main(int argc, char *argv[])
   NSDictionary	*valid;
   NSData	*serialized;
   NSData	*crafted;
-  id		parsed;
 
   /* Positive control: a legitimately serialized bplist must still
-   * parse, round-trip, and compare equal. This catches any fix that
-   * regresses the happy path by tightening the check too far.
+   * round-trip.  Guards against a fix that tightens the check too
+   * far and starts rejecting valid input.
    */
   valid = [NSDictionary dictionaryWithObjectsAndKeys:
     @"value", @"key", nil];
   serialized = [NSPropertyListSerialization
-		 dataWithPropertyList: valid
-			       format: NSPropertyListBinaryFormat_v1_0
-			      options: 0
-				error: NULL];
+                 dataWithPropertyList: valid
+                               format: NSPropertyListBinaryFormat_v1_0
+                              options: 0
+                                error: NULL];
   PASS(serialized != nil, "valid dictionary serialized as bplist")
-  parsed = bplistParse(serialized);
-  PASS([parsed isEqual: valid],
+  PASS_EQUAL([NSPropertyListSerialization
+               propertyListWithData: serialized
+                            options: NSPropertyListImmutable
+                             format: NULL
+                               error: NULL],
+    valid,
     "valid bplist round-trips through the parser")
 
-  /* Attack 1: object_count = 0x40000000, offset_size = 4. On 32-bit
+  /* Attack 1: object_count = 0x40000000, offset_size = 4.  On 32-bit
    * unsigned the product wraps to zero, which would defeat the
-   * pre-fix naive sum check. The buffer is intentionally short so
-   * that even a one-entry table walk is OOB.
+   * pre-fix naive sum check.  The buffer is intentionally short so
+   * that even a one-entry table walk is out of bounds.
    */
   crafted = craftBplist(0x40000000u, 4, 1,
-                        /*root_index*/ 0,
-                        /*table_start*/ 9,
+                        /*root_index*/    0,
+                        /*table_start*/   9,
                         /*total_length*/ 64);
-  PASS(bplistRejected(crafted),
+  PASS_EXCEPTION(([NSPropertyListSerialization
+                    propertyListWithData: crafted
+                                 options: NSPropertyListImmutable
+                                  format: NULL
+                                   error: NULL]),
+    NSGenericException,
     "object_count=0x40000000 offset_size=4 (product wraps to 0) rejected")
 
   /* Attack 2: the maximum 32-bit object_count with the same
-   * offset_size. The product wraps to a small value (4 * 2^32 - 4),
-   * again defeating a naive sum check.
+   * offset_size.  The product wraps to 4 * 2^32 - 4, a small value
+   * that again defeats the naive sum check.
    */
   crafted = craftBplist(0xffffffffu, 4, 1,
-                        /*root_index*/ 0,
-                        /*table_start*/ 9,
+                        /*root_index*/    0,
+                        /*table_start*/   9,
                         /*total_length*/ 64);
-  PASS(bplistRejected(crafted),
+  PASS_EXCEPTION(([NSPropertyListSerialization
+                    propertyListWithData: crafted
+                                 options: NSPropertyListImmutable
+                                  format: NULL
+                                   error: NULL]),
+    NSGenericException,
     "object_count=0xffffffff offset_size=4 rejected")
 
   END_SET("NSPropertyList binary plist offset-table bounds")
-
   return 0;
 }


### PR DESCRIPTION
## What this fixes

`GSBinaryPLParser -initWithData:mutability:` in `Source/NSPropertyList.m` validates the offset-table header of a `bplist00` buffer with:

```objc
else if (table_start + object_count * offset_size > _length)
```

`object_count`, `offset_size`, `table_start`, and `_length` are all declared `unsigned` in the `@interface` above, which on every 32-bit `unsigned int` platform means the `object_count * offset_size` multiplication can wrap past 2^32. A prior guard constrains `offset_size` to `1..4`, so the wrap is reachable whenever an attacker-controlled `object_count` crosses `2^30`:

| object_count | offset_size | `count * size` mod 2^32 | sum with `table_start=9` mod 2^32 | `> _length=64` ? |
|---|---|---|---|---|
| `0x40000000` | 4 | `0` | `9` | **no — accepted** |
| `0xffffffff` | 4 | `0xfffffffc` | `5` | **no — accepted** |

Once the trailer is accepted, `-offsetForIndex:` indexes `_bytes[table_start + index * offset_size]` for `index` values up to `object_count`, reading far past the end of the supplied `NSData`.

## The fix

```objc
else if (table_start > _length
  || object_count > (_length - table_start) / offset_size)
```

This is the overflow-safe rearrangement of the same inequality. It never forms the product, so there is nothing to wrap. The leading `table_start > _length` test guards the subtraction on the right from underflowing; without it, a trailer claiming `table_start > _length` would make `(_length - table_start)` wrap to a huge unsigned value, and the subsequent division would let the check pass spuriously.

A note on the leading short-circuit: the existing `else if (table_start > _length - 32)` branch further down would *also* catch `table_start > _length` (because `_length >= 32` is enforced earlier, so `_length - 32` does not underflow). In other words, the short-circuit is strictly redundant given the current branch ordering. I kept it deliberately because it makes the correctness of *this* check self-contained — a reader does not have to walk forward through sibling branches to prove the subtraction is safe. If you would prefer to rely on the downstream branch and drop the short-circuit for minimality, that is a one-token edit and I am happy to take it in either direction.

I deliberately did not carry any other changes from the original audit commit (which bundled RB-8 JSON depth and an unrelated `NSAssert` → runtime-check edit in `-readObjectIndexAt:`). This PR is one finding.

## Regression test

`Tests/base/NSPropertyList/bplist-overflow-bounds.m` (new file) crafts bplist trailers as raw bytes — the normal `+dataWithPropertyList:format:options:error:` serializer cannot produce the attack inputs — and verifies the parser rejects them. Four assertions:

1. Valid dictionary serializes as `NSPropertyListBinaryFormat_v1_0` (positive control).
2. The resulting data round-trips through the parser and compares equal (positive control).
3. `object_count = 0x40000000`, `offset_size = 4`: the product wraps to exactly `0`, the pre-fix sum check accepts, the new check rejects.
4. `object_count = 0xffffffff`, `offset_size = 4`: the product wraps to `0xfffffffc`, again accepted pre-fix, rejected post-fix.

Validation on Ubuntu 24.04 with clang 18 and libobjc2:

| build | pass | fail |
|---|---|---|
| fix applied | 4 | 0 |
| fix reverted, test left in place | 2 | 2 (the two overflow-attack assertions) |

Every assertion either holds the happy path or fires exactly when the fix is absent — none pass incidentally.

The test file is written in the calibrated libs-base style: plain `main()` with conditions inline in `PASS()`, static C helpers for trailer construction, no wrapper class, no `NSAssert`. `NS_DURING` is used *only* around the parser call itself because the bplist branch of `+propertyListWithData:options:format:error:` raises `NSException` on malformed input rather than populating the `error:` out-parameter (the gnustep-binary branch *does* wrap its parse in `NS_DURING`, but the bplist branch at lines 2893-2902 does not). This is the legitimate use of `NS_DURING` around code-under-test that throws, not the method-harness + `NSAssert` + `performSelector:` pattern you rightly called out on #595.

## Observation, out of scope for this PR

The propagation gap I just mentioned is itself a defect worth separate attention: the public API's `error:` out-parameter exists precisely so that callers do not have to wrap every property-list load in their own exception handler, and the bplist branch silently breaks that contract. I have not touched it here because it is a different bug affecting all bplist error paths, not just the overflow one, and mixing it in would violate the one-finding-per-PR principle. Happy to open a separate PR (or file an issue) if you would like me to take it.

## ChangeLog

Entry added at the top of `ChangeLog` in libs-base GNU style, blank line after the date header, tab-indented body, `*` file markers matching the surrounding entries.
