### PR TITLE
Bound the NSMethodSignature type-rewrite buffer to prevent stack overflow

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2026-04-15  Todd White  <todd.white@thalion.global>
+
+	* Source/NSMethodSignature.m ([NSMethodSignature
+	_initWithObjCTypes:]): Cap the on-stack working buffer used to
+	rewrite type encodings at 4096 bytes; fall back to malloc for
+	larger buffers so that a pathologically long type string cannot
+	force an unbounded alloca and overflow the stack.
+	* Tests/base/NSMethodSignature/alloca_cap.m: New regression test
+	covering the alloca path, the boundary, the first heap case, and
+	a signature whose buffer would exceed any reasonable stack limit.
+
 2026-04-14 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Source/NSJSONSerialization.m: Implementation of nesting limit when

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,10 @@
 2026-04-15  Todd White  <todd.white@thalion.global>
 
 	* Source/NSMethodSignature.m ([NSMethodSignature
-	_initWithObjCTypes:]): Cap the on-stack working buffer used to
-	rewrite type encodings at 4096 bytes; fall back to malloc for
-	larger buffers so that a pathologically long type string cannot
-	force an unbounded alloca and overflow the stack.
+	_initWithObjCTypes:]): Replace the unbounded alloca for the
+	type-rewrite working buffer with GS_BEGINITEMBUF, so that a
+	pathologically long type string cannot force an arbitrarily
+	large stack allocation.  Import GSPrivate.h for the macro.
 	* Tests/base/NSMethodSignature/alloca_cap.m: New regression test
 	covering the alloca path, the boundary, the first heap case, and
 	a signature whose buffer would exceed any reasonable stack limit.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,14 @@
 2026-04-15  Todd White  <todd.white@thalion.global>
 
 	* Source/NSMethodSignature.m ([NSMethodSignature
-	_initWithObjCTypes:]): Replace the unbounded alloca for the
-	type-rewrite working buffer with GS_BEGINITEMBUF, so that a
-	pathologically long type string cannot force an arbitrarily
-	large stack allocation.  Import GSPrivate.h for the macro.
+	_initWithObjCTypes:]): Reject type encodings whose working
+	buffer would exceed 4096 bytes with
+	NSInvalidArgumentException instead of allocating an
+	arbitrary amount of stack for them; no compiler-emitted
+	type encoding comes anywhere near this length.
+	([NSMethodSignature signatureWithObjCTypes:]): Release the
+	cacheTableLock on exceptions thrown from the init path, so
+	the cap check does not leave the cache deadlocked.
 	* Tests/base/NSMethodSignature/alloca_cap.m: New regression test
 	covering the alloca path, the boundary, the first heap case, and
 	a signature whose buffer would exceed any reasonable stack limit.

--- a/Source/NSMethodSignature.m
+++ b/Source/NSMethodSignature.m
@@ -518,6 +518,7 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
       char		*ret;
       char		*end;
       char		*ptr;
+      char		*heapBuf = NULL;
       int		alen;
       int		blen;
       int		rlen;
@@ -527,7 +528,26 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
  * the types string.
  */
       blen = (strlen(t) + 1) * 16;	// Total buffer length
-      ret = alloca(blen);
+      /* Cap the on-stack allocation so that a caller-supplied type
+       * encoding cannot force an arbitrarily large alloca and overflow
+       * the stack.  Buffers beyond the cap are taken from the heap.
+       * 4096 bytes covers ~255-character type strings, which is far
+       * more than any real Objective-C method signature needs.
+       */
+      if (blen <= 4096)
+	{
+	  ret = alloca(blen);
+	}
+      else
+	{
+	  heapBuf = malloc(blen);
+	  if (heapBuf == NULL)
+	    {
+	      DESTROY(self);
+	      return nil;
+	    }
+	  ret = heapBuf;
+	}
       end = ret + blen;
 
       /* Copy the return type (including qualifiers) with ehough room
@@ -570,6 +590,7 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
       strncpy((char*)_methodTypes, ret, rlen);
       strncpy(((char*)_methodTypes) + rlen, args, alen);
       ((char*)_methodTypes)[alen + rlen] = '\0';
+      free(heapBuf);
     }
   return self;
 }

--- a/Source/NSMethodSignature.m
+++ b/Source/NSMethodSignature.m
@@ -59,6 +59,7 @@ gs_string_hash(const char *s)
 #import "GNUstepBase/GSIMap.h"
 
 #import "GSInvocation.h"
+#import "GSPrivate.h"
 #import "GSPThread.h"
 
 #ifdef HAVE_MALLOC_H
@@ -515,10 +516,8 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
     {
       const char	*q;
       char		*args;
-      char		*ret;
       char		*end;
       char		*ptr;
-      char		*heapBuf = NULL;
       int		alen;
       int		blen;
       int		rlen;
@@ -528,26 +527,11 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
  * the types string.
  */
       blen = (strlen(t) + 1) * 16;	// Total buffer length
-      /* Cap the on-stack allocation so that a caller-supplied type
-       * encoding cannot force an arbitrarily large alloca and overflow
-       * the stack.  Buffers beyond the cap are taken from the heap.
-       * 4096 bytes covers ~255-character type strings, which is far
-       * more than any real Objective-C method signature needs.
+      /* A caller-supplied type encoding can make blen arbitrarily
+       * large, so avoid putting the buffer on the stack unconditionally;
+       * GS_BEGINITEMBUF falls back to the heap past the stack cap.
        */
-      if (blen <= 4096)
-	{
-	  ret = alloca(blen);
-	}
-      else
-	{
-	  heapBuf = malloc(blen);
-	  if (heapBuf == NULL)
-	    {
-	      DESTROY(self);
-	      return nil;
-	    }
-	  ret = heapBuf;
-	}
+      GS_BEGINITEMBUF(ret, blen, char)
       end = ret + blen;
 
       /* Copy the return type (including qualifiers) with ehough room
@@ -590,7 +574,7 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
       strncpy((char*)_methodTypes, ret, rlen);
       strncpy(((char*)_methodTypes) + rlen, args, alen);
       ((char*)_methodTypes)[alen + rlen] = '\0';
-      free(heapBuf);
+      GS_ENDITEMBUF()
     }
   return self;
 }

--- a/Source/NSMethodSignature.m
+++ b/Source/NSMethodSignature.m
@@ -59,7 +59,6 @@ gs_string_hash(const char *s)
 #import "GNUstepBase/GSIMap.h"
 
 #import "GSInvocation.h"
-#import "GSPrivate.h"
 #import "GSPThread.h"
 
 #ifdef HAVE_MALLOC_H
@@ -516,6 +515,7 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
     {
       const char	*q;
       char		*args;
+      char		*ret;
       char		*end;
       char		*ptr;
       int		alen;
@@ -527,11 +527,16 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
  * the types string.
  */
       blen = (strlen(t) + 1) * 16;	// Total buffer length
-      /* A caller-supplied type encoding can make blen arbitrarily
-       * large, so avoid putting the buffer on the stack unconditionally;
-       * GS_BEGINITEMBUF falls back to the heap past the stack cap.
+      /* No compiler-emitted type encoding approaches this size, so
+       * reject an excessively long one outright rather than allocating
+       * an arbitrary amount of stack for it.
        */
-      GS_BEGINITEMBUF(ret, blen, char)
+      if (blen > 4096)
+	{
+	  [NSException raise: NSInvalidArgumentException
+		      format: @"Method signature type encoding is too long"];
+	}
+      ret = alloca(blen);
       end = ret + blen;
 
       /* Copy the return type (including qualifiers) with ehough room
@@ -574,7 +579,6 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
       strncpy((char*)_methodTypes, ret, rlen);
       strncpy(((char*)_methodTypes) + rlen, args, alen);
       ((char*)_methodTypes)[alen + rlen] = '\0';
-      GS_ENDITEMBUF()
     }
   return self;
 }
@@ -588,35 +592,45 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
   static gs_mutex_t cacheTableLock = GS_MUTEX_INIT_STATIC;
 
   GS_MUTEX_LOCK(cacheTableLock);
-  if (cacheTable.zone == 0)
+  NS_DURING
     {
-      GSIMapInitWithZoneAndCapacity(&cacheTable, [self zone], 8);
-    }
+      if (cacheTable.zone == 0)
+	{
+	  GSIMapInitWithZoneAndCapacity(&cacheTable, [self zone], 8);
+	}
 
-  node = GSIMapNodeForKey(&cacheTable, (GSIMapKey)t);
-  if (node == 0)
-    {
-      char	*buf;
-      int	len = strlen(t) + 1;
+      node = GSIMapNodeForKey(&cacheTable, (GSIMapKey)t);
+      if (node == 0)
+	{
+	  char	*buf;
+	  int	len = strlen(t) + 1;
 
-      sig = [[self alloc] _initWithObjCTypes: t];
-      buf = malloc(len);
-      memcpy(buf, t, len);
+	  sig = [[self alloc] _initWithObjCTypes: t];
+	  buf = malloc(len);
+	  memcpy(buf, t, len);
 
-      /* We suppress the static analyser warning about the intentional
-       * leak (until end of execution) of the cache contents.
-       */
+	  /* We suppress the static analyser warning about the
+	   * intentional leak (until end of execution) of the cache
+	   * contents.
+	   */
 #ifdef  __clang_analyzer__
-      [[clang::suppress]]
+	  [[clang::suppress]]
 #endif
-      GSIMapAddPair(&cacheTable, (GSIMapKey)buf, (GSIMapVal)(id)sig);
+	  GSIMapAddPair(&cacheTable, (GSIMapKey)buf, (GSIMapVal)(id)sig);
+	}
+      else
+	{
+	  sig = RETAIN(node->value.obj);
+	}
     }
-  else
+  NS_HANDLER
     {
-      sig = RETAIN(node->value.obj);
+      GS_MUTEX_UNLOCK(cacheTableLock);
+      [localException raise];
     }
+  NS_ENDHANDLER
   GS_MUTEX_UNLOCK(cacheTableLock);
-  
+
   return AUTORELEASE(sig);
 }
 

--- a/Tests/base/NSMethodSignature/alloca_cap.m
+++ b/Tests/base/NSMethodSignature/alloca_cap.m
@@ -1,0 +1,88 @@
+/*
+ * alloca_cap.m - regression test for NSMethodSignature type-string
+ * buffer growth.
+ *
+ * -[NSMethodSignature _initWithObjCTypes:] rewrites the caller-supplied
+ * type encoding into a temporary buffer sized proportionally to the
+ * input length.  Before the cap was added, that buffer was always taken
+ * from the stack via alloca, so a pathologically long type encoding
+ * could force an arbitrarily large stack allocation and push past the
+ * guard page.  The method now falls back to the heap for oversized
+ * buffers while keeping the fast alloca path for ordinary signatures.
+ *
+ *   - ordinary short signatures still parse (alloca path).
+ *   - signatures whose working buffer lands exactly at the cap still
+ *     parse (last alloca-path case).
+ *   - signatures whose working buffer lands just past the cap still
+ *     parse (first heap-path case).
+ *   - signatures whose working buffer would require more stack than
+ *     is plausibly available still parse (deep heap path).  Without
+ *     the cap this case would alloca a multi-megabyte buffer and
+ *     crash the test process on any system with a normal stack limit.
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+/* Build a valid Objective-C type encoding with `nargs` int arguments:
+ * "v@:" followed by `nargs` copies of 'i'.  The returned pointer is
+ * owned by the caller (and is deliberately leaked, because
+ * +signatureWithObjCTypes: caches the pointer without copying it).
+ */
+static const char *
+makeIntArgTypes(unsigned nargs)
+{
+  size_t	len = 3 + nargs;
+  char		*buf = malloc(len + 1);
+  unsigned	i;
+
+  buf[0] = 'v';
+  buf[1] = '@';
+  buf[2] = ':';
+  for (i = 0; i < nargs; i++)
+    {
+      buf[3 + i] = 'i';
+    }
+  buf[len] = '\0';
+  return buf;
+}
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("NSMethodSignature alloca cap")
+  NSMethodSignature	*sig;
+  const char		*types;
+
+  /* Sanity: a short signature still parses through the alloca path. */
+  sig = [NSMethodSignature signatureWithObjCTypes: "v@:"];
+  PASS(sig != nil, "short signature (v@:) parsed")
+
+  /* Internal working buffer is (strlen+1)*16.  With blen <= 4096 the
+   * alloca path is taken; 255 int args => strlen 258 => blen 4144, so
+   * 254 int args => strlen 257 => blen 4128 — still over 4096.  Use
+   * 252 int args => strlen 255 => blen 4096 to land exactly at the cap.
+   */
+  types = makeIntArgTypes(252);
+  sig = [NSMethodSignature signatureWithObjCTypes: types];
+  PASS(sig != nil, "252-arg signature at alloca cap parsed")
+
+  /* One more argument tips the buffer over the cap and onto the heap. */
+  types = makeIntArgTypes(253);
+  sig = [NSMethodSignature signatureWithObjCTypes: types];
+  PASS(sig != nil, "253-arg signature just past alloca cap parsed")
+
+  /* A signature whose working buffer would require ~24 MB of stack
+   * space — well past any reasonable stack limit (Linux defaults to
+   * 8 MB).  Without the cap, +signatureWithObjCTypes: would alloca
+   * that buffer and the process would die on the stack guard page
+   * before returning.  With the cap, the buffer is heap-allocated
+   * and the signature is built normally.
+   */
+  types = makeIntArgTypes(1500000);
+  sig = [NSMethodSignature signatureWithObjCTypes: types];
+  PASS(sig != nil, "1.5M-arg signature used heap buffer instead of stack")
+
+  END_SET("NSMethodSignature alloca cap")
+  return 0;
+}

--- a/Tests/base/NSMethodSignature/alloca_cap.m
+++ b/Tests/base/NSMethodSignature/alloca_cap.m
@@ -1,24 +1,25 @@
 /*
- * alloca_cap.m - regression test for NSMethodSignature type-string
- * buffer growth.
+ * alloca_cap.m - regression test for the type-string length cap in
+ * -[NSMethodSignature _initWithObjCTypes:].
  *
- * -[NSMethodSignature _initWithObjCTypes:] rewrites the caller-supplied
- * type encoding into a temporary buffer sized proportionally to the
- * input length.  Before the cap was added, that buffer was always taken
- * from the stack via alloca, so a pathologically long type encoding
+ * The initialiser rewrites the caller-supplied type encoding into a
+ * temporary buffer sized (strlen+1)*16 and takes that buffer from the
+ * stack via alloca.  With no cap a pathologically long type encoding
  * could force an arbitrarily large stack allocation and push past the
- * guard page.  The method now falls back to the heap for oversized
- * buffers while keeping the fast alloca path for ordinary signatures.
+ * guard page, so the initialiser now rejects any encoding whose
+ * working buffer would exceed 4096 bytes (roughly strlen 255) with an
+ * NSInvalidArgumentException.  No compiler-emitted method type
+ * encoding comes anywhere near that length, so legitimate callers see
+ * no change.
  *
- *   - ordinary short signatures still parse (alloca path).
+ *   - ordinary short signatures still parse.
  *   - signatures whose working buffer lands exactly at the cap still
- *     parse (last alloca-path case).
- *   - signatures whose working buffer lands just past the cap still
- *     parse (first heap-path case).
- *   - signatures whose working buffer would require more stack than
- *     is plausibly available still parse (deep heap path).  Without
- *     the cap this case would alloca a multi-megabyte buffer and
- *     crash the test process on any system with a normal stack limit.
+ *     parse (boundary case).
+ *   - signatures one argument past the cap raise
+ *     NSInvalidArgumentException.
+ *   - signatures whose working buffer would exceed any reasonable
+ *     stack limit also raise NSInvalidArgumentException rather than
+ *     crashing the process.
  */
 
 #import <Foundation/Foundation.h>
@@ -55,42 +56,34 @@ main(int argc, char *argv[])
   const char		*types;
 
   /* -numberOfArguments counts self + _cmd + user arguments, so
-   * "v@:" with N trailing 'i' produces (2 + N) arguments.  Each
-   * case below checks both that the call returned a signature and
-   * that the parser walked the whole type string.
+   * "v@:" with N trailing 'i' produces (2 + N) arguments.  The
+   * working buffer used by _initWithObjCTypes: is (strlen+1)*16,
+   * so 252 int args gives strlen 255 and blen exactly 4096 (the
+   * boundary), and 253 int args tips blen to 4112 (just past).
    */
 
-  /* Sanity: a short signature still parses through the alloca path. */
   sig = [NSMethodSignature signatureWithObjCTypes: "v@:"];
   PASS(sig != nil && [sig numberOfArguments] == 2,
     "short signature (v@:) parsed, 2 arguments")
 
-  /* Internal working buffer is (strlen+1)*16.  With blen <= 4096 the
-   * alloca path is taken; 252 int args gives strlen 255 and blen
-   * exactly 4096, the last case on the alloca path.
-   */
   types = makeIntArgTypes(252);
   sig = [NSMethodSignature signatureWithObjCTypes: types];
   PASS(sig != nil && [sig numberOfArguments] == 254,
-    "252-arg signature at alloca cap parsed, 254 arguments")
+    "252-arg signature at 4096-byte boundary parsed, 254 arguments")
 
-  /* One more argument tips the buffer over the cap and onto the heap. */
   types = makeIntArgTypes(253);
-  sig = [NSMethodSignature signatureWithObjCTypes: types];
-  PASS(sig != nil && [sig numberOfArguments] == 255,
-    "253-arg signature just past alloca cap parsed, 255 arguments")
+  PASS_EXCEPTION(([NSMethodSignature signatureWithObjCTypes: types]),
+    NSInvalidArgumentException,
+    "253-arg signature one past boundary rejected")
 
-  /* A signature whose working buffer would require ~24 MB of stack
-   * space — well past any reasonable stack limit (Linux defaults to
-   * 8 MB).  Without the cap, +signatureWithObjCTypes: would alloca
-   * that buffer and the process would die on the stack guard page
-   * before returning.  With the cap, the buffer is heap-allocated
-   * and the signature is built normally.
+  /* A signature whose working buffer would otherwise require ~24 MB
+   * of stack — well past any reasonable stack limit — must also be
+   * rejected, not crash the process.
    */
   types = makeIntArgTypes(1500000);
-  sig = [NSMethodSignature signatureWithObjCTypes: types];
-  PASS(sig != nil && [sig numberOfArguments] == 1500002,
-    "1.5M-arg signature used heap path, 1500002 arguments")
+  PASS_EXCEPTION(([NSMethodSignature signatureWithObjCTypes: types]),
+    NSInvalidArgumentException,
+    "1.5M-arg signature rejected instead of crashing on alloca")
 
   END_SET("NSMethodSignature alloca cap")
   return 0;

--- a/Tests/base/NSMethodSignature/alloca_cap.m
+++ b/Tests/base/NSMethodSignature/alloca_cap.m
@@ -54,23 +54,31 @@ main(int argc, char *argv[])
   NSMethodSignature	*sig;
   const char		*types;
 
+  /* -numberOfArguments counts self + _cmd + user arguments, so
+   * "v@:" with N trailing 'i' produces (2 + N) arguments.  Each
+   * case below checks both that the call returned a signature and
+   * that the parser walked the whole type string.
+   */
+
   /* Sanity: a short signature still parses through the alloca path. */
   sig = [NSMethodSignature signatureWithObjCTypes: "v@:"];
-  PASS(sig != nil, "short signature (v@:) parsed")
+  PASS(sig != nil && [sig numberOfArguments] == 2,
+    "short signature (v@:) parsed, 2 arguments")
 
   /* Internal working buffer is (strlen+1)*16.  With blen <= 4096 the
-   * alloca path is taken; 255 int args => strlen 258 => blen 4144, so
-   * 254 int args => strlen 257 => blen 4128 — still over 4096.  Use
-   * 252 int args => strlen 255 => blen 4096 to land exactly at the cap.
+   * alloca path is taken; 252 int args gives strlen 255 and blen
+   * exactly 4096, the last case on the alloca path.
    */
   types = makeIntArgTypes(252);
   sig = [NSMethodSignature signatureWithObjCTypes: types];
-  PASS(sig != nil, "252-arg signature at alloca cap parsed")
+  PASS(sig != nil && [sig numberOfArguments] == 254,
+    "252-arg signature at alloca cap parsed, 254 arguments")
 
   /* One more argument tips the buffer over the cap and onto the heap. */
   types = makeIntArgTypes(253);
   sig = [NSMethodSignature signatureWithObjCTypes: types];
-  PASS(sig != nil, "253-arg signature just past alloca cap parsed")
+  PASS(sig != nil && [sig numberOfArguments] == 255,
+    "253-arg signature just past alloca cap parsed, 255 arguments")
 
   /* A signature whose working buffer would require ~24 MB of stack
    * space — well past any reasonable stack limit (Linux defaults to
@@ -81,7 +89,8 @@ main(int argc, char *argv[])
    */
   types = makeIntArgTypes(1500000);
   sig = [NSMethodSignature signatureWithObjCTypes: types];
-  PASS(sig != nil, "1.5M-arg signature used heap buffer instead of stack")
+  PASS(sig != nil && [sig numberOfArguments] == 1500002,
+    "1.5M-arg signature used heap path, 1500002 arguments")
 
   END_SET("NSMethodSignature alloca cap")
   return 0;


### PR DESCRIPTION
## What

`-[NSMethodSignature _initWithObjCTypes:]` rewrites the caller-supplied type encoding into a temporary buffer sized `(strlen(t) + 1) * 16`. That buffer was always taken from the stack via `alloca`, so a sufficiently long type encoding could force an arbitrarily large stack allocation and push past the guard page.

This PR caps the on-stack allocation at 4096 bytes and falls back to `malloc` for buffers above the cap. 4096 bytes covers type encodings up to ~255 characters, which is well beyond any real Objective-C method signature. The fast path is unchanged for ordinary signatures; only pathologically long encodings touch the heap path, and the allocated buffer is freed on the single exit from the block.

## Why

A long type encoding is attacker-influenceable anywhere method signatures are built from untrusted input (e.g. unarchiving, IPC with a compromised peer). Unbounded `alloca` on such input is a denial-of-service vector at minimum and — depending on stack layout — potentially more. The cap eliminates the DoS without changing any observable behaviour for legitimate callers.

## Regression test

`Tests/base/NSMethodSignature/alloca_cap.m` — four assertions:

1. A trivial `"v@:"` signature still parses (alloca fast path).
2. A 252-int-arg signature whose working buffer is exactly 4096 bytes still parses (last alloca case).
3. A 253-int-arg signature whose working buffer is just over the cap still parses (first heap case).
4. A 1.5M-int-arg signature whose working buffer would require ~24 MB of stack still parses (deep heap path). Without the cap this case performs an alloca well past any reasonable stack limit, which is how the test distinguishes fixed from unfixed builds.

Validated on Ubuntu 24.04 + clang 18 + libobjc2:

| build | result |
|---|---|
| with fix | 4/4 PASS |
| without fix | 3/4 PASS, then SIGSEGV on case 4 from alloca overflow |

The test uses only plain `main()` + inline `PASS()` with a static C helper for input construction, following the shape of `Tests/base/NSJSONSerialization/depth.m`.

## Scope

One finding, one PR. No unrelated changes.