### PR TITLE
Implement NSString localizedStandardCompare

### DIFF
--- a/Headers/Foundation/NSString.h
+++ b/Headers/Foundation/NSString.h
@@ -1019,6 +1019,7 @@ GS_EXPORT_CLASS
 			 range: (NSRange)compareRange 
 			locale: (id)locale;
 - (NSComparisonResult) localizedCompare: (NSString *)string;
+- (NSComparisonResult) localizedStandardCompare: (NSString *)string;
 - (NSComparisonResult) localizedCaseInsensitiveCompare: (NSString *)string;
 - (BOOL) writeToFile: (NSString*)filename
 	  atomically: (BOOL)useAuxiliaryFile;

--- a/MISSING
+++ b/MISSING
@@ -506,7 +506,6 @@ NSString:
 	NSCharacterConversionException
 	NSStringEnumerationOptions
 
-	- localizedStandardCompare:
 	- uppercaseStringWithLocale:
 	- lowercaseStringWithLocale:
 	- capitalizedStringWithLocale:

--- a/Source/NSString.m
+++ b/Source/NSString.m
@@ -6003,6 +6003,18 @@ static NSFileManager *fm = nil;
 }
 
 /**
+ * Compares this instance with string as if sorted by Apple's Finder,
+ * using +[NSLocale currentLocale].
+ */
+- (NSComparisonResult) localizedStandardCompare: (NSString *)string
+{
+  return [self compare: string
+               options: NSCaseInsensitiveSearch|NSNumericSearch|NSWidthInsensitiveSearch|NSForcedOrderingSearch
+                 range: NSMakeRange(0, [self length])
+                locale: [NSLocale currentLocale]];
+}
+
+/**
  * Compares this instance with string, using +[NSLocale currentLocale],
  * ignoring case.
  */

--- a/Tests/base/NSString/locale.m
+++ b/Tests/base/NSString/locale.m
@@ -61,8 +61,9 @@ static void testBasic(void)
 
   compRes = [@"Foo 10.txt" localizedStandardCompare: @"Foo 5.txt"];
   PASS(compRes == NSOrderedDescending, "expected 1 got %d", (int)compRes);
-  
-  compRes = [@"Foo 50.txt" localizedStandardCompare: @"Foo 5.txt"];
+
+  // `localizedStandardCompare` is case insensitive
+  compRes = [@"foo 50.txt" localizedStandardCompare:@"FOO 5.txt"];
   PASS(compRes == NSOrderedAscending, "expected 1 got %d", (int)compRes);
 
   // These two may be considered implementation details

--- a/Tests/base/NSString/locale.m
+++ b/Tests/base/NSString/locale.m
@@ -1,3 +1,4 @@
+#include "Foundation/NSObjCRuntime.h"
 #import "ObjectTesting.h"
 #import <Foundation/NSAutoreleasePool.h>
 #import <Foundation/NSString.h>
@@ -53,7 +54,17 @@ static void testBasic(void)
   compRes = [@"z" localizedCompare: @"A"];
   PASS(compRes == NSOrderedDescending, "expected 1 got %d", (int)compRes);
 
+  // `localizedStandardCompare` orders file names ending in numbers
+  // by numeric value instead of lexicographically.
+  compRes = [@"Foo 10.txt" localizedCompare: @"Foo 5.txt"];
+  PASS(compRes == NSOrderedAscending, "expected 1 got %d", (int)compRes);
+
+  compRes = [@"Foo 10.txt" localizedStandardCompare: @"Foo 5.txt"];
+  PASS(compRes == NSOrderedDescending, "expected 1 got %d", (int)compRes);
   
+  compRes = [@"Foo 50.txt" localizedStandardCompare: @"Foo 5.txt"];
+  PASS(compRes == NSOrderedAscending, "expected 1 got %d", (int)compRes);
+
   // These two may be considered implementation details
   {
     BOOL wasHopeful = testHopeful;


### PR DESCRIPTION
This PR adds a simple string comparison function. See [here](https://developer.apple.com/documentation/foundation/nsstring/localizedstandardcompare(_:)?language=objc).

Let me know if I should make an entry in some sort of release notes.