### PR TITLE
Tighten NSFileHandle retained NSError annotations

### DIFF
--- a/Headers/Foundation/NSArray.h
+++ b/Headers/Foundation/NSArray.h
@@ -56,19 +56,22 @@ enum
 typedef NSUInteger NSBinarySearchingOptions;
 #endif
 
+NS_ASSUME_NONNULL_BEGIN
+
 GS_EXPORT_CLASS
 @interface GS_GENERIC_CLASS(NSArray, __covariant ElementT) : NSObject
   <NSCoding, NSCopying, NSMutableCopying, NSFastEnumeration>
 
 + (instancetype) array;
 + (instancetype) arrayWithArray: (GS_GENERIC_CLASS(NSArray, ElementT) *)array;
-+ (instancetype) arrayWithContentsOfFile: (NSString*)file;
++ (instancetype _Nullable) arrayWithContentsOfFile: (NSString*)file;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
-+ (instancetype) arrayWithContentsOfURL: (NSURL*)aURL;
++ (instancetype _Nullable) arrayWithContentsOfURL: (NSURL*)aURL;
 #endif
 + (instancetype) arrayWithObject: (id)anObject;
 + (instancetype) arrayWithObjects: (id)firstObject, ...;
-+ (instancetype) arrayWithObjects: (const id[])objects count: (NSUInteger)count;
++ (instancetype) arrayWithObjects: (const id _Nonnull [])objects
+                             count: (NSUInteger)count;
 
 - (GS_GENERIC_CLASS(NSArray, ElementT) *) arrayByAddingObject:
   (GS_GENERIC_TYPE(ElementT))anObject;
@@ -80,8 +83,10 @@ GS_EXPORT_CLASS
  * Returns the number of elements contained in the receiver.
  */
 - (NSUInteger) count;
-- (void) getObjects: (__unsafe_unretained GS_GENERIC_TYPE(ElementT)[])aBuffer;
-- (void) getObjects: (__unsafe_unretained GS_GENERIC_TYPE(ElementT)[])aBuffer
+- (void) getObjects:
+  (__unsafe_unretained GS_GENERIC_TYPE(ElementT) _Nonnull [])aBuffer;
+- (void) getObjects:
+  (__unsafe_unretained GS_GENERIC_TYPE(ElementT) _Nonnull [])aBuffer
               range: (NSRange)aRange;
 - (NSUInteger) indexOfObject: (GS_GENERIC_TYPE(ElementT))anObject;
 - (NSUInteger) indexOfObject: (GS_GENERIC_TYPE(ElementT))anObject
@@ -95,9 +100,9 @@ GS_EXPORT_CLASS
 - (instancetype) initWithArray: (GS_GENERIC_CLASS(NSArray, ElementT)*)array
                      copyItems: (BOOL)shouldCopy;
 #endif
-- (instancetype) initWithContentsOfFile: (NSString*)file;
+- (instancetype _Nullable) initWithContentsOfFile: (NSString*)file;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
-- (instancetype) initWithContentsOfURL: (NSURL*)aURL;
+- (instancetype _Nullable) initWithContentsOfURL: (NSURL*)aURL;
 #endif
 - (instancetype) initWithObjects: (GS_GENERIC_TYPE(ElementT)) firstObject, ...;
 
@@ -108,11 +113,12 @@ GS_EXPORT_CLASS
  * and needs to be re-implemented in subclasses in order to have all
  * other initialisers work.
  */
-- (instancetype) initWithObjects: (const GS_GENERIC_TYPE(ElementT)[])objects
+- (instancetype) initWithObjects:
+  (const GS_GENERIC_TYPE(ElementT) _Nonnull [])objects
                            count: (NSUInteger)count;
-- (GS_GENERIC_TYPE(ElementT)) lastObject;
+- (GS_GENERIC_TYPE(ElementT) _Nullable) lastObject;
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
-- (GS_GENERIC_TYPE(ElementT)) firstObject;
+- (GS_GENERIC_TYPE(ElementT) _Nullable) firstObject;
 #endif
 
 /** <override-subclass />
@@ -129,27 +135,27 @@ GS_EXPORT_CLASS
   (NSIndexSet *)indexes;
 #endif
 
-- (GS_GENERIC_TYPE(ElementT)) firstObjectCommonWithArray:
+- (GS_GENERIC_TYPE(ElementT) _Nullable) firstObjectCommonWithArray:
     (GS_GENERIC_CLASS(NSArray, ElementT) *)otherArray;
 - (BOOL) isEqualToArray: (NSArray*)otherArray;
 
 #if OS_API_VERSION(GS_API_OPENSTEP, GS_API_MACOSX)
 - (void) makeObjectsPerform: (SEL)aSelector;
-- (void) makeObjectsPerform: (SEL)aSelector withObject: (id)argument;
+- (void) makeObjectsPerform: (SEL)aSelector withObject: (id _Nullable)argument;
 #endif
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 - (void) makeObjectsPerformSelector: (SEL)aSelector;
-- (void) makeObjectsPerformSelector: (SEL)aSelector withObject: (id)arg;
+- (void) makeObjectsPerformSelector: (SEL)aSelector withObject: (id _Nullable)arg;
 #endif
 
-- (NSData*) sortedArrayHint;
+- (NSData *_Nullable) sortedArrayHint;
 - (GS_GENERIC_CLASS(NSArray, ElementT)*) sortedArrayUsingFunction:
     (NSComparisonResult (*)(id, id, void*))comparator
-			        context: (void*)context;
+			        context: (void *_Nullable)context;
 - (GS_GENERIC_CLASS(NSArray, ElementT)*) sortedArrayUsingFunction:
     (NSComparisonResult (*)(id, id, void*))comparator
-			      context: (void*)context
-				     hint: (NSData*)hint;
+			      context: (void *_Nullable)context
+				     hint: (NSData *_Nullable)hint;
 - (GS_GENERIC_CLASS(NSArray, ElementT)*) sortedArrayUsingSelector:
   (SEL)comparator;
 - (GS_GENERIC_CLASS(NSArray, ElementT)*) subarrayWithRange: (NSRange)aRange;
@@ -162,15 +168,15 @@ GS_EXPORT_CLASS
 - (GS_GENERIC_CLASS(NSEnumerator, ElementT)*) reverseObjectEnumerator;
 
 - (NSString*) description;
-- (NSString*) descriptionWithLocale: (id)locale;
-- (NSString*) descriptionWithLocale: (id)locale
+- (NSString*) descriptionWithLocale: (id _Nullable)locale;
+- (NSString*) descriptionWithLocale: (id _Nullable)locale
 			     indent: (NSUInteger)level;
 
 - (BOOL) writeToFile: (NSString*)path atomically: (BOOL)useAuxiliaryFile;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 - (BOOL) writeToURL: (NSURL*)url atomically: (BOOL)useAuxiliaryFile;
 - (id) valueForKey: (NSString*)key;
-- (void) setValue: (id)value forKey: (NSString*)key;
+- (void) setValue: (id _Nullable)value forKey: (NSString*)key;
 #endif
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
@@ -389,7 +395,7 @@ GS_EXPORT_CLASS
 - (void) sortUsingFunction:
     (NSComparisonResult (*)(GS_GENERIC_TYPE(ElementT),
        GS_GENERIC_TYPE(ElementT),void*))compare
-		           context: (void*)context;
+		           context: (void *_Nullable)context;
 - (void) sortUsingSelector: (SEL)comparator;
 
 
@@ -414,6 +420,8 @@ GS_EXPORT_CLASS
 atIndexedSubscript: (NSUInteger)anIndex;
 #endif
 @end
+
+NS_ASSUME_NONNULL_END
 
 #if	defined(__cplusplus)
 }

--- a/Headers/Foundation/NSData.h
+++ b/Headers/Foundation/NSData.h
@@ -98,37 +98,39 @@ enum {
 DEFINE_BLOCK_TYPE(GSDataDeallocatorBlock, void, void*, NSUInteger);
 #endif
 
+NS_ASSUME_NONNULL_BEGIN
+
 GS_EXPORT_CLASS
 @interface NSData : NSObject <NSCoding, NSCopying, NSMutableCopying>
 
 // Allocating and Initializing a Data Object
 
 + (instancetype) data;
-+ (instancetype) dataWithBytes: (const void*)bytes
++ (instancetype) dataWithBytes: (const void *_Nullable)bytes
                         length: (NSUInteger)length;
-+ (instancetype) dataWithBytesNoCopy: (void*)bytes
++ (instancetype) dataWithBytesNoCopy: (void *_Nullable)bytes
                               length: (NSUInteger)length;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
-+ (instancetype) dataWithBytesNoCopy: (void*)aBuffer
++ (instancetype) dataWithBytesNoCopy: (void *_Nullable)aBuffer
                               length: (NSUInteger)bufferSize
                         freeWhenDone: (BOOL)shouldFree;
 #endif
-+ (instancetype) dataWithContentsOfFile: (NSString *)path
-                                options: (NSDataReadingOptions)readOptionsMask
-                                  error: (NSError **)errorPtr;
-+ (instancetype) dataWithContentsOfFile: (NSString*)path;
-+ (instancetype) dataWithContentsOfMappedFile: (NSString*)path;
++ (instancetype _Nullable) dataWithContentsOfFile: (NSString *)path
+                                          options: (NSDataReadingOptions)readOptionsMask
+                                            error: (NSError **)errorPtr;
++ (instancetype _Nullable) dataWithContentsOfFile: (NSString*)path;
++ (instancetype _Nullable) dataWithContentsOfMappedFile: (NSString*)path;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
-+ (instancetype) dataWithContentsOfURL: (NSURL *)url
-                               options: (NSDataReadingOptions)readOptionsMask
-                                 error: (NSError **)errorPtr;
-+ (instancetype) dataWithContentsOfURL: (NSURL*)url;
++ (instancetype _Nullable) dataWithContentsOfURL: (NSURL *)url
+                                         options: (NSDataReadingOptions)readOptionsMask
+                                           error: (NSError **)errorPtr;
++ (instancetype _Nullable) dataWithContentsOfURL: (NSURL*)url;
 #endif
 + (instancetype) dataWithData: (NSData*)data;
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_9,GS_API_LATEST)
-- (instancetype) initWithBase64EncodedData: (NSData*)base64Data
+- (instancetype _Nullable) initWithBase64EncodedData: (NSData*)base64Data
   options: (NSDataBase64DecodingOptions)options;
-- (instancetype) initWithBase64EncodedString: (NSString*)base64String
+- (instancetype _Nullable) initWithBase64EncodedString: (NSString*)base64String
   options: (NSDataBase64DecodingOptions)options;
 /**
  * <override-subclass/>
@@ -141,31 +143,31 @@ GS_EXPORT_CLASS
                               length: (NSUInteger)length
                          deallocator: (GSDataDeallocatorBlock)deallocBlock;
 #endif
-- (instancetype) initWithBytes: (const void*)aBuffer
+- (instancetype) initWithBytes: (const void *_Nullable)aBuffer
                         length: (NSUInteger)bufferSize;
-- (instancetype) initWithBytesNoCopy: (void*)aBuffer
+- (instancetype) initWithBytesNoCopy: (void *_Nullable)aBuffer
                               length: (NSUInteger)bufferSize;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
-- (instancetype) initWithBytesNoCopy: (void*)aBuffer
+- (instancetype) initWithBytesNoCopy: (void *_Nullable)aBuffer
                               length: (NSUInteger)bufferSize
                         freeWhenDone: (BOOL)shouldFree;
 #endif
-- (instancetype) initWithContentsOfFile: (NSString*)path;
-- (instancetype) initWithContentsOfFile: (NSString *) path 
-                                options: (NSDataReadingOptions) readOptionsMask 
-                                  error: (NSError **) errorPtr;
-- (instancetype) initWithContentsOfMappedFile: (NSString*)path;
+- (instancetype _Nullable) initWithContentsOfFile: (NSString*)path;
+- (instancetype _Nullable) initWithContentsOfFile: (NSString *) path
+                                          options: (NSDataReadingOptions) readOptionsMask
+                                            error: (NSError **) errorPtr;
+- (instancetype _Nullable) initWithContentsOfMappedFile: (NSString*)path;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
-- (instancetype) initWithContentsOfURL: (NSURL*)url;
-- (instancetype) initWithContentsOfURL: (NSURL *)url
-                               options: (NSDataReadingOptions)readOptionsMask
-                                 error: (NSError **)errorPtr;
+- (instancetype _Nullable) initWithContentsOfURL: (NSURL*)url;
+- (instancetype _Nullable) initWithContentsOfURL: (NSURL *)url
+                                         options: (NSDataReadingOptions)readOptionsMask
+                                           error: (NSError **)errorPtr;
 #endif
 - (instancetype) initWithData: (NSData*)data;
 
 // Accessing Data
 
-- (const void*) bytes;
+- (const void *_Nullable) bytes;
 - (NSString*) description;
 - (void) getBytes: (void*)buffer;
 - (void) getBytes: (void*)buffer
@@ -355,21 +357,21 @@ GS_EXPORT_CLASS
 
 - (void) increaseLengthBy: (NSUInteger)extraLength;
 - (void) setLength: (NSUInteger)size;
-- (void*) mutableBytes;
+- (void *_Nullable) mutableBytes;
 
 // Appending Data
 
-- (void) appendBytes: (const void*)aBuffer
+- (void) appendBytes: (const void *_Nullable)aBuffer
 	      length: (NSUInteger)bufferSize;
 - (void) appendData: (NSData*)other;
 
 // Modifying Data
 
 - (void) replaceBytesInRange: (NSRange)aRange
-		   withBytes: (const void*)bytes;
+		   withBytes: (const void *_Nullable)bytes;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 - (void) replaceBytesInRange: (NSRange)aRange
-		   withBytes: (const void*)bytes
+		   withBytes: (const void *_Nullable)bytes
 		      length: (NSUInteger)length;
 #endif
 - (void) resetBytesInRange: (NSRange)aRange;
@@ -391,6 +393,8 @@ GS_EXPORT_CLASS
 	       atIndex: (unsigned int)index;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 #if OS_API_VERSION(GS_API_NONE, GS_API_NONE)
 

--- a/Headers/Foundation/NSData.h
+++ b/Headers/Foundation/NSData.h
@@ -117,13 +117,13 @@ GS_EXPORT_CLASS
 #endif
 + (instancetype _Nullable) dataWithContentsOfFile: (NSString *)path
                                           options: (NSDataReadingOptions)readOptionsMask
-                                            error: (NSError **)errorPtr;
+                                            error: (NSError *_Nullable *_Nullable)errorPtr;
 + (instancetype _Nullable) dataWithContentsOfFile: (NSString*)path;
 + (instancetype _Nullable) dataWithContentsOfMappedFile: (NSString*)path;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 + (instancetype _Nullable) dataWithContentsOfURL: (NSURL *)url
                                          options: (NSDataReadingOptions)readOptionsMask
-                                           error: (NSError **)errorPtr;
+                                           error: (NSError *_Nullable *_Nullable)errorPtr;
 + (instancetype _Nullable) dataWithContentsOfURL: (NSURL*)url;
 #endif
 + (instancetype) dataWithData: (NSData*)data;
@@ -155,13 +155,13 @@ GS_EXPORT_CLASS
 - (instancetype _Nullable) initWithContentsOfFile: (NSString*)path;
 - (instancetype _Nullable) initWithContentsOfFile: (NSString *) path
                                           options: (NSDataReadingOptions) readOptionsMask
-                                            error: (NSError **) errorPtr;
+                                            error: (NSError *_Nullable *_Nullable) errorPtr;
 - (instancetype _Nullable) initWithContentsOfMappedFile: (NSString*)path;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 - (instancetype _Nullable) initWithContentsOfURL: (NSURL*)url;
 - (instancetype _Nullable) initWithContentsOfURL: (NSURL *)url
                                          options: (NSDataReadingOptions)readOptionsMask
-                                           error: (NSError **)errorPtr;
+                                           error: (NSError *_Nullable *_Nullable)errorPtr;
 #endif
 - (instancetype) initWithData: (NSData*)data;
 

--- a/Headers/Foundation/NSData.h
+++ b/Headers/Foundation/NSData.h
@@ -106,8 +106,8 @@ GS_EXPORT_CLASS
 // Allocating and Initializing a Data Object
 
 + (instancetype) data;
-+ (instancetype) dataWithBytes: (const void *_Nullable)bytes
-                        length: (NSUInteger)length;
++ (nonnull instancetype) dataWithBytes: (const void *_Nullable)bytes
+                                length: (NSUInteger)length;
 + (instancetype) dataWithBytesNoCopy: (void *_Nullable)bytes
                               length: (NSUInteger)length;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
@@ -143,8 +143,8 @@ GS_EXPORT_CLASS
                               length: (NSUInteger)length
                          deallocator: (GSDataDeallocatorBlock)deallocBlock;
 #endif
-- (instancetype) initWithBytes: (const void *_Nullable)aBuffer
-                        length: (NSUInteger)bufferSize;
+- (nonnull instancetype) initWithBytes: (const void *_Nullable)aBuffer
+                                length: (NSUInteger)bufferSize;
 - (instancetype) initWithBytesNoCopy: (void *_Nullable)aBuffer
                               length: (NSUInteger)bufferSize;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)

--- a/Headers/Foundation/NSDictionary.h
+++ b/Headers/Foundation/NSDictionary.h
@@ -36,34 +36,38 @@ extern "C" {
 @class GS_GENERIC_CLASS(NSSet, ElementT);
 @class NSString, NSURL;
 
+NS_ASSUME_NONNULL_BEGIN
+
 GS_EXPORT_CLASS
 @interface GS_GENERIC_CLASS(NSDictionary,
   __covariant KeyT:id<NSCopying>, __covariant ValT)
   : NSObject <NSCoding, NSCopying, NSMutableCopying, NSFastEnumeration>
 + (instancetype) dictionary;
-+ (instancetype) dictionaryWithContentsOfFile: (NSString*)path;
++ (instancetype _Nullable) dictionaryWithContentsOfFile: (NSString*)path;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
-+ (instancetype) dictionaryWithContentsOfURL: (NSURL*)aURL;
++ (instancetype _Nullable) dictionaryWithContentsOfURL: (NSURL*)aURL;
 #endif
 + (instancetype) dictionaryWithDictionary: (NSDictionary*)otherDictionary;
 + (instancetype) dictionaryWithObject: (GS_GENERIC_TYPE(ValT))object
                                forKey: (GS_GENERIC_TYPE(KeyT))key;
 + (instancetype) dictionaryWithObjects: (GS_GENERIC_CLASS(NSArray,ValT)*)objects
                                forKeys: (GS_GENERIC_CLASS(NSArray,KeyT)*)keys;
-+ (instancetype) dictionaryWithObjects: (const GS_GENERIC_TYPE(ValT)[])objects
-  forKeys: (const GS_GENERIC_TYPE_F(KeyT,id<NSCopying>)[])keys
++ (instancetype) dictionaryWithObjects:
+  (const GS_GENERIC_TYPE(ValT) _Nonnull [])objects
+  forKeys:
+  (const GS_GENERIC_TYPE_F(KeyT,id<NSCopying>) _Nonnull [])keys
   count: (NSUInteger)count;
 + (instancetype) dictionaryWithObjectsAndKeys: (id)firstObject, ...;
 
 - (GS_GENERIC_CLASS(NSArray,KeyT)*) allKeys;
-- (GS_GENERIC_CLASS(NSArray,KeyT)*) allKeysForObject:
-  (GS_GENERIC_TYPE(ValT))anObject;
+- (GS_GENERIC_CLASS(NSArray,KeyT)* _Nullable) allKeysForObject:
+  (GS_GENERIC_TYPE(ValT) _Nullable)anObject;
 - (GS_GENERIC_CLASS(NSArray,ValT)*) allValues;
 - (NSUInteger) count;						// Primitive
 - (NSString*) description;
 - (NSString*) descriptionInStringsFileFormat;
-- (NSString*) descriptionWithLocale: (id)locale;
-- (NSString*) descriptionWithLocale: (id)locale
+- (NSString*) descriptionWithLocale: (id _Nullable)locale;
+- (NSString*) descriptionWithLocale: (id _Nullable)locale
 			     indent: (NSUInteger)level;
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
@@ -74,13 +78,15 @@ DEFINE_BLOCK_TYPE(GSKeysAndObjectsEnumeratorBlock, void, GS_GENERIC_TYPE_F(KeyT,
   usingBlock: (GSKeysAndObjectsEnumeratorBlock)aBlock;
 #endif
 
-- (void) getObjects: (__unsafe_unretained GS_GENERIC_TYPE(ValT)[])objects
-  andKeys: (__unsafe_unretained GS_GENERIC_TYPE_F(KeyT,id<NSCopying>)[])keys;
+- (void) getObjects:
+  (__unsafe_unretained GS_GENERIC_TYPE(ValT) _Nullable [])objects
+  andKeys:
+  (__unsafe_unretained GS_GENERIC_TYPE_F(KeyT,id<NSCopying>) _Nullable [])keys;
 - (instancetype) init;
-- (instancetype) initWithContentsOfFile: (NSString*)path;
+- (instancetype _Nullable) initWithContentsOfFile: (NSString*)path;
 
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
-- (instancetype) initWithContentsOfURL: (NSURL*)aURL;
+- (instancetype _Nullable) initWithContentsOfURL: (NSURL*)aURL;
 #endif
 
 - (instancetype) initWithDictionary:
@@ -90,8 +96,9 @@ DEFINE_BLOCK_TYPE(GSKeysAndObjectsEnumeratorBlock, void, GS_GENERIC_TYPE_F(KeyT,
 - (id) initWithObjects: (GS_GENERIC_CLASS(NSArray,KeyT)*)objects
                forKeys: (GS_GENERIC_CLASS(NSArray,ValT)*)keys;
 - (id) initWithObjectsAndKeys: (GS_GENERIC_TYPE(ValT))firstObject, ...;
-- (id) initWithObjects: (const GS_GENERIC_TYPE(ValT)[])objects
-	       forKeys: (const GS_GENERIC_TYPE_F(KeyT,id<NSCopying>)[])keys
+- (id) initWithObjects: (const GS_GENERIC_TYPE(ValT) _Nonnull [])objects
+	       forKeys:
+  (const GS_GENERIC_TYPE_F(KeyT,id<NSCopying>) _Nonnull [])keys
 		 count: (NSUInteger)count; // Primitive
 - (BOOL) isEqualToDictionary: (GS_GENERIC_CLASS(NSDictionary,KeyT, ValT)*)other;
 
@@ -110,14 +117,14 @@ DEFINE_BLOCK_TYPE(GSKeysAndObjectsPredicateBlock, BOOL, GS_GENERIC_TYPE_F(KeyT,i
 - (GS_GENERIC_CLASS(NSArray,ValT)*) keysSortedByValueUsingComparator:(NSComparator)cmptr;
 - (GS_GENERIC_CLASS(NSArray,ValT)*) keysSortedByValueWithOptions:(NSSortOptions)opts usingComparator:(NSComparator)cmptr;  
 - (GS_GENERIC_CLASS(NSEnumerator,ValT)*) objectEnumerator;	// Primitive
-- (GS_GENERIC_TYPE(ValT)) objectForKey:
+- (GS_GENERIC_TYPE(ValT) _Nullable) objectForKey:
   (GS_GENERIC_TYPE(KeyT))aKey;				// Primitive
 - (GS_GENERIC_CLASS(NSArray,ValT)*) objectsForKeys:
   (GS_GENERIC_CLASS(NSArray,KeyT)*)keys
   notFoundMarker: (GS_GENERIC_TYPE(ValT))marker;
 
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
-- (GS_GENERIC_TYPE(ValT)) valueForKey: (NSString*)key;
+- (GS_GENERIC_TYPE(ValT) _Nullable) valueForKey: (NSString*)key;
 #endif
 
 - (BOOL) writeToFile: (NSString*)path atomically: (BOOL)useAuxiliaryFile;
@@ -128,7 +135,7 @@ DEFINE_BLOCK_TYPE(GSKeysAndObjectsPredicateBlock, BOOL, GS_GENERIC_TYPE_F(KeyT,i
 /**
  * Method called by array subscripting.
  */
-- (GS_GENERIC_TYPE(ValT)) objectForKeyedSubscript:
+- (GS_GENERIC_TYPE(ValT) _Nullable) objectForKeyedSubscript:
   (GS_GENERIC_TYPE(KeyT))aKey;
 @end
 
@@ -153,17 +160,22 @@ GS_EXPORT_CLASS
 - (void) setDictionary:
     (GS_GENERIC_CLASS(NSDictionary, KeyT, ValT)*)otherDictionary;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
-- (void) setValue: (GS_GENERIC_TYPE(ValT))value forKey: (NSString*)key;
-- (void) takeStoredValue: (GS_GENERIC_TYPE(ValT))value forKey: (NSString*)key;
-- (void) takeValue: (GS_GENERIC_TYPE(ValT))value forKey: (NSString*)key;
+- (void) setValue: (GS_GENERIC_TYPE(ValT) _Nullable)value
+           forKey: (NSString*)key;
+- (void) takeStoredValue: (GS_GENERIC_TYPE(ValT) _Nullable)value
+                  forKey: (NSString*)key;
+- (void) takeValue: (GS_GENERIC_TYPE(ValT) _Nullable)value
+            forKey: (NSString*)key;
 #endif
 /**
  * Method called by array subscripting.
  */
-- (void) setObject: (GS_GENERIC_TYPE(ValT))anObject
+- (void) setObject: (GS_GENERIC_TYPE(ValT) _Nullable)anObject
  forKeyedSubscript: (GS_GENERIC_TYPE(KeyT))aKey;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 #if	defined(__cplusplus)
 }

--- a/Headers/Foundation/NSError.h
+++ b/Headers/Foundation/NSError.h
@@ -37,6 +37,8 @@ extern "C" {
 
 @class NSArray, NSDictionary, NSString;
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef NSString* NSErrorDomain;
 
 /**
@@ -135,7 +137,7 @@ GS_EXPORT_CLASS
 @private
   int		_code;
   NSString	*_domain;
-  NSDictionary	*_userInfo;
+  NSDictionary	*_Nullable _userInfo;
 #endif
 #if     GS_NONFRAGILE
 #else
@@ -154,7 +156,7 @@ GS_EXPORT_CLASS
  */
 + (instancetype) errorWithDomain: (NSErrorDomain)aDomain
                             code: (NSInteger)aCode
-                        userInfo: (NSDictionary*)aDictionary;
+                        userInfo: (NSDictionary *_Nullable)aDictionary;
 
 /**
  * Return the error code ... which is not globally unique, just unique for
@@ -173,7 +175,7 @@ GS_EXPORT_CLASS
  */
 - (instancetype) initWithDomain: (NSErrorDomain)aDomain
                            code: (NSInteger)aCode
-                       userInfo: (NSDictionary*)aDictionary;
+                       userInfo: (NSDictionary *_Nullable)aDictionary;
 
 /**
  * Return a human readable description for the error.<br />
@@ -191,7 +193,7 @@ GS_EXPORT_CLASS
  * The default implementation uses the value from the user info dictionary
  * if it is available, otherwise it returns nil.
  */
-- (NSString *) localizedFailureReason;
+- (NSString *_Nullable) localizedFailureReason;
 
 /**
  * Returns an array of strings to be used as titles of buttons in an
@@ -200,7 +202,7 @@ GS_EXPORT_CLASS
  * The default implementation uses the value from the user info dictionary
  * if it is available, otherwise it returns nil.
  */
-- (NSArray *) localizedRecoveryOptions;
+- (NSArray *_Nullable) localizedRecoveryOptions;
 
 /**
  * Returns a string used as the secondary text in an alert panel,
@@ -209,14 +211,14 @@ GS_EXPORT_CLASS
  * The default implementation uses the value from the user info dictionary
  * if it is available, otherwise it returns nil.
  */
-- (NSString *) localizedRecoverySuggestion;
+- (NSString *_Nullable) localizedRecoverySuggestion;
 
 /**
  * Not yet useful in GNUstep.<br />
  * The default implementation uses the value from the user info dictionary
  * if it is available, otherwise it returns nil.
  */
-- (id) recoveryAttempter;
+- (id _Nullable) recoveryAttempter;
 #endif
 
 /**
@@ -227,8 +229,10 @@ GS_EXPORT_CLASS
  * <code>NSError</code> instance if an error is available describing any
  * underlying problem.<br />
  */
-- (NSDictionary*) userInfo;
+- (NSDictionary *_Nullable) userInfo;
 @end
+
+NS_ASSUME_NONNULL_END
 
 #if	defined(__cplusplus)
 }

--- a/Headers/Foundation/NSFileHandle.h
+++ b/Headers/Foundation/NSFileHandle.h
@@ -55,11 +55,11 @@ GS_EXPORT_CLASS
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
 + (instancetype) fileHandleForReadingFromURL: (NSURL*)url
-				       error: (NSError**)error;
+				       error: (NSError *_Nullable *_Nullable)error;
 + (instancetype) fileHandleForWritingToURL: (NSURL*)url
-				     error: (NSError**)error;
+				     error: (NSError *_Nullable *_Nullable)error;
 + (instancetype) fileHandleForUpdatingURL: (NSURL*)url
-				    error: (NSError**)error;
+				    error: (NSError *_Nullable *_Nullable)error;
 #endif
 
 - (id) initWithFileDescriptor: (int)desc;

--- a/Headers/Foundation/NSFileManager.h
+++ b/Headers/Foundation/NSFileManager.h
@@ -590,6 +590,7 @@ GS_EXPORT_CLASS
     BOOL justContents: 1;
     BOOL skipHidden: 1;
     BOOL currentIsDir: 1;
+    BOOL skipPackages: 1;
   } _flags;
 #endif
 #if     GS_NONFRAGILE

--- a/Headers/Foundation/NSFileManager.h
+++ b/Headers/Foundation/NSFileManager.h
@@ -310,7 +310,7 @@ GS_EXPORT_CLASS
  */
 - (BOOL) createSymbolicLinkAtPath: (NSString*)path
               withDestinationPath: (NSString*)destPath
-                            error: (NSError**)error;
+                            error: (NSError *_Nullable *_Nullable)error;
 
 - (BOOL) setAttributes:(NSDictionary *)attributes ofItemAtPath:(NSString *)path error:(NSError **)error;
 #endif
@@ -391,7 +391,7 @@ GS_EXPORT_CLASS
 - (NSArray*) contentsOfDirectoryAtPath: (NSString*)path error: (NSError**)error;
 
 - (NSDictionary*) attributesOfFileSystemForPath: (NSString*)path
-                                          error: (NSError**)error;
+                                          error: (NSError *_Nullable *_Nullable)error;
 #endif
 
 - (BOOL) copyPath: (NSString*)source

--- a/Headers/Foundation/NSJSONSerialization.h
+++ b/Headers/Foundation/NSJSONSerialization.h
@@ -91,18 +91,18 @@ GS_EXPORT_CLASS
 @interface NSJSONSerialization : NSObject
 + (NSData *_Nullable) dataWithJSONObject: (id)obj
                                  options: (NSJSONWritingOptions)opt
-                                   error: (NSError **)error;
+                                   error: (NSError *_Nullable *_Nullable)error;
 + (BOOL) isValidJSONObject: (id)obj;
 + (id _Nullable) JSONObjectWithData: (NSData *)data
                             options: (NSJSONReadingOptions)opt
-                              error: (NSError **)error;
+                              error: (NSError *_Nullable *_Nullable)error;
 + (id _Nullable) JSONObjectWithStream: (NSInputStream *)stream
                               options: (NSJSONReadingOptions)opt
-                                error: (NSError **)error;
+                                error: (NSError *_Nullable *_Nullable)error;
 + (NSInteger) writeJSONObject: (id)obj
                      toStream: (NSOutputStream *)stream
                       options: (NSJSONWritingOptions)opt
-                        error: (NSError **)error;
+                        error: (NSError *_Nullable *_Nullable)error;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Headers/Foundation/NSJSONSerialization.h
+++ b/Headers/Foundation/NSJSONSerialization.h
@@ -28,6 +28,8 @@
 @class NSInputStream;
 @class NSOutputStream;
 
+NS_ASSUME_NONNULL_BEGIN
+
 enum
 {
   /**
@@ -87,18 +89,20 @@ typedef NSUInteger NSJSONReadingOptions;
  */
 GS_EXPORT_CLASS
 @interface NSJSONSerialization : NSObject
-+ (NSData*) dataWithJSONObject: (id)obj
-                       options: (NSJSONWritingOptions)opt
-                         error: (NSError **)error;
++ (NSData *_Nullable) dataWithJSONObject: (id)obj
+                                 options: (NSJSONWritingOptions)opt
+                                   error: (NSError **)error;
 + (BOOL) isValidJSONObject: (id)obj;
-+ (id) JSONObjectWithData: (NSData *)data
-                  options: (NSJSONReadingOptions)opt
-                    error: (NSError **)error;
-+ (id) JSONObjectWithStream: (NSInputStream *)stream
-                    options: (NSJSONReadingOptions)opt
-                      error: (NSError **)error;
++ (id _Nullable) JSONObjectWithData: (NSData *)data
+                            options: (NSJSONReadingOptions)opt
+                              error: (NSError **)error;
++ (id _Nullable) JSONObjectWithStream: (NSInputStream *)stream
+                              options: (NSJSONReadingOptions)opt
+                                error: (NSError **)error;
 + (NSInteger) writeJSONObject: (id)obj
                      toStream: (NSOutputStream *)stream
                       options: (NSJSONWritingOptions)opt
                         error: (NSError **)error;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Headers/Foundation/NSObjCRuntime.h
+++ b/Headers/Foundation/NSObjCRuntime.h
@@ -185,6 +185,16 @@ extern "C" {
 #endif
 
 /*
+ * Import a declaration with a specific Swift name when the compiler
+ * supports the attribute.
+ */
+#if __has_attribute(swift_name)
+#  define NS_SWIFT_NAME(_name) __attribute__((swift_name(#_name)))
+#else
+#  define NS_SWIFT_NAME(_name)
+#endif
+
+/*
  * Backwards compatibility macro for instance type.
  */
 #if !__has_feature(objc_instancetype)
@@ -243,17 +253,21 @@ typedef NS_OPTIONS(NSUInteger, NSSortOptions)
 
 #import <GNUstepBase/GSObjCRuntime.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_5,GS_API_LATEST)
-GS_EXPORT NSString	*NSStringFromProtocol(Protocol *aProtocol);
-GS_EXPORT Protocol	*NSProtocolFromString(NSString *aProtocolName);
+GS_EXPORT NSString	*_Nullable NSStringFromProtocol(Protocol *_Nullable aProtocol);
+GS_EXPORT Protocol	*_Nullable NSProtocolFromString(NSString *aProtocolName);
 #endif
 GS_EXPORT SEL		NSSelectorFromString(NSString *aSelectorName);
-GS_EXPORT NSString	*NSStringFromSelector(SEL aSelector);
+GS_EXPORT NSString	*_Nullable NSStringFromSelector(SEL aSelector);
 GS_EXPORT SEL		NSSelectorFromString(NSString *aSelectorName);
-GS_EXPORT Class		NSClassFromString(NSString *aClassName);
-GS_EXPORT NSString	*NSStringFromClass(Class aClass);
+GS_EXPORT Class		_Nullable NSClassFromString(NSString *aClassName);
+GS_EXPORT NSString	*_Nullable NSStringFromClass(Class _Nullable aClass);
 GS_EXPORT const char	*NSGetSizeAndAlignment(const char *typePtr,
-  NSUInteger *sizep, NSUInteger *alignp);
+  NSUInteger *_Nullable sizep, NSUInteger *_Nullable alignp);
+
+NS_ASSUME_NONNULL_END
 
 #if OS_API_VERSION(GS_API_NONE, GS_API_NONE)
 /* Logging */

--- a/Headers/Foundation/NSObject.h
+++ b/Headers/Foundation/NSObject.h
@@ -48,6 +48,8 @@ extern "C" {
 @class NSInvocation;
 @class Protocol;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * The NSObject protocol describes a minimal set of methods that all
  * objects are expected to support.  You should be able to send any
@@ -71,7 +73,7 @@ extern "C" {
  * superclass of the receiver's class, ignoring proxies, then use
  * "class_getSuperclass(object_getClass())".
  */
-- (Class) superclass;
+- (Class _Nullable) superclass;
 
 /**
  * Returns whether the receiver is equal to the argument.  Defining equality is
@@ -90,7 +92,7 @@ extern "C" {
  * If two objects are equal, then they must have the same hash value, however
  * equal hash values do not imply equality.
  */
-- (BOOL) isEqual: (id)anObject;
+- (BOOL) isEqual: (id _Nullable)anObject;
 
 /**
  * Returns YES if the receiver is an instance of the class, an instance of the
@@ -141,24 +143,24 @@ extern "C" {
  * Performs the specified selector.  The selector must correspond to a method
  * that takes no arguments.
  */
-- (id) performSelector: (SEL)aSelector;
+- (id _Nullable) performSelector: (SEL)aSelector;
 
 /**
  * Performs the specified selector, with the object as the argument.  This
  * method does not perform any automatic unboxing, so the selector must
  * correspond to a method that takes one object argument.
  */
-- (id) performSelector: (SEL)aSelector
-	    withObject: (id)anObject;
+- (id _Nullable) performSelector: (SEL)aSelector
+	    withObject: (id _Nullable)anObject;
 
 /**
  * Performs the specified selector, with the objects as the arguments.  This
  * method does not perform any automatic unboxing, so the selector must
  * correspond to a method that takes two object arguments.
  */
-- (id) performSelector: (SEL)aSelector
-	    withObject: (id)object1
-	    withObject: (id)object2;
+- (id _Nullable) performSelector: (SEL)aSelector
+	    withObject: (id _Nullable)object1
+	    withObject: (id _Nullable)object2;
 
 /**
  * Returns YES if the object can respond to messages with the specified
@@ -223,7 +225,7 @@ extern "C" {
 /**
  * Returns the zone of the object.
  */
-- (NSZone*) zone NS_AUTOMATED_REFCOUNT_UNAVAILABLE;
+- (NSZone *_Nullable) zone NS_AUTOMATED_REFCOUNT_UNAVAILABLE;
 @end
 
 /**
@@ -246,7 +248,7 @@ extern "C" {
  * new copy, or are themselves copied, or whether some other mechanism
  * entirely is used.
  */
-- (id) copyWithZone: (NSZone*)zone;
+- (id) copyWithZone: (NSZone *_Nullable)zone;
 @end
 
 /**
@@ -268,7 +270,7 @@ extern "C" {
  * new copy, or are themselves copied, or whether some other mechanism
  * entirely is used.
  */
-- (id) mutableCopyWithZone: (NSZone*)zone;
+- (id) mutableCopyWithZone: (NSZone *_Nullable)zone;
 @end
 
 /**
@@ -325,7 +327,7 @@ GS_EXPORT_CLASS GS_ROOT_CLASS
 - (NSString*) className;
 #endif
 
-+ (id) allocWithZone: (NSZone*)z;
++ (id) allocWithZone: (NSZone *_Nullable)z;
 + (id) alloc;
 + (Class) class;
 
@@ -375,8 +377,8 @@ GS_EXPORT_CLASS GS_ROOT_CLASS
  * of +initialize.
  */
 + (void) initialize;
-+ (IMP) instanceMethodForSelector: (SEL)aSelector;
-+ (NSMethodSignature*) instanceMethodSignatureForSelector: (SEL)aSelector;
++ (IMP _Nullable) instanceMethodForSelector: (SEL)aSelector;
++ (NSMethodSignature *_Nullable) instanceMethodSignatureForSelector: (SEL)aSelector;
 + (BOOL) instancesRespondToSelector: (SEL)aSelector;
 + (BOOL) isSubclassOfClass: (Class)aClass;
 + (id) new;
@@ -392,12 +394,12 @@ GS_EXPORT_CLASS GS_ROOT_CLASS
 - (void) doesNotRecognizeSelector: (SEL)aSelector;
 - (void) forwardInvocation: (NSInvocation*)anInvocation;
 - (id) init;
-- (IMP) methodForSelector: (SEL)aSelector;
-- (NSMethodSignature*) methodSignatureForSelector: (SEL)aSelector;
+- (IMP _Nullable) methodForSelector: (SEL)aSelector;
+- (NSMethodSignature *_Nullable) methodSignatureForSelector: (SEL)aSelector;
 - (id) mutableCopy;
 - (id) replacementObjectForArchiver: (NSArchiver*)anArchiver;
 - (id) replacementObjectForCoder: (NSCoder*)anEncoder;
-- (Class) superclass;
+- (Class _Nullable) superclass;
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_5, GS_API_LATEST)
 /**
  * This method will be called when attempting to send a message a class that
@@ -450,10 +452,12 @@ GS_EXPORT_CLASS GS_ROOT_CLASS
  * runtime, you must also implement -forwardInvocation: with equivalent
  * semantics.  This will be considerably slower, but more portable.
  */
-- (id) forwardingTargetForSelector: (SEL)aSelector;
+- (id _Nullable) forwardingTargetForSelector: (SEL)aSelector;
 
 #endif
 @end
+
+NS_ASSUME_NONNULL_END
 
 /**
  * Used to allocate memory to hold an object, and initialise the
@@ -520,6 +524,8 @@ NSIncrementExtraRefCount(id anObject);
  *  Declares some methods for sending messages to self after a fixed delay.
  *  (These methods <em>are</em> in OpenStep and OS X.)
  */
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSObject (TimedPerformers)
 
 /**
@@ -537,13 +543,13 @@ NSIncrementExtraRefCount(id anObject);
  */
 + (void) cancelPreviousPerformRequestsWithTarget: (id)obj
 					selector: (SEL)s
-					  object: (id)arg;
+					  object: (id _Nullable)arg;
 /**
  * Sets given message to be sent to this instance after given delay,
  * in any run loop mode.  See [NSRunLoop].
  */
 - (void) performSelector: (SEL)s
-	      withObject: (id)arg
+	      withObject: (id _Nullable)arg
 	      afterDelay: (NSTimeInterval)seconds;
 
 /**
@@ -551,7 +557,7 @@ NSIncrementExtraRefCount(id anObject);
  * in given run loop modes.  See [NSRunLoop].
  */
 - (void) performSelector: (SEL)s
-	      withObject: (id)arg
+	      withObject: (id _Nullable)arg
 	      afterDelay: (NSTimeInterval)seconds
 		 inModes: (NSArray*)modes;
 @end
@@ -591,6 +597,8 @@ NSIncrementExtraRefCount(id anObject);
  */
 - (BOOL) isContentDiscarded;
 @end
+
+NS_ASSUME_NONNULL_END
 #endif
 #if	defined(__cplusplus)
 }

--- a/Headers/Foundation/NSPropertyList.h
+++ b/Headers/Foundation/NSPropertyList.h
@@ -269,20 +269,20 @@ GS_EXPORT_CLASS
 + (NSData *) dataWithPropertyList: (id)aPropertyList
                            format: (NSPropertyListFormat)aFormat
                           options: (NSPropertyListWriteOptions)anOption
-                            error: (out NSError**)error;
+                            error: (out NSError *_Nullable *_Nullable)error;
 + (id) propertyListWithData: (NSData*)data
                     options: (NSPropertyListReadOptions)anOption
                      format: (NSPropertyListFormat*)aFormat
-                      error: (out NSError**)error;
+                      error: (out NSError *_Nullable *_Nullable)error;
 + (id) propertyListWithStream: (NSInputStream*)stream
                       options: (NSPropertyListReadOptions)anOption
                        format: (NSPropertyListFormat*)aFormat
-                        error: (out NSError**)error;
+                        error: (out NSError *_Nullable *_Nullable)error;
 + (NSInteger) writePropertyList: (id)aPropertyList
                        toStream: (NSOutputStream*)stream
                          format: (NSPropertyListFormat)aFormat
                         options: (NSPropertyListWriteOptions)anOption
-                          error: (out NSError**)error;
+                          error: (out NSError *_Nullable *_Nullable)error;
 #endif
 
 @end

--- a/Headers/Foundation/NSRegularExpression.h
+++ b/Headers/Foundation/NSRegularExpression.h
@@ -118,16 +118,16 @@ GS_EXPORT_CLASS
 #if GS_USE_ICU || GS_UNSAFE_REGEX
 + (NSRegularExpression*) regularExpressionWithPattern: (NSString*)aPattern
   options: (NSRegularExpressionOptions)opts
-  error: (NSError**)e;
+  error: (NSError *_Nullable *_Nullable)e;
 - (id) initWithPattern: (NSString*)aPattern
 	       options: (NSRegularExpressionOptions)opts
-		 error: (NSError**)e;
+		 error: (NSError *_Nullable *_Nullable)e;
 + (NSRegularExpression*) regularExpressionWithPattern: (NSString*)aPattern
   options: (NSRegularExpressionOptions)opts
-  error: (NSError**)e;
+  error: (NSError *_Nullable *_Nullable)e;
 - (id) initWithPattern: (NSString*)aPattern
 	       options: (NSRegularExpressionOptions)opts
-		 error: (NSError**)e;
+		 error: (NSError *_Nullable *_Nullable)e;
 - (NSString*) pattern; 
 #if     GS_API_VERSION( 13100, GS_API_LATEST)
 /** In the GNUstep implementation this method is the fundametal primitive

--- a/Headers/Foundation/NSSet.h
+++ b/Headers/Foundation/NSSet.h
@@ -42,6 +42,8 @@ extern "C" {
 @class GS_GENERIC_CLASS(NSDictionary, KeyT:id<NSCopying>, ValT);
 @class NSString;
 
+NS_ASSUME_NONNULL_BEGIN
+
 GS_EXPORT_CLASS
 @interface GS_GENERIC_CLASS(NSSet, __covariant ElementT) : NSObject <NSCoding,
                                                              NSCopying,
@@ -53,22 +55,24 @@ GS_EXPORT_CLASS
 + (instancetype) setWithObject: (GS_GENERIC_TYPE(ElementT))anObject;
 + (instancetype) setWithObjects: (GS_GENERIC_TYPE(ElementT))firstObject, ...;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
-+ (instancetype) setWithObjects: (const GS_GENERIC_TYPE(ElementT)[])objects
++ (instancetype) setWithObjects:
+  (const GS_GENERIC_TYPE(ElementT) _Nonnull [])objects
 		                  count: (NSUInteger)count;
 #endif
 + (instancetype) setWithSet: (GS_GENERIC_CLASS(NSSet, ElementT)*)aSet;
 
 - (GS_GENERIC_CLASS(NSArray, ElementT)*) allObjects;
-- (GS_GENERIC_TYPE(ElementT)) anyObject;
+- (GS_GENERIC_TYPE(ElementT) _Nullable) anyObject;
 - (BOOL) containsObject: (GS_GENERIC_TYPE(ElementT))anObject;
 - (NSUInteger) count;
 - (NSString*) description;
-- (NSString*) descriptionWithLocale: (id)locale;
+- (NSString*) descriptionWithLocale: (id _Nullable)locale;
 
 - (instancetype) init;
 - (instancetype) initWithArray: (GS_GENERIC_CLASS(NSArray, ElementT)*)other;
 - (instancetype) initWithObjects: (GS_GENERIC_TYPE(ElementT))firstObject, ...;
-- (instancetype) initWithObjects: (const GS_GENERIC_TYPE(ElementT)[])objects
+- (instancetype) initWithObjects:
+  (const GS_GENERIC_TYPE(ElementT) _Nonnull [])objects
 		                   count: (NSUInteger)count;
 - (instancetype) initWithSet: (GS_GENERIC_CLASS(NSSet, ElementT)*)other;
 - (instancetype) initWithSet: (GS_GENERIC_CLASS(NSSet, ElementT)*)other
@@ -79,12 +83,14 @@ GS_EXPORT_CLASS
 - (BOOL) isSubsetOfSet: (GS_GENERIC_CLASS(NSSet, ElementT)*)otherSet;
 
 - (void) makeObjectsPerform: (SEL)aSelector;
-- (void) makeObjectsPerform: (SEL)aSelector withObject: (id)argument;
+- (void) makeObjectsPerform: (SEL)aSelector withObject: (id _Nullable)argument;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 - (void) makeObjectsPerformSelector: (SEL)aSelector;
-- (void) makeObjectsPerformSelector: (SEL)aSelector withObject: (id)argument;
+- (void) makeObjectsPerformSelector: (SEL)aSelector
+                         withObject: (id _Nullable)argument;
 #endif
-- (GS_GENERIC_TYPE(ElementT)) member: (GS_GENERIC_TYPE(ElementT))anObject;
+- (GS_GENERIC_TYPE(ElementT) _Nullable) member:
+  (GS_GENERIC_TYPE(ElementT))anObject;
 - (GS_GENERIC_CLASS(NSEnumerator, ElementT)*) objectEnumerator;
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
@@ -196,6 +202,8 @@ GS_EXPORT_CLASS
 - (GS_GENERIC_TYPE(ElementT)) unique:
     (GS_GENERIC_TYPE(ElementT)) NS_CONSUMED anObject NS_RETURNS_RETAINED;
 @end
+
+NS_ASSUME_NONNULL_END
 
 /*
  * Functions for managing a global uniquing set.

--- a/Headers/Foundation/NSString.h
+++ b/Headers/Foundation/NSString.h
@@ -513,6 +513,8 @@ DEFINE_BLOCK_TYPE(GSNSStringLineEnumerationBlock, void, NSString *line, BOOL *st
  * </p>
  */
 
+NS_ASSUME_NONNULL_BEGIN
+
 GS_EXPORT_CLASS
 @interface NSString :NSObject <NSCoding, NSCopying, NSMutableCopying>
 
@@ -520,51 +522,51 @@ GS_EXPORT_CLASS
 + (instancetype) stringWithCharacters: (const unichar*)chars
                                length: (NSUInteger)length;
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_4,GS_API_LATEST) && GS_API_VERSION( 10200,GS_API_LATEST)
-+ (instancetype) stringWithCString: (const char*)byteString
-                          encoding: (NSStringEncoding)encoding;
++ (instancetype _Nullable) stringWithCString: (const char*)byteString
+                                    encoding: (NSStringEncoding)encoding;
 #endif
-+ (instancetype) stringWithCString: (const char*)byteString
-                            length: (NSUInteger)length;
-+ (instancetype) stringWithCString: (const char*)byteString;
++ (instancetype _Nullable) stringWithCString: (const char*)byteString
+                                      length: (NSUInteger)length;
++ (instancetype _Nullable) stringWithCString: (const char*)byteString;
 + (instancetype) stringWithFormat: (NSString*)format, ... NS_FORMAT_FUNCTION(1,2);
-+ (instancetype) stringWithContentsOfFile: (NSString *)path;
++ (instancetype _Nullable) stringWithContentsOfFile: (NSString *)path;
 
 // Initializing Newly Allocated Strings
 - (instancetype) init;
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_4,GS_API_LATEST) && GS_API_VERSION( 10200,GS_API_LATEST)
-- (instancetype) initWithBytes: (const void*)bytes
-                        length: (NSUInteger)length
-                      encoding: (NSStringEncoding)encoding;
-- (instancetype) initWithBytesNoCopy: (void*)bytes
-                              length: (NSUInteger)length
-                            encoding: (NSStringEncoding)encoding
-                        freeWhenDone: (BOOL)flag;
+- (instancetype _Nullable) initWithBytes: (const void*)bytes
+                                  length: (NSUInteger)length
+                                encoding: (NSStringEncoding)encoding;
+- (instancetype _Nullable) initWithBytesNoCopy: (void*)bytes
+                                        length: (NSUInteger)length
+                                      encoding: (NSStringEncoding)encoding
+                                  freeWhenDone: (BOOL)flag;
 #endif
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_4,GS_API_LATEST)
-+ (instancetype) stringWithContentsOfFile: (NSString*)path
-                             usedEncoding: (NSStringEncoding*)enc
-                                    error: (NSError**)error;
-- (instancetype) initWithContentsOfFile: (NSString*)path
-                           usedEncoding: (NSStringEncoding*)enc
-                                  error: (NSError**)error;
-+ (instancetype) stringWithContentsOfFile: (NSString*)path
-                                 encoding: (NSStringEncoding)enc
-                                    error: (NSError**)error;
-- (instancetype) initWithContentsOfFile: (NSString*)path
-                               encoding: (NSStringEncoding)enc
-                                  error: (NSError**)error;
-+ (instancetype) stringWithContentsOfURL: (NSURL*)url
-                            usedEncoding: (NSStringEncoding*)enc
-                                   error: (NSError**)error;
-- (instancetype) initWithContentsOfURL: (NSURL*)url
-                          usedEncoding: (NSStringEncoding*)enc
-                                 error: (NSError**)error;
-+ (instancetype) stringWithContentsOfURL: (NSURL*)url
-                                encoding: (NSStringEncoding)enc
-                                   error: (NSError**)error;
-- (instancetype) initWithContentsOfURL: (NSURL*)url
-                              encoding: (NSStringEncoding)enc
-                                 error: (NSError**)error;
++ (instancetype _Nullable) stringWithContentsOfFile: (NSString*)path
+                                       usedEncoding: (NSStringEncoding *_Nullable)enc
+                                              error: (NSError**)error;
+- (instancetype _Nullable) initWithContentsOfFile: (NSString*)path
+                                     usedEncoding: (NSStringEncoding *_Nullable)enc
+                                            error: (NSError**)error;
++ (instancetype _Nullable) stringWithContentsOfFile: (NSString*)path
+                                           encoding: (NSStringEncoding)enc
+                                              error: (NSError**)error;
+- (instancetype _Nullable) initWithContentsOfFile: (NSString*)path
+                                         encoding: (NSStringEncoding)enc
+                                            error: (NSError**)error;
++ (instancetype _Nullable) stringWithContentsOfURL: (NSURL*)url
+                                      usedEncoding: (NSStringEncoding *_Nullable)enc
+                                             error: (NSError**)error;
+- (instancetype _Nullable) initWithContentsOfURL: (NSURL*)url
+                                    usedEncoding: (NSStringEncoding *_Nullable)enc
+                                           error: (NSError**)error;
++ (instancetype _Nullable) stringWithContentsOfURL: (NSURL*)url
+                                          encoding: (NSStringEncoding)enc
+                                             error: (NSError**)error;
+- (instancetype _Nullable) initWithContentsOfURL: (NSURL*)url
+                                        encoding: (NSStringEncoding)enc
+                                           error: (NSError**)error;
 - (BOOL) writeToFile: (NSString*)path
 	  atomically: (BOOL)atomically
 	    encoding: (NSStringEncoding)enc
@@ -592,16 +594,16 @@ GS_EXPORT_CLASS
 - (instancetype) initWithCStringNoCopy: (char*)byteString
                                 length: (NSUInteger)length
                           freeWhenDone: (BOOL)flag;
-- (instancetype) initWithCString: (const char*)byteString
-                          length: (NSUInteger)length;
-- (instancetype) initWithCString: (const char*)byteString;
+- (instancetype _Nullable) initWithCString: (const char*)byteString
+                                    length: (NSUInteger)length;
+- (instancetype _Nullable) initWithCString: (const char*)byteString;
 - (instancetype) initWithString: (NSString*)string;
 - (instancetype) initWithFormat: (NSString*)format, ... NS_FORMAT_FUNCTION(1,2);
 - (instancetype) initWithFormat: (NSString*)format
                       arguments: (va_list)argList NS_FORMAT_FUNCTION(1,0);
-- (instancetype) initWithData: (NSData*)data
-                     encoding: (NSStringEncoding)encoding;
-- (instancetype) initWithContentsOfFile: (NSString*)path;
+- (instancetype _Nullable) initWithData: (NSData*)data
+                               encoding: (NSStringEncoding)encoding;
+- (instancetype _Nullable) initWithContentsOfFile: (NSString*)path;
 
 // Getting a String's Length
 - (NSUInteger) length;
@@ -658,8 +660,8 @@ GS_EXPORT_CLASS
 #endif
 
 // Converting String Contents into a Property List
-- (id) propertyList;
-- (NSDictionary*) propertyListFromStringsFileFormat;
+- (id _Nullable) propertyList;
+- (NSDictionary *_Nullable) propertyListFromStringsFileFormat;
 
 // Identifying and Comparing Strings
 - (NSComparisonResult) compare: (NSString*)aString;
@@ -670,7 +672,7 @@ GS_EXPORT_CLASS
 			 range: (NSRange)aRange;
 - (BOOL) hasPrefix: (NSString*)aString;
 - (BOOL) hasSuffix: (NSString*)aString;
-- (BOOL) isEqual: (id)anObject;
+- (BOOL) isEqual: (id _Nullable)anObject;
 - (BOOL) isEqualToString: (NSString*)aString;
 - (NSUInteger) hash;
 
@@ -692,8 +694,8 @@ GS_EXPORT_CLASS
 - (BOOL) getCString: (char*)buffer
 	  maxLength: (NSUInteger)maxLength
 	   encoding: (NSStringEncoding)encoding;
-- (instancetype) initWithCString: (const char*)byteString
-                        encoding: (NSStringEncoding)encoding;
+- (instancetype _Nullable) initWithCString: (const char*)byteString
+                                   encoding: (NSStringEncoding)encoding;
 - (NSUInteger) lengthOfBytesUsingEncoding: (NSStringEncoding)encoding;
 - (NSUInteger) maximumLengthOfBytesUsingEncoding: (NSStringEncoding)encoding;
 #endif
@@ -714,13 +716,13 @@ GS_EXPORT_CLASS
 
 // Working With Encodings
 - (BOOL) canBeConvertedToEncoding: (NSStringEncoding)encoding;
-- (NSData*) dataUsingEncoding: (NSStringEncoding)encoding;
+- (NSData *_Nullable) dataUsingEncoding: (NSStringEncoding)encoding;
 /** Conversion to an encoding where byte order matters but is not specified
  * (NSUnicodeStringEncoding, NSUTF16StringEncoding, NSUTF32StringEncoding)
  * produces data with a Byte Order Marker (BOM) at the start of the data.
  */
-- (NSData*) dataUsingEncoding: (NSStringEncoding)encoding
-	 allowLossyConversion: (BOOL)flag;
+- (NSData *_Nullable) dataUsingEncoding: (NSStringEncoding)encoding
+		   allowLossyConversion: (BOOL)flag;
 + (NSStringEncoding) defaultCStringEncoding;
 - (NSString*) description;
 - (NSStringEncoding) fastestEncoding;
@@ -736,9 +738,9 @@ GS_EXPORT_CLASS
  * completions.  Returns 0 if no match found, else a positive number that is
  * only accurate if outputArray was non-nil.
  */
-- (NSUInteger) completePathIntoString: (NSString**)outputName
+- (NSUInteger) completePathIntoString: (NSString * _Nullable * _Nonnull)outputName
 			caseSensitive: (BOOL)flag
-		     matchesIntoArray: (NSArray**)outputArray
+		     matchesIntoArray: (NSArray * _Nullable * _Nullable)outputArray
 			  filterTypes: (NSArray*)filterTypes;
 
 /**
@@ -752,7 +754,7 @@ GS_EXPORT_CLASS
  * This method uses [NSFileManager-fileSystemRepresentationWithPath:] to
  * perform the conversion.
  */
-- (const GSNativeChar*) fileSystemRepresentation;
+- (const GSNativeChar *_Nullable) fileSystemRepresentation;
 
 /**
  * Converts the receiver to a C string path using the character encoding
@@ -1003,15 +1005,15 @@ GS_EXPORT_CLASS
   NS_FORMAT_FUNCTION(1,2);
 
 + (instancetype) stringWithString: (NSString*)aString;
-+ (instancetype) stringWithContentsOfURL: (NSURL*)url;
-+ (instancetype) stringWithUTF8String: (const char*)bytes;
++ (instancetype _Nullable) stringWithContentsOfURL: (NSURL*)url;
++ (instancetype _Nullable) stringWithUTF8String: (const char*)bytes;
 - (instancetype) initWithFormat: (NSString*)format
                          locale: (NSDictionary*)locale, ... NS_FORMAT_FUNCTION(1,3);
 - (instancetype) initWithFormat: (NSString*)format
                          locale: (NSDictionary*)locale
                       arguments: (va_list)argList NS_FORMAT_FUNCTION(1,0);
-- (instancetype) initWithUTF8String: (const char *)bytes;
-- (instancetype) initWithContentsOfURL: (NSURL*)url;
+- (instancetype _Nullable) initWithUTF8String: (const char *)bytes;
+- (instancetype _Nullable) initWithContentsOfURL: (NSURL*)url;
 - (NSString*) substringWithRange: (NSRange)aRange;
 - (NSComparisonResult) caseInsensitiveCompare: (NSString*)aString;
 - (NSComparisonResult) compare: (NSString*)string 
@@ -1033,18 +1035,18 @@ GS_EXPORT_CLASS
              forRange: (NSRange)aRange;
 - (NSRange) lineRangeForRange: (NSRange)aRange;
 - (const char*) lossyCString;
-- (NSString*) stringByAddingPercentEscapesUsingEncoding: (NSStringEncoding)e;
+- (NSString *_Nullable) stringByAddingPercentEscapesUsingEncoding: (NSStringEncoding)e;
 - (NSString*) stringByPaddingToLength: (NSUInteger)newLength
 			   withString: (NSString*)padString
 		      startingAtIndex: (NSUInteger)padIndex;
-- (NSString*) stringByReplacingPercentEscapesUsingEncoding: (NSStringEncoding)e;
+- (NSString *_Nullable) stringByReplacingPercentEscapesUsingEncoding: (NSStringEncoding)e;
 - (NSString*) stringByTrimmingCharactersInSet: (NSCharacterSet*)aSet;
 - (const char *)UTF8String;
 #endif
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_9,GS_API_LATEST)
 - (NSString *) stringByAddingPercentEncodingWithAllowedCharacters: (NSCharacterSet *)aSet;
-- (NSString *) stringByRemovingPercentEncoding;
+- (NSString *_Nullable) stringByRemovingPercentEncoding;
 #endif
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_3,GS_API_LATEST) 
@@ -1111,11 +1113,11 @@ GS_EXPORT_CLASS
 + (instancetype) string;
 + (instancetype) stringWithCharacters: (const unichar*)characters
                                length: (NSUInteger)length;
-+ (instancetype) stringWithCString: (const char*)byteString
-                            length: (NSUInteger)length;
-+ (instancetype) stringWithCString: (const char*)byteString;
++ (instancetype _Nullable) stringWithCString: (const char*)byteString
+                                      length: (NSUInteger)length;
++ (instancetype _Nullable) stringWithCString: (const char*)byteString;
 + (instancetype) stringWithFormat: (NSString*)format, ... NS_FORMAT_FUNCTION(1,2);
-+ (instancetype) stringWithContentsOfFile: (NSString*)path;
++ (instancetype _Nullable) stringWithContentsOfFile: (NSString*)path;
 + (NSMutableString*) stringWithCapacity: (NSUInteger)capacity;
 
 // Initializing Newly Allocated Strings
@@ -1135,6 +1137,8 @@ GS_EXPORT_CLASS
 - (void) setString: (NSString*)aString;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 #ifdef __OBJC_GNUSTEP_RUNTIME_ABI__
 #  if __OBJC_GNUSTEP_RUNTIME_ABI__ >= 20

--- a/Headers/Foundation/NSURL.h
+++ b/Headers/Foundation/NSURL.h
@@ -250,7 +250,7 @@ GS_EXPORT_CLASS
  * response if the data is unrachable.<br />
  * Returns YES on success, NO on failure.
  */
-- (BOOL) checkResourceIsReachableAndReturnError: (NSError **)error;
+- (BOOL) checkResourceIsReachableAndReturnError: (NSError *_Nullable *_Nullable)error;
 #endif
 
 /**
@@ -801,4 +801,3 @@ GS_NSURLComponents_IVARS;
 #endif	/* GS_API_MACOSX */
 
 #endif	/* __NSURL_h_GNUSTEP_BASE_INCLUDE */
-

--- a/Headers/Foundation/NSURL.h
+++ b/Headers/Foundation/NSURL.h
@@ -80,7 +80,12 @@ GS_EXPORT_CLASS
   void		*_Nullable _data;
 #endif
 }
- 
+
+/**
+ * Initialize an empty URL object.
+ */
+- (nonnull instancetype) init;
+
 /**
  * Create and return a file URL with the supplied path.<br />
  * The value of aPath must be a valid filesystem path.<br />
@@ -796,5 +801,4 @@ GS_NSURLComponents_IVARS;
 #endif	/* GS_API_MACOSX */
 
 #endif	/* __NSURL_h_GNUSTEP_BASE_INCLUDE */
-
 

--- a/Headers/Foundation/NSURL.h
+++ b/Headers/Foundation/NSURL.h
@@ -40,6 +40,8 @@ extern "C" {
 @class NSDictionary;
 @class NSArray;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  URL scheme constant for use with [NSURL-initWithScheme:host:path:].
  */
@@ -73,9 +75,9 @@ GS_EXPORT_CLASS
 #if	GS_EXPOSE(NSURL)
 @private
   NSString	*_urlString;
-  NSURL		*_baseURL;
-  void		*_clients;
-  void		*_data;
+  NSURL		*_Nullable _baseURL;
+  void		*_Nullable _clients;
+  void		*_Nullable _data;
 #endif
 }
  
@@ -100,12 +102,12 @@ GS_EXPORT_CLASS
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_11, GS_API_LATEST)
 + (instancetype) fileURLWithPath: (NSString *)aPath
 		     isDirectory: (BOOL)isDir
-		   relativeToURL: (NSURL *)baseURL;
+		   relativeToURL: (NSURL *_Nullable)baseURL;
 
 /** Create and return a file URL with the supplied path, relative to a base URL.
  */
 + (instancetype) fileURLWithPath: (NSString *)aPath
-		   relativeToURL: (NSURL *)baseURL;
+		   relativeToURL: (NSURL *_Nullable)baseURL;
 #endif
 
 /**
@@ -114,12 +116,12 @@ GS_EXPORT_CLASS
  * conforming to the description (in RFC2396) of an absolute URL.<br />
  * Calls -initWithString:
  */
-+ (instancetype) URLWithString: (NSString*)aUrlString;
++ (instancetype _Nullable) URLWithString: (NSString*)aUrlString;
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_10, GS_API_LATEST)
-+ (instancetype) URLByResolvingAliasFileAtURL: (NSURL*)url
-                                      options: (NSURLBookmarkResolutionOptions)options
-                                        error: (NSError**)error;
++ (instancetype _Nullable) URLByResolvingAliasFileAtURL: (NSURL*)url
+                                                options: (NSURLBookmarkResolutionOptions)options
+                                                  error: (NSError**)error;
 #endif
 
 /**
@@ -128,8 +130,8 @@ GS_EXPORT_CLASS
  * conforming to the description (in RFC2396) of a relative URL.<br />
  * Calls -initWithString:relativeToURL:
  */
-+ (instancetype) URLWithString: (NSString*)aUrlString
-                 relativeToURL: (NSURL*)aBaseUrl;
++ (instancetype _Nullable) URLWithString: (NSString*)aUrlString
+                           relativeToURL: (NSURL *_Nullable)aBaseUrl;
 
 /**
  * Initialise as a file URL with the specified path (which must
@@ -167,7 +169,7 @@ GS_EXPORT_CLASS
  * Calls -initWithScheme:host:path:
  */
 - (instancetype) initFileURLWithPath: (NSString *)aPath
-		       relativeToURL: (NSURL *)baseURL;
+		       relativeToURL: (NSURL *_Nullable)baseURL;
 
 /**
  * Initialise as a file URL with the specified path (which must
@@ -180,7 +182,7 @@ GS_EXPORT_CLASS
  */
 - (instancetype) initFileURLWithPath: (NSString *)aPath
 			 isDirectory: (BOOL)isDir
-		       relativeToURL: (NSURL *)baseURL;
+		       relativeToURL: (NSURL *_Nullable)baseURL;
 #endif
 
 /**
@@ -194,15 +196,15 @@ GS_EXPORT_CLASS
  * Permits the 'aHost' part to contain 'username:password@host:port' or
  * 'host:port' in addition to a simple host name or address.
  */
-- (instancetype) initWithScheme: (NSString*)aScheme
-                           host: (NSString*)aHost
-                           path: (NSString*)aPath;
+- (instancetype _Nullable) initWithScheme: (NSString*)aScheme
+                                     host: (NSString *_Nullable)aHost
+                                     path: (NSString*)aPath;
 
 /**
  * Initialise as an absolute URL.<br />
  * Calls -initWithString:relativeToURL:
  */
-- (instancetype) initWithString: (NSString*)aUrlString;
+- (instancetype _Nullable) initWithString: (NSString*)aUrlString;
 
 /** <init />
  * Initialised using aUrlString and aBaseUrl.  The value of aBaseUrl
@@ -212,8 +214,8 @@ GS_EXPORT_CLASS
  * Parses an empty string as an empty path.<br />
  * If the string cannot be parsed the method returns nil.
  */
-- (instancetype) initWithString: (NSString*)aUrlString
-                  relativeToURL: (NSURL*)aBaseUrl;
+- (instancetype _Nullable) initWithString: (NSString*)aUrlString
+                            relativeToURL: (NSURL *_Nullable)aBaseUrl;
 
 #if GS_HAS_DECLARED_PROPERTIES
 @property (readonly, getter=isFileURL) BOOL fileURL;
@@ -236,7 +238,7 @@ GS_EXPORT_CLASS
  * If the receiver is a relative URL, returns its base URL.<br />
  * Otherwise, returns nil.
  */
-- (NSURL*) baseURL;
+- (NSURL *_Nullable) baseURL;
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6,GS_API_LATEST) 
 /** Attempts to load from the specified URL and provides an error
@@ -252,7 +254,7 @@ GS_EXPORT_CLASS
  * The fragment is everything in the original URL string after a '#'<br />
  * File URLs do not have fragments.
  */
-- (NSString*) fragment;
+- (NSString *_Nullable) fragment;
 
 /**
  * Returns the host portion of the receiver or nil if there is no
@@ -262,7 +264,7 @@ GS_EXPORT_CLASS
  * Returns IPv6 addresses <em>without</em> the enclosing square brackets
  * required (by RFC2732) in URL strings.
  */
-- (NSString*) host;
+- (NSString *_Nullable) host;
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6,GS_API_LATEST) 
 /** Returns the last (rightmost) path component of the receiver.
@@ -292,7 +294,7 @@ GS_EXPORT_CLASS
  *   background load operation to operate!
  * </p>
  */
-- (void) loadResourceDataNotifyingClient: (id)client
+- (void) loadResourceDataNotifyingClient: (id _Nullable)client
 			      usingCache: (BOOL)shouldUseCache;
 
 /**
@@ -302,7 +304,7 @@ GS_EXPORT_CLASS
  * but before the query.<br />
  * File URLs do not have parameters.
  */
-- (NSString*) parameterString;
+- (NSString *_Nullable) parameterString;
 
 /**
  * Returns the password portion of the receiver or nil if there is no
@@ -312,7 +314,7 @@ GS_EXPORT_CLASS
  * NB. because of its security implications it is recommended that you
  * do not use URLs with users and passwords unless necessary.
  */
-- (NSString*) password;
+- (NSString *_Nullable) password;
 
 /**
  * Returns the path portion of the receiver.<br />
@@ -346,13 +348,13 @@ GS_EXPORT_CLASS
  * Percent escape sequences in the user string are translated in GNUstep
  * but this appears to be broken in MacOS-X.
  */
-- (NSNumber*) port;
+- (NSNumber *_Nullable) port;
 
 /**
  * Asks a URL handle to return the property for the specified key and
  * returns the result.
  */
-- (id) propertyForKey: (NSString*)propertyKey;
+- (id _Nullable) propertyForKey: (NSString*)propertyKey;
 
 /**
  * Returns the query portion of the receiver or nil if there is no
@@ -361,14 +363,14 @@ GS_EXPORT_CLASS
  * but before the fragment.<br />
  * File URLs do not have queries.
  */
-- (NSString*) query;
+- (NSString *_Nullable) query;
 
 /**
  * Returns the path of the receiver, without taking any base URL into account.
  * If the receiver is an absolute URL, -relativePath is the same as -path.<br />
  * Returns nil if there is no path specified for the URL.
  */
-- (NSString*) relativePath;
+- (NSString *_Nullable) relativePath;
 
 /**
  * Returns the relative portion of the URL string.  If the receiver is not
@@ -382,7 +384,7 @@ GS_EXPORT_CLASS
  * an existing NSURLHandle can be used to provide the data, or if it should
  * be refetched.
  */
-- (NSData*) resourceDataUsingCache: (BOOL)shouldUseCache;
+- (NSData *_Nullable) resourceDataUsingCache: (BOOL)shouldUseCache;
 
 /**
  * Returns the resource specifier of the URL ... the part which lies
@@ -393,7 +395,7 @@ GS_EXPORT_CLASS
 /**
  * Returns the scheme of the receiver.
  */
-- (NSString*) scheme;
+- (NSString *_Nullable) scheme;
 
 /**
  * Calls [NSURLHandle-writeProperty:forKey:] to set the named property.
@@ -463,11 +465,11 @@ GS_EXPORT_CLASS
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
 - (BOOL) isFileReferenceURL;
 
-- (NSURL *) fileReferenceURL;
+- (NSURL *_Nullable) fileReferenceURL;
 
-- (NSURL *) filePathURL;
+- (NSURL *_Nullable) filePathURL;
 
-- (BOOL) getResourceValue: (id*)value 
+- (BOOL) getResourceValue: (id _Nullable * _Nullable)value
                    forKey: (NSString *)key 
                     error: (NSError**)error;
 #endif
@@ -487,7 +489,7 @@ GS_EXPORT_CLASS
  * NB. because of its security implications it is recommended that you
  * do not use URLs with users and passwords unless necessary.
  */
-- (NSString*) user;
+- (NSString *_Nullable) user;
 
 @end
 
@@ -517,6 +519,8 @@ GS_EXPORT_CLASS
 - (void) URL: (NSURL*)sender
   resourceDidFailLoadingWithReason: (NSString*)reason;
 @end
+
+NS_ASSUME_NONNULL_END
 
 /** URL Resource Value Constants **/
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
@@ -792,7 +796,5 @@ GS_NSURLComponents_IVARS;
 #endif	/* GS_API_MACOSX */
 
 #endif	/* __NSURL_h_GNUSTEP_BASE_INCLUDE */
-
-
 
 

--- a/Headers/module.modulemap
+++ b/Headers/module.modulemap
@@ -1,0 +1,10 @@
+module Foundation [system] {
+  header "Foundation/Foundation.h"
+
+  textual header "GNUstepBase/GSVersionMacros.h"
+  textual header "GNUstepBase/GSConfig.h"
+  textual header "GNUstepBase/GNUstep.h"
+  textual header "GNUstepBase/GSBlocks.h"
+
+  export *
+}

--- a/Source/NSFileManager.m
+++ b/Source/NSFileManager.m
@@ -194,6 +194,7 @@
 	      followSymlinks: (BOOL)follow
 		justContents: (BOOL)justContents
                   skipHidden: (BOOL)skipHidden
+                skipPackages: (BOOL)skipPackages
                 errorHandler: (GSDirEnumErrorHandler) handler
 			 for: (NSFileManager*)mgr;
 
@@ -958,6 +959,7 @@ static gs_mutex_t       classLock = GS_MUTEX_INIT_STATIC;
   NSString              *path;
   BOOL                  shouldRecurse;
   BOOL                  shouldSkipHidden;
+  BOOL                  shouldSkipPackages;
 
   [self _setLastError: nil code: 0];
 
@@ -986,6 +988,16 @@ static gs_mutex_t       classLock = GS_MUTEX_INIT_STATIC;
     {
       shouldSkipHidden = NO;
     }
+
+  if ((mask & NSDirectoryEnumerationSkipsPackageDescendants)
+    == NSDirectoryEnumerationSkipsPackageDescendants)
+    {
+      shouldSkipPackages = YES;
+    }
+  else
+    {
+      shouldSkipPackages = NO;
+    }
   
   direnum = [[GSURLEnumerator alloc]
 		       initWithDirectoryPath: path
@@ -993,6 +1005,7 @@ static gs_mutex_t       classLock = GS_MUTEX_INIT_STATIC;
                               followSymlinks: NO
                                 justContents: NO
                                   skipHidden: shouldSkipHidden
+                                skipPackages: shouldSkipPackages
                                 errorHandler: handler
                                          for: self];
 
@@ -2752,6 +2765,7 @@ static inline void gsedRelease(GSEnumeratedDirectory X)
 	      followSymlinks: (BOOL)follow
 		justContents: (BOOL)justContents
                   skipHidden: (BOOL)skipHidden
+                skipPackages: (BOOL)skipPackages
                 errorHandler: (GSDirEnumErrorHandler) handler
 			 for: (NSFileManager*)mgr
 {
@@ -2770,6 +2784,7 @@ static inline void gsedRelease(GSEnumeratedDirectory X)
       _flags.isFollowing = follow ? 1 : 0;
       _flags.justContents = justContents ? 1 : 0;
       _flags.skipHidden = skipHidden ? 1 : 0;
+      _flags.skipPackages = skipPackages ? 1 : 0;
       _errorHandler = handler;
       
       _topPath = [[NSString alloc] initWithString: path];
@@ -2830,6 +2845,7 @@ static inline void gsedRelease(GSEnumeratedDirectory X)
                       followSymlinks: follow
                         justContents: justContents
                           skipHidden: NO
+                        skipPackages: NO
                         errorHandler: NULL
                                  for: mgr];
 }
@@ -3041,6 +3057,17 @@ static inline void gsedRelease(GSEnumeratedDirectory X)
 	      if (S_IFDIR == (S_IFMT & statbuf.st_mode))
 		{
 		  _DIR  *dir_pointer;
+		  NSString *extension;
+
+		  extension = [[_currentFilePath pathExtension] lowercaseString];
+		  if (_flags.skipPackages
+		    && ([extension isEqualToString: @"app"]
+		      || [extension isEqualToString: @"bundle"]
+		      || [extension isEqualToString: @"framework"]
+		      || [extension isEqualToString: @"plugin"]))
+		    {
+		      break;
+		    }
 
 		  dir_pointer
 		    = _OPENDIR([_mgr fileSystemRepresentationWithPath:

--- a/Source/NSURL.m
+++ b/Source/NSURL.m
@@ -1744,7 +1744,66 @@ static NSUInteger	urlAlign;
                    forKey: (NSString *)key 
                     error: (NSError**)error
 {
-  // TODO: unimplemented
+  if (value != 0)
+    {
+      *value = nil;
+    }
+
+  if (NO == [self isFileURL])
+    {
+      return NO;
+    }
+
+  if (nil == key)
+    {
+      return NO;
+    }
+
+  if ([key isEqualToString: NSURLNameKey])
+    {
+      if (value != 0)
+	{
+	  *value = [self lastPathComponent];
+	}
+      return YES;
+    }
+  else if ([key isEqualToString: NSURLIsDirectoryKey]
+    || [key isEqualToString: NSURLFileSizeKey])
+    {
+      NSDictionary	*attributes;
+      NSString		*path = [self path];
+
+      if (nil == path)
+	{
+	  return NO;
+	}
+
+      attributes = [[NSFileManager defaultManager] fileAttributesAtPath: path
+							    traverseLink: YES];
+      if (nil == attributes)
+	{
+	  return NO;
+	}
+
+      if ([key isEqualToString: NSURLIsDirectoryKey])
+	{
+	  if (value != 0)
+	    {
+	      NSString	*fileType = [attributes objectForKey: NSFileType];
+
+	      *value = [NSNumber numberWithBool:
+		[fileType isEqualToString: NSFileTypeDirectory]];
+	    }
+	  return YES;
+	}
+
+      if (value != 0)
+	{
+	  *value = [attributes objectForKey: NSFileSize];
+	}
+      return (*value != nil);
+    }
+
   return NO;
 }
 

--- a/Source/NSURL.m
+++ b/Source/NSURL.m
@@ -1767,11 +1767,20 @@ static NSUInteger	urlAlign;
 	}
       return YES;
     }
-  else if ([key isEqualToString: NSURLIsDirectoryKey]
+  else if ([key isEqualToString: NSURLIsRegularFileKey]
+    || [key isEqualToString: NSURLIsDirectoryKey]
+    || [key isEqualToString: NSURLIsSymbolicLinkKey]
+    || [key isEqualToString: NSURLIsPackageKey]
+    || [key isEqualToString: NSURLIsHiddenKey]
+    || [key isEqualToString: NSURLCreationDateKey]
+    || [key isEqualToString: NSURLContentAccessDateKey]
+    || [key isEqualToString: NSURLContentModificationDateKey]
+    || [key isEqualToString: NSURLAttributeModificationDateKey]
     || [key isEqualToString: NSURLFileSizeKey])
     {
       NSDictionary	*attributes;
       NSString		*path = [self path];
+      NSString		*fileType;
 
       if (nil == path)
 	{
@@ -1779,22 +1788,94 @@ static NSUInteger	urlAlign;
 	}
 
       attributes = [[NSFileManager defaultManager] fileAttributesAtPath: path
-							    traverseLink: YES];
+							    traverseLink: NO];
       if (nil == attributes)
 	{
 	  return NO;
 	}
 
-      if ([key isEqualToString: NSURLIsDirectoryKey])
+      fileType = [attributes objectForKey: NSFileType];
+      if ([key isEqualToString: NSURLIsRegularFileKey])
 	{
 	  if (value != 0)
 	    {
-	      NSString	*fileType = [attributes objectForKey: NSFileType];
-
+	      *value = [NSNumber numberWithBool:
+		[fileType isEqualToString: NSFileTypeRegular]];
+	    }
+	  return YES;
+	}
+      else if ([key isEqualToString: NSURLIsDirectoryKey])
+	{
+	  if (value != 0)
+	    {
 	      *value = [NSNumber numberWithBool:
 		[fileType isEqualToString: NSFileTypeDirectory]];
 	    }
 	  return YES;
+	}
+      else if ([key isEqualToString: NSURLIsSymbolicLinkKey])
+	{
+	  if (value != 0)
+	    {
+	      *value = [NSNumber numberWithBool:
+		[fileType isEqualToString: NSFileTypeSymbolicLink]];
+	    }
+	  return YES;
+	}
+      else if ([key isEqualToString: NSURLIsPackageKey])
+	{
+	  if (value != 0)
+	    {
+	      NSString	*extension = [[path pathExtension] lowercaseString];
+
+	      *value = [NSNumber numberWithBool:
+		[extension isEqualToString: @"app"]
+		|| [extension isEqualToString: @"bundle"]
+		|| [extension isEqualToString: @"framework"]
+		|| [extension isEqualToString: @"plugin"]];
+	    }
+	  return YES;
+	}
+      else if ([key isEqualToString: NSURLIsHiddenKey])
+	{
+	  if (value != 0)
+	    {
+	      *value = [NSNumber numberWithBool:
+		[[path lastPathComponent] hasPrefix: @"."]];
+	    }
+	  return YES;
+	}
+      else if ([key isEqualToString: NSURLCreationDateKey])
+	{
+	  if (value != 0)
+	    {
+	      *value = [attributes objectForKey: NSFileCreationDate];
+	    }
+	  return (*value != nil);
+	}
+      else if ([key isEqualToString: NSURLContentAccessDateKey])
+	{
+	  if (value != 0)
+	    {
+	      *value = [attributes objectForKey: NSFileModificationDate];
+	    }
+	  return (*value != nil);
+	}
+      else if ([key isEqualToString: NSURLContentModificationDateKey])
+	{
+	  if (value != 0)
+	    {
+	      *value = [attributes objectForKey: NSFileModificationDate];
+	    }
+	  return (*value != nil);
+	}
+      else if ([key isEqualToString: NSURLAttributeModificationDateKey])
+	{
+	  if (value != 0)
+	    {
+	      *value = [attributes objectForKey: NSFileModificationDate];
+	    }
+	  return (*value != nil);
 	}
 
       if (value != 0)

--- a/Source/NSURL.m
+++ b/Source/NSURL.m
@@ -727,6 +727,11 @@ static NSUInteger	urlAlign;
   return nil;
 }
 
+- (id) init
+{
+  return [self initWithString: @""];
+}
+
 - (id) initFileURLWithPath: (NSString *)aPath
 {
   /* isDirectory flag will be overwritten if a directory exists. */

--- a/Tests/base/NSFileManager/general.m
+++ b/Tests/base/NSFileManager/general.m
@@ -287,6 +287,12 @@ int main()
 
   PASS([mgr createDirectoryAtPath: @"subdir" attributes: nil],
        "NSFileManager can create a subdirectory");
+  PASS([mgr createDirectoryAtPath: @"Sample.app" attributes: nil],
+       "NSFileManager can create a package directory");
+  PASS([mgr createFileAtPath: @"Sample.app/Info.plist"
+		    contents: [@"{}" dataUsingEncoding: NSASCIIStringEncoding]
+		  attributes: nil],
+       "NSFileManager can create a package leaf");
   
   {
     NSURL			*u;
@@ -308,6 +314,31 @@ int main()
 	  found++;
       }
     PASS(2 == found, "URL enumerator finds expected file and subdirectory")
+  }
+
+  {
+    NSURL			*u;
+    NSDirectoryEnumerator	*e;
+    BOOL			foundPackage = NO;
+    BOOL			foundPackageLeaf = NO;
+
+    e = [mgr enumeratorAtURL: [NSURL fileURLWithPath: @"."]
+  includingPropertiesForKeys: nil
+		     options: NSDirectoryEnumerationSkipsPackageDescendants
+		errorHandler: nil];
+
+    while (nil != (u = [e nextObject]))
+      {
+	NSString	*c = [[u path] lastPathComponent];
+
+	if ([c isEqualToString: @"Sample.app"])
+	  foundPackage = YES;
+	if ([c isEqualToString: @"Info.plist"])
+	  foundPackageLeaf = YES;
+      }
+    PASS(foundPackage, "URL enumerator lists package directory")
+    PASS(!foundPackageLeaf,
+      "URL enumerator skips package descendants when requested")
   }
 
   PASS([mgr changeCurrentDirectoryPath: @"subdir"], 

--- a/Tests/base/NSURL/resourceValues.m
+++ b/Tests/base/NSURL/resourceValues.m
@@ -1,0 +1,103 @@
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#import "ObjectTesting.h"
+
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
+
+static BOOL
+getValue(NSURL *url, NSString *key, id *value)
+{
+  NSError *error = nil;
+
+  return [url getResourceValue: value forKey: key error: &error];
+}
+
+int
+main()
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSFileManager *fm = [NSFileManager defaultManager];
+  NSString *root = [NSTemporaryDirectory()
+    stringByAppendingPathComponent: @"NSURLResourceValuesTest"];
+  NSString *filePath = [root stringByAppendingPathComponent: @"file.txt"];
+  NSString *hiddenPath = [root stringByAppendingPathComponent: @".hidden"];
+  NSString *dirPath = [root stringByAppendingPathComponent: @"Sample.app"];
+  NSString *linkPath = [root stringByAppendingPathComponent: @"link.txt"];
+  NSURL *fileURL;
+  NSURL *hiddenURL;
+  NSURL *dirURL;
+  NSURL *linkURL;
+  id value = nil;
+
+  START_SET("NSURL resource values");
+
+  [fm removeFileAtPath: root handler: nil];
+  PASS([fm createDirectoryAtPath: root attributes: nil],
+    "created resource value test directory");
+  PASS([@"hello" writeToFile: filePath atomically: YES],
+    "created regular file");
+  PASS([@"secret" writeToFile: hiddenPath atomically: YES],
+    "created hidden file");
+  PASS([fm createDirectoryAtPath: dirPath attributes: nil],
+    "created package directory");
+#if !defined(_WIN32)
+  PASS(0 == symlink([filePath fileSystemRepresentation],
+    [linkPath fileSystemRepresentation]), "created symbolic link");
+#endif
+
+  fileURL = [NSURL fileURLWithPath: filePath];
+  hiddenURL = [NSURL fileURLWithPath: hiddenPath];
+  dirURL = [NSURL fileURLWithPath: dirPath];
+  linkURL = [NSURL fileURLWithPath: linkPath];
+
+  PASS(getValue(fileURL, NSURLNameKey, &value), "NSURLNameKey succeeds");
+  PASS_EQUAL(value, @"file.txt", "NSURLNameKey returns last path component");
+
+  PASS(getValue(fileURL, NSURLIsRegularFileKey, &value),
+    "NSURLIsRegularFileKey succeeds");
+  PASS_EQUAL(value, [NSNumber numberWithBool: YES],
+    "regular file reports regular");
+  PASS(getValue(fileURL, NSURLIsDirectoryKey, &value),
+    "NSURLIsDirectoryKey succeeds");
+  PASS_EQUAL(value, [NSNumber numberWithBool: NO],
+    "regular file is not a directory");
+  PASS(getValue(fileURL, NSURLFileSizeKey, &value),
+    "NSURLFileSizeKey succeeds");
+  PASS_EQUAL(value, [NSNumber numberWithUnsignedLongLong: 5],
+    "file size is reported");
+
+  PASS(getValue(dirURL, NSURLIsDirectoryKey, &value),
+    "directory NSURLIsDirectoryKey succeeds");
+  PASS_EQUAL(value, [NSNumber numberWithBool: YES],
+    "directory reports directory");
+  PASS(getValue(dirURL, NSURLIsPackageKey, &value),
+    "NSURLIsPackageKey succeeds");
+  PASS_EQUAL(value, [NSNumber numberWithBool: YES],
+    ".app directory reports package");
+
+  PASS(getValue(hiddenURL, NSURLIsHiddenKey, &value),
+    "NSURLIsHiddenKey succeeds");
+  PASS_EQUAL(value, [NSNumber numberWithBool: YES],
+    "dot file reports hidden");
+
+#if !defined(_WIN32)
+  PASS(getValue(linkURL, NSURLIsSymbolicLinkKey, &value),
+    "NSURLIsSymbolicLinkKey succeeds");
+  PASS_EQUAL(value, [NSNumber numberWithBool: YES],
+    "symbolic link reports symbolic link");
+#endif
+
+  PASS(getValue(fileURL, NSURLContentModificationDateKey, &value),
+    "NSURLContentModificationDateKey succeeds");
+  PASS([value isKindOfClass: [NSDate class]],
+    "modification date is an NSDate");
+
+  [fm removeFileAtPath: root handler: nil];
+
+  END_SET("NSURL resource values");
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- Annotate the three NSFileHandle URL factory NSError out-parameters as nullable storage.
- Keep the change scoped to the retained URL factory family.

## Validation
- scripts/run-phase15i-nsfilehandle-import-shape-audit.sh
- scripts/run-phase15i-nsfilehandle-nserror-runtime-gate.sh
- scripts/run-phase15i-nsfilehandle-promotion-validation.sh
- PATH=/usr/GNUstep/System/Tools:$PATH make check testobj=NSFileHandle/general.m