### PR TITLE
Fix KVO bugs related to cyclical observer dependencies (#608)

### DIFF
--- a/Source/NSKVOInternal.h
+++ b/Source/NSKVOInternal.h
@@ -106,7 +106,8 @@
   NSMutableDictionary<NSString *, NSMutableArray<_NSKVOKeyObserver *> *>
                            *_keyObserverMap;
   NSInteger                 _dependencyDepth;
-  NSMutableSet<NSString *> *_existingDependentKeys;
+  NSMutableSet<id>         *_existingDependentKeys;
+  NSMutableSet<id>         *_dependencyAncestorKeys;
   gs_mutex_t                _lock;
 }
 - (instancetype)init;

--- a/Source/NSKVOSupport.m
+++ b/Source/NSKVOSupport.m
@@ -207,31 +207,70 @@ _NSKVOKeypathObserver ()
   [super dealloc];
 }
 
-- (void) pushDependencyStack
+- (void) beginDependencyExpansionScope
 {
   GS_MUTEX_LOCK(_lock);
   if (_dependencyDepth == 0)
     {
       _existingDependentKeys = [NSMutableSet new];
+      _dependencyAncestorKeys = [NSMutableSet new];
     }
   ++_dependencyDepth;
   GS_MUTEX_UNLOCK(_lock);
 }
 
-- (BOOL) lockDependentKeypath: (NSString *)keypath
+- (id) dependencyKeyForObject: (id)object key: (NSString *)key
 {
+  return [NSArray arrayWithObjects:
+                   (object ?: [NSNull null]),
+                   (key ?: @""),
+                   nil];
+}
+
+- (void) pushAncestorForNode: (_NSKVOKeyObserver *)keyObserver
+{
+  id ancestorKey = [self dependencyKeyForObject: keyObserver.object
+                                            key: keyObserver.key];
   GS_MUTEX_LOCK(_lock);
-  if ([_existingDependentKeys containsObject:keypath])
+  [_dependencyAncestorKeys addObject: ancestorKey];
+  GS_MUTEX_UNLOCK(_lock);
+}
+
+- (void) popAncestorForNode: (_NSKVOKeyObserver *)keyObserver
+{
+  id ancestorKey = [self dependencyKeyForObject: keyObserver.object
+                                            key: keyObserver.key];
+  GS_MUTEX_LOCK(_lock);
+  [_dependencyAncestorKeys removeObject: ancestorKey];
+  GS_MUTEX_UNLOCK(_lock);
+}
+
+/// Mark keypath as visited in the current dependency-expansion scope.
+- (BOOL) markDependentKeypathVisited: (NSString *)keypath
+                             forNode: (_NSKVOKeyObserver *)keyObserver
+{
+  NSString *dependentKey;
+  NSString *unusedRemainder;
+  id visitToken;
+
+  dependentKey = _NSKVCSplitKeypath(keypath, &unusedRemainder);
+  visitToken = [self dependencyKeyForObject: keyObserver.object
+                                        key: dependentKey];
+  GS_MUTEX_LOCK(_lock);
+  if ([_existingDependentKeys containsObject:visitToken])
     {
+      BOOL isCycle = [_dependencyAncestorKeys containsObject: visitToken];
       GS_MUTEX_UNLOCK(_lock);
-      return NO;
+      // If it's on the active ancestor stack, treat as true cycle and dedup.
+      // If it's already visited but not on stack, allow expansion to continue.
+      return !isCycle;
     }
-  [_existingDependentKeys addObject:keypath];
+  [_existingDependentKeys addObject:visitToken];
   GS_MUTEX_UNLOCK(_lock);
   return YES;
 }
 
-- (void) popDependencyStack
+- (void) endDependencyExpansionScope
 {
   GS_MUTEX_LOCK(_lock);
   --_dependencyDepth;
@@ -239,6 +278,8 @@ _NSKVOKeypathObserver ()
     {
       [_existingDependentKeys release];
       _existingDependentKeys = nil;
+      [_dependencyAncestorKeys release];
+      _dependencyAncestorKeys = nil;
     }
   GS_MUTEX_UNLOCK(_lock);
 }
@@ -344,28 +385,39 @@ _addNestedObserversAndOptionallyDependents(_NSKVOKeyObserver *keyObserver,
           NSArray 		*affectedKeyObservers;
           NSMutableArray 	*dependentObservers;
 
+          affectedKeyObservers = keyObserver.affectedObservers;
+
           /* affectedKeyObservers is the list of observers that must be notified
            * of changes. If we have descendants, we have to add ourselves to the
            * growing list of affected keys. If not, we must pass it along
            * unmodified. (This is a minor optimization: we don't need to signal
-           * for our own reconstruction
-           *  if we have no subpath observers.)
-	   */
-          affectedKeyObservers = (keyObserver.restOfKeypath
-	    ? ([keyObserver.affectedObservers arrayByAddingObject:keyObserver]
-	    ?: [NSArray arrayWithObject:keyObserver])
-	    : keyObserver.affectedObservers);
+           * for our own reconstruction if we have no subpath observers.)
+           */
+          if (keyObserver.restOfKeypath)
+          {
+            if (affectedKeyObservers)
+              {
+                affectedKeyObservers =
+                  [affectedKeyObservers arrayByAddingObject:keyObserver];
+              }
+            else
+              {
+                affectedKeyObservers = [NSArray arrayWithObject:keyObserver];
+              }
+          }
 
-          [observationInfo pushDependencyStack];
-          /* Don't allow our own key to be recreated.
-	   */
-          [observationInfo lockDependentKeypath:keyObserver.key];
+          [observationInfo beginDependencyExpansionScope];
+          [observationInfo pushAncestorForNode: keyObserver];
+          /* Don't allow our own key to be recreated. */
+          [observationInfo markDependentKeypathVisited:keyObserver.key
+                                               forNode:keyObserver];
 
           dependentObservers =
             [NSMutableArray arrayWithCapacity:[valueInfluencingKeys count]];
           for (NSString *dependentKeypath in valueInfluencingKeys)
             {
-              if ([observationInfo lockDependentKeypath:dependentKeypath])
+              if ([observationInfo markDependentKeypathVisited:dependentKeypath
+                                                       forNode:keyObserver])
                 {
                   _NSKVOKeyObserver *dependentObserver
                     = _addKeypathObserver(object, dependentKeypath,
@@ -376,10 +428,14 @@ _addNestedObserversAndOptionallyDependents(_NSKVOKeyObserver *keyObserver,
                       [dependentObservers addObject:dependentObserver];
                     }
                 }
+              else
+                {
+                }
             }
           keyObserver.dependentObservers = dependentObservers;
 
-          [observationInfo popDependencyStack];
+          [observationInfo popAncestorForNode: keyObserver];
+          [observationInfo endDependencyExpansionScope];
         }
     }
   else
@@ -458,6 +514,7 @@ _addKeypathObserver(id object, NSString *keypath,
     {
       _addNestedObserversAndOptionallyDependents(keyObserver, true);
       _addKeyObserver(keyObserver);
+    } else {
     }
 
   return keyObserver;
@@ -847,7 +904,8 @@ _dispatchWillChange(id notifyingObject, NSString *key,
 {
   _NSKVOObservationInfo *observationInfo
     = (__bridge _NSKVOObservationInfo *) [notifyingObject observationInfo];
-  for (_NSKVOKeyObserver *keyObserver in [observationInfo observersForKey:key])
+  NSArray<_NSKVOKeyObserver *> *observers = [observationInfo observersForKey:key];
+  for (_NSKVOKeyObserver *keyObserver in observers)
     {
       _NSKVOKeypathObserver *keypathObserver;
 

--- a/Source/NSKVOSupport.m
+++ b/Source/NSKVOSupport.m
@@ -207,6 +207,8 @@ _NSKVOKeypathObserver ()
   [super dealloc];
 }
 
+// While exploring the observer graph, for dependencies, we use this to 
+// detect cycles to prevent infinite recursion. 
 - (void) beginDependencyExpansionScope
 {
   GS_MUTEX_LOCK(_lock);
@@ -219,6 +221,8 @@ _NSKVOKeypathObserver ()
   GS_MUTEX_UNLOCK(_lock);
 }
 
+/* Nodes (observable values) in the observer graph are uniquely identified
+ * using a combination of the object pointer and the name of the value */
 - (id) dependencyKeyForObject: (id)object key: (NSString *)key
 {
   return [NSArray arrayWithObjects:
@@ -227,7 +231,7 @@ _NSKVOKeypathObserver ()
                    nil];
 }
 
-- (void) pushAncestorForNode: (_NSKVOKeyObserver *)keyObserver
+- (void) pushObserverToCurrentAncestorStack: (_NSKVOKeyObserver *)keyObserver
 {
   id ancestorKey = [self dependencyKeyForObject: keyObserver.object
                                             key: keyObserver.key];
@@ -236,7 +240,7 @@ _NSKVOKeypathObserver ()
   GS_MUTEX_UNLOCK(_lock);
 }
 
-- (void) popAncestorForNode: (_NSKVOKeyObserver *)keyObserver
+- (void) popObserverFromCurrentAncestorStack: (_NSKVOKeyObserver *)keyObserver
 {
   id ancestorKey = [self dependencyKeyForObject: keyObserver.object
                                             key: keyObserver.key];
@@ -246,7 +250,7 @@ _NSKVOKeypathObserver ()
 }
 
 /// Mark keypath as visited in the current dependency-expansion scope.
-- (BOOL) markDependentKeypathVisited: (NSString *)keypath
+- (BOOL) checkDependencyForCycle: (NSString *)keypath
                              forNode: (_NSKVOKeyObserver *)keyObserver
 {
   NSString *dependentKey;
@@ -261,7 +265,7 @@ _NSKVOKeypathObserver ()
     {
       BOOL isCycle = [_dependencyAncestorKeys containsObject: visitToken];
       GS_MUTEX_UNLOCK(_lock);
-      // If it's on the active ancestor stack, treat as true cycle and dedup.
+      // If it's on the current ancestor stack, treat as cycle and dedup.
       // If it's already visited but not on stack, allow expansion to continue.
       return !isCycle;
     }
@@ -407,16 +411,17 @@ _addNestedObserversAndOptionallyDependents(_NSKVOKeyObserver *keyObserver,
           }
 
           [observationInfo beginDependencyExpansionScope];
-          [observationInfo pushAncestorForNode: keyObserver];
+          [observationInfo pushObserverToCurrentAncestorStack: keyObserver];
           /* Don't allow our own key to be recreated. */
-          [observationInfo markDependentKeypathVisited:keyObserver.key
+          [observationInfo checkDependencyForCycle:keyObserver.key
                                                forNode:keyObserver];
 
+          /* The observers, which affect us */
           dependentObservers =
             [NSMutableArray arrayWithCapacity:[valueInfluencingKeys count]];
           for (NSString *dependentKeypath in valueInfluencingKeys)
             {
-              if ([observationInfo markDependentKeypathVisited:dependentKeypath
+              if ([observationInfo checkDependencyForCycle:dependentKeypath
                                                        forNode:keyObserver])
                 {
                   _NSKVOKeyObserver *dependentObserver
@@ -428,13 +433,10 @@ _addNestedObserversAndOptionallyDependents(_NSKVOKeyObserver *keyObserver,
                       [dependentObservers addObject:dependentObserver];
                     }
                 }
-              else
-                {
-                }
             }
           keyObserver.dependentObservers = dependentObservers;
 
-          [observationInfo popAncestorForNode: keyObserver];
+          [observationInfo popObserverFromCurrentAncestorStack: keyObserver];
           [observationInfo endDependencyExpansionScope];
         }
     }

--- a/Tests/base/NSKVOSupport/ComplexNilAndCycleTest.m
+++ b/Tests/base/NSKVOSupport/ComplexNilAndCycleTest.m
@@ -106,6 +106,11 @@ int main(void)
 {
   CREATE_AUTORELEASE_POOL(pool);
 
+#if !defined(clang)
+  testHopeful = YES;
+#endif
+
+// testcases here
   BNode *b = AUTORELEASE([BNode new]);
   b.e = 1;
 
@@ -164,6 +169,11 @@ int main(void)
   PASS(obs->calls == 1, "updating e should still notify");
 
   [root removeObserver: obs forKeyPath: @"x"];
+  
+#if !defined(clang)
+  testHopeful = NO;
+#endif
+
   DESTROY(pool);
   return 0;
 }

--- a/Tests/base/NSKVOSupport/ComplexNilAndCycleTest.m
+++ b/Tests/base/NSKVOSupport/ComplexNilAndCycleTest.m
@@ -1,0 +1,149 @@
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+@class BNode;
+
+@interface CNode : NSObject
+{
+  NSInteger _f;
+}
+@property (nonatomic, retain) NSObject *d;
+@property (nonatomic, retain) BNode *b;
+@property (nonatomic, assign) NSInteger f;
+@end
+@implementation CNode
+- (NSInteger) f
+{
+  return _f;
+}
+- (void) setF: (NSInteger)f
+{
+  BOOL notifyD = (self.d != nil);
+  [self willChangeValueForKey: @"f"];
+  if (notifyD)
+    {
+      [self willChangeValueForKey: @"d"];
+    }
+  _f = f;
+  if (notifyD)
+    {
+      [self didChangeValueForKey: @"d"];
+    }
+  [self didChangeValueForKey: @"f"];
+}
+@end
+
+@interface BNode : NSObject
+@property (nonatomic, retain) CNode *c;
+@property (nonatomic, assign) NSInteger e;
+@end
+@implementation BNode
+@end
+
+@interface ANode : NSObject
+@property (nonatomic, retain) BNode *b;
+@property (nonatomic, retain) CNode *c;
+@end
+@implementation ANode
+@end
+
+@interface RootNode : NSObject
+@property (nonatomic, retain) ANode *a;
+@property (nonatomic, readonly) BOOL x;
+@end
+@implementation RootNode
++ (NSSet *) keyPathsForValuesAffectingX
+{
+  return [NSSet setWithObjects: @"a.b.c.d", @"a.c.b.e", nil];
+}
+- (BOOL) x
+{
+  return (self.a.b.c.d != nil) || (self.a.c.b.e > 0);
+}
+@end
+
+@interface TestObserver : NSObject
+{
+@public
+  NSUInteger calls;
+}
+@end
+@implementation TestObserver
+- (void) observeValueForKeyPath: (NSString *)keyPath
+                       ofObject: (id)object
+                         change: (NSDictionary *)change
+                        context: (void *)context
+{
+  (void)keyPath;
+  (void)object;
+  (void)change;
+  (void)context;
+  calls++;
+}
+@end
+
+int main(void)
+{
+  CREATE_AUTORELEASE_POOL(pool);
+
+  BNode *b = AUTORELEASE([BNode new]);
+  b.e = 1;
+
+  CNode *cForA = AUTORELEASE([CNode new]);
+  cForA.b = b;
+
+  CNode *cForB = AUTORELEASE([CNode new]);
+  cForB.d = nil;
+  cForB.f = 10;
+
+  ANode *a = AUTORELEASE([ANode new]);
+  a.b = b;
+  a.c = cForA;
+  b.c = cForB;
+
+  RootNode *root = AUTORELEASE([RootNode new]);
+  root.a = a;
+
+  TestObserver *obs = AUTORELEASE([TestObserver new]);
+  [root addObserver: obs forKeyPath: @"x" options: 0 context: NULL];
+
+  obs->calls = 0;
+  b.e = 2;
+  PASS(obs->calls == 1, "updating e should trigger notification");
+
+  CNode *newCForB = AUTORELEASE([CNode new]);
+  newCForB.d = AUTORELEASE([NSObject new]);
+  newCForB.f = 100;
+  obs->calls = 0;
+  b.c = newCForB;
+  PASS(obs->calls == 1,
+       "updating c with a new object where d is non-nil should trigger notification");
+
+  obs->calls = 0;
+  b.e = 3;
+  PASS(obs->calls == 1, "updating e should still notify");
+
+  obs->calls = 0;
+  newCForB.f = 101;
+  PASS(obs->calls == 1, "updating f should notify");
+
+  obs->calls = 0;
+  newCForB.d = nil;
+  PASS(obs->calls == 1, "setting d to nil again should notify");
+
+  obs->calls = 0;
+  newCForB.f = 102;
+  PASS(obs->calls == 0, "updating f should not notify after d became nil");
+
+  obs->calls = 0;
+  b.c = nil;
+  PASS(obs->calls == 1, "setting c to nil should notify");
+
+  obs->calls = 0;
+  b.e = 4;
+  PASS(obs->calls == 1, "updating e should still notify");
+
+  [root removeObserver: obs forKeyPath: @"x"];
+  DESTROY(pool);
+  return 0;
+}

--- a/Tests/base/NSKVOSupport/ComplexNilAndCycleTest.m
+++ b/Tests/base/NSKVOSupport/ComplexNilAndCycleTest.m
@@ -6,12 +6,16 @@
 @interface CNode : NSObject
 {
   NSInteger _f;
+  NSObject *_d;
+  BNode *_b;
 }
 @property (nonatomic, retain) NSObject *d;
 @property (nonatomic, retain) BNode *b;
 @property (nonatomic, assign) NSInteger f;
 @end
 @implementation CNode
+@synthesize d = _d;
+@synthesize b = _b;
 - (NSInteger) f
 {
   return _f;
@@ -34,24 +38,40 @@
 @end
 
 @interface BNode : NSObject
+{
+  CNode *_c;
+  NSInteger _e;
+}
 @property (nonatomic, retain) CNode *c;
 @property (nonatomic, assign) NSInteger e;
 @end
 @implementation BNode
+@synthesize c = _c;
+@synthesize e = _e;
 @end
 
 @interface ANode : NSObject
+{
+  BNode *_b;
+  CNode *_c;
+}
 @property (nonatomic, retain) BNode *b;
 @property (nonatomic, retain) CNode *c;
 @end
 @implementation ANode
+@synthesize b = _b;
+@synthesize c = _c;
 @end
 
 @interface RootNode : NSObject
+{
+  ANode *_a;
+}
 @property (nonatomic, retain) ANode *a;
 @property (nonatomic, readonly) BOOL x;
 @end
 @implementation RootNode
+@synthesize a = _a;
 + (NSSet *) keyPathsForValuesAffectingX
 {
   return [NSSet setWithObjects: @"a.b.c.d", @"a.c.b.e", nil];

--- a/Tests/base/NSKVOSupport/branchVisitedScope.m
+++ b/Tests/base/NSKVOSupport/branchVisitedScope.m
@@ -1,0 +1,114 @@
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+@interface BVSLeaf : NSObject
+@property (nonatomic, assign) NSInteger value;
+@property (nonatomic, assign) BOOL flag;
+@end
+
+@implementation BVSLeaf
+@end
+
+@interface BVSNode : NSObject
+@property (nonatomic, retain) BVSLeaf *leaf;
+@property (nonatomic, readonly) NSInteger score;
+@end
+
+@implementation BVSNode
++ (NSSet *) keyPathsForValuesAffectingScore
+{
+  return [NSSet setWithObject: @"leaf.value"];
+}
+- (NSInteger) score
+{
+  return self.leaf.value;
+}
+@end
+
+@interface BVSHolder : NSObject
+@property (nonatomic, retain) BVSNode *node;
+@end
+@implementation BVSHolder
+@end
+
+@interface BVSRoot : NSObject
+@property (nonatomic, retain) BVSHolder *holder;
+@property (nonatomic, readonly) BVSNode *selected;
+@property (nonatomic, readonly) BOOL derived;
+@end
+
+@implementation BVSRoot
++ (NSSet *) keyPathsForValuesAffectingSelected
+{
+  return [NSSet setWithObject: @"holder.node"];
+}
++ (NSSet *) keyPathsForValuesAffectingDerived
+{
+  return [NSSet setWithObjects: @"selected.score", @"selected.leaf.flag", nil];
+}
+- (BVSNode *) selected
+{
+  return self.holder.node;
+}
+- (BOOL) derived
+{
+  return (self.selected.score > 0) && self.selected.leaf.flag;
+}
+@end
+
+@interface BVSObserver : NSObject
+{
+@public
+  NSUInteger calls;
+}
+@end
+
+@implementation BVSObserver
+- (void) observeValueForKeyPath: (NSString *)keyPath
+                       ofObject: (id)object
+                         change: (NSDictionary *)change
+                        context: (void *)context
+{
+  (void)keyPath;
+  (void)object;
+  (void)change;
+  (void)context;
+  calls++;
+}
+@end
+
+int main(void)
+{
+  CREATE_AUTORELEASE_POOL(pool);
+
+  BVSRoot *root = AUTORELEASE([BVSRoot new]);
+  root.holder = AUTORELEASE([BVSHolder new]);
+
+  BVSLeaf *leaf = AUTORELEASE([BVSLeaf new]);
+  leaf.value = 1;
+  leaf.flag = YES;
+  BVSNode *node = AUTORELEASE([BVSNode new]);
+  node.leaf = leaf;
+
+  BVSObserver *observer = AUTORELEASE([BVSObserver new]);
+  [root addObserver: observer
+         forKeyPath: @"derived"
+            options: 0
+            context: NULL];
+
+  // Repeatedly rematerialize the shared dependency path.
+  for (NSUInteger i = 0; i < 25; i++)
+    {
+      root.holder.node = nil;
+      root.holder.node = node;
+    }
+
+  observer->calls = 0;
+  leaf.value = 2;
+  PASS(observer->calls == 1,
+       "Single leaf mutation should emit one derived notification");
+
+  [root removeObserver: observer forKeyPath: @"derived"];
+  DESTROY(pool);
+  return 0;
+}

--- a/Tests/base/NSKVOSupport/branchVisitedScope.m
+++ b/Tests/base/NSKVOSupport/branchVisitedScope.m
@@ -2,19 +2,29 @@
 #import "ObjectTesting.h"
 
 @interface BVSLeaf : NSObject
+{
+  NSInteger _value;
+  BOOL _flag;
+}
 @property (nonatomic, assign) NSInteger value;
 @property (nonatomic, assign) BOOL flag;
 @end
 
 @implementation BVSLeaf
+@synthesize value = _value;
+@synthesize flag = _flag;
 @end
 
 @interface BVSNode : NSObject
+{
+  BVSLeaf *_leaf;
+}
 @property (nonatomic, retain) BVSLeaf *leaf;
 @property (nonatomic, readonly) NSInteger score;
 @end
 
 @implementation BVSNode
+@synthesize leaf = _leaf;
 + (NSSet *) keyPathsForValuesAffectingScore
 {
   return [NSSet setWithObject: @"leaf.value"];
@@ -26,18 +36,26 @@
 @end
 
 @interface BVSHolder : NSObject
+{
+  BVSNode *_node;
+}
 @property (nonatomic, retain) BVSNode *node;
 @end
 @implementation BVSHolder
+@synthesize node = _node;
 @end
 
 @interface BVSRoot : NSObject
+{
+  BVSHolder *_holder;
+}
 @property (nonatomic, retain) BVSHolder *holder;
 @property (nonatomic, readonly) BVSNode *selected;
 @property (nonatomic, readonly) BOOL derived;
 @end
 
 @implementation BVSRoot
+@synthesize holder = _holder;
 + (NSSet *) keyPathsForValuesAffectingSelected
 {
   return [NSSet setWithObject: @"holder.node"];
@@ -97,7 +115,8 @@ int main(void)
             context: NULL];
 
   // Repeatedly rematerialize the shared dependency path.
-  for (NSUInteger i = 0; i < 25; i++)
+  NSUInteger i;
+  for (i = 0; i < 25; i++)
     {
       root.holder.node = nil;
       root.holder.node = node;

--- a/Tests/base/NSKVOSupport/branchVisitedScope.m
+++ b/Tests/base/NSKVOSupport/branchVisitedScope.m
@@ -99,6 +99,10 @@ int main(void)
 {
   CREATE_AUTORELEASE_POOL(pool);
 
+#if !defined(clang)
+  testHopeful = YES;
+#endif
+
   BVSRoot *root = AUTORELEASE([BVSRoot new]);
   root.holder = AUTORELEASE([BVSHolder new]);
 
@@ -128,6 +132,11 @@ int main(void)
        "Single leaf mutation should emit one derived notification");
 
   [root removeObserver: observer forKeyPath: @"derived"];
+  
+#if !defined(clang)
+  testHopeful = NO;
+#endif
+
   DESTROY(pool);
   return 0;
 }

--- a/Tests/base/NSKVOSupport/cyclicalDependencies.m
+++ b/Tests/base/NSKVOSupport/cyclicalDependencies.m
@@ -111,6 +111,10 @@ int main(void)
 {
   CREATE_AUTORELEASE_POOL(pool);
 
+#if !defined(clang)
+  testHopeful = YES;
+#endif
+
   {
     CDODirectCycleRoot *root = AUTORELEASE([CDODirectCycleRoot new]);
     CDOObserver *observer = AUTORELEASE([CDOObserver new]);
@@ -140,6 +144,10 @@ int main(void)
 
     [root removeObserver: observer forKeyPath: @"derived"];
   }
+
+#if !defined(clang)
+  testHopeful = NO;
+#endif
 
   DESTROY(pool);
   return 0;

--- a/Tests/base/NSKVOSupport/cyclicalDependencies.m
+++ b/Tests/base/NSKVOSupport/cyclicalDependencies.m
@@ -23,6 +23,9 @@
 @end
 
 @interface CDODirectCycleRoot : NSObject
+{
+  NSInteger _leaf;
+}
 @property (nonatomic, assign) NSInteger leaf;
 @property (nonatomic, readonly) NSInteger a;
 @property (nonatomic, readonly) NSInteger b;
@@ -30,6 +33,7 @@
 @end
 
 @implementation CDODirectCycleRoot
+@synthesize leaf = _leaf;
 + (NSSet *) keyPathsForValuesAffectingA
 {
   return [NSSet setWithObject: @"b"];
@@ -57,6 +61,9 @@
 @end
 
 @interface CDOThreeCycleRoot : NSObject
+{
+  NSInteger _leaf;
+}
 @property (nonatomic, assign) NSInteger leaf;
 @property (nonatomic, readonly) NSInteger x;
 @property (nonatomic, readonly) NSInteger y;
@@ -65,6 +72,7 @@
 @end
 
 @implementation CDOThreeCycleRoot
+@synthesize leaf = _leaf;
 + (NSSet *) keyPathsForValuesAffectingX
 {
   return [NSSet setWithObject: @"y"];

--- a/Tests/base/NSKVOSupport/cyclicalDependencies.m
+++ b/Tests/base/NSKVOSupport/cyclicalDependencies.m
@@ -1,0 +1,138 @@
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+@interface CDOObserver : NSObject
+{
+@public
+  NSUInteger calls;
+}
+@end
+
+@implementation CDOObserver
+- (void) observeValueForKeyPath: (NSString *)keyPath
+                       ofObject: (id)object
+                         change: (NSDictionary *)change
+                        context: (void *)context
+{
+  (void)keyPath;
+  (void)object;
+  (void)change;
+  (void)context;
+  calls++;
+}
+@end
+
+@interface CDODirectCycleRoot : NSObject
+@property (nonatomic, assign) NSInteger leaf;
+@property (nonatomic, readonly) NSInteger a;
+@property (nonatomic, readonly) NSInteger b;
+@property (nonatomic, readonly) NSInteger derived;
+@end
+
+@implementation CDODirectCycleRoot
++ (NSSet *) keyPathsForValuesAffectingA
+{
+  return [NSSet setWithObject: @"b"];
+}
++ (NSSet *) keyPathsForValuesAffectingB
+{
+  return [NSSet setWithObject: @"a"];
+}
++ (NSSet *) keyPathsForValuesAffectingDerived
+{
+  return [NSSet setWithObjects: @"a", @"leaf", nil];
+}
+- (NSInteger) a
+{
+  return self.leaf;
+}
+- (NSInteger) b
+{
+  return self.leaf;
+}
+- (NSInteger) derived
+{
+  return self.a + self.leaf;
+}
+@end
+
+@interface CDOThreeCycleRoot : NSObject
+@property (nonatomic, assign) NSInteger leaf;
+@property (nonatomic, readonly) NSInteger x;
+@property (nonatomic, readonly) NSInteger y;
+@property (nonatomic, readonly) NSInteger z;
+@property (nonatomic, readonly) NSInteger derived;
+@end
+
+@implementation CDOThreeCycleRoot
++ (NSSet *) keyPathsForValuesAffectingX
+{
+  return [NSSet setWithObject: @"y"];
+}
++ (NSSet *) keyPathsForValuesAffectingY
+{
+  return [NSSet setWithObject: @"z"];
+}
++ (NSSet *) keyPathsForValuesAffectingZ
+{
+  return [NSSet setWithObject: @"x"];
+}
++ (NSSet *) keyPathsForValuesAffectingDerived
+{
+  return [NSSet setWithObjects: @"x", @"leaf", nil];
+}
+- (NSInteger) x
+{
+  return self.leaf;
+}
+- (NSInteger) y
+{
+  return self.leaf;
+}
+- (NSInteger) z
+{
+  return self.leaf;
+}
+- (NSInteger) derived
+{
+  return self.x + self.leaf;
+}
+@end
+
+int main(void)
+{
+  CREATE_AUTORELEASE_POOL(pool);
+
+  {
+    CDODirectCycleRoot *root = AUTORELEASE([CDODirectCycleRoot new]);
+    CDOObserver *observer = AUTORELEASE([CDOObserver new]);
+    root.leaf = 1;
+
+    [root addObserver: observer forKeyPath: @"derived" options: 0 context: NULL];
+
+    observer->calls = 0;
+    root.leaf = 2;
+    PASS(observer->calls == 1,
+         "Direct A<->B cycle: leaf mutation notifies derived exactly once");
+
+    [root removeObserver: observer forKeyPath: @"derived"];
+  }
+
+  {
+    CDOThreeCycleRoot *root = AUTORELEASE([CDOThreeCycleRoot new]);
+    CDOObserver *observer = AUTORELEASE([CDOObserver new]);
+    root.leaf = 5;
+
+    [root addObserver: observer forKeyPath: @"derived" options: 0 context: NULL];
+
+    observer->calls = 0;
+    root.leaf = 6;
+    PASS(observer->calls == 1,
+         "Three-node X->Y->Z->X cycle: leaf mutation notifies derived exactly once");
+
+    [root removeObserver: observer forKeyPath: @"derived"];
+  }
+
+  DESTROY(pool);
+  return 0;
+}

--- a/Tests/base/NSKVOSupport/visitedAliasCollision.m
+++ b/Tests/base/NSKVOSupport/visitedAliasCollision.m
@@ -97,6 +97,12 @@ int main(void)
 {
   CREATE_AUTORELEASE_POOL(pool);
 
+#if !defined(clang)
+  testHopeful = YES;
+#endif
+
+// testcases here
+
   VACRoot *root = AUTORELEASE([VACRoot new]);
   root.holder = AUTORELEASE([VACHolder new]);
 
@@ -123,6 +129,11 @@ int main(void)
        "selectedA.leaf.flag branch should be wired (leaf.flag notifies derived)");
 
   [root removeObserver: obs forKeyPath: @"derived"];
+
+#if !defined(clang)
+  testHopeful = NO;
+#endif
+
   DESTROY(pool);
   return 0;
 }

--- a/Tests/base/NSKVOSupport/visitedAliasCollision.m
+++ b/Tests/base/NSKVOSupport/visitedAliasCollision.m
@@ -1,0 +1,110 @@
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+@interface VACLeaf : NSObject
+@property (nonatomic, assign) NSInteger value;
+@property (nonatomic, assign) BOOL flag;
+@end
+@implementation VACLeaf
+@end
+
+@interface VACNode : NSObject
+@property (nonatomic, retain) VACLeaf *leaf;
+@property (nonatomic, readonly) NSInteger score;
+@end
+@implementation VACNode
++ (NSSet *) keyPathsForValuesAffectingScore
+{
+  return [NSSet setWithObject: @"leaf.value"];
+}
+- (NSInteger) score
+{
+  return self.leaf.value;
+}
+@end
+
+@interface VACHolder : NSObject
+@property (nonatomic, retain) VACNode *node;
+@end
+@implementation VACHolder
+@end
+
+@interface VACRoot : NSObject
+@property (nonatomic, retain) VACHolder *holder;
+@property (nonatomic, readonly) VACNode *selectedA;
+@property (nonatomic, readonly) VACNode *selectedB;
+@property (nonatomic, readonly) BOOL derived;
+@end
+
+@implementation VACRoot
++ (NSSet *) keyPathsForValuesAffectingSelectedA
+{
+  return [NSSet setWithObject: @"holder.node"];
+}
++ (NSSet *) keyPathsForValuesAffectingSelectedB
+{
+  // Intentionally identical dependency text as selectedA.
+  return [NSSet setWithObject: @"holder.node"];
+}
++ (NSSet *) keyPathsForValuesAffectingDerived
+{
+  return [NSSet setWithObjects: @"selectedA.leaf.flag", @"selectedB.score", nil];
+}
+- (VACNode *) selectedA { return self.holder.node; }
+- (VACNode *) selectedB { return self.holder.node; }
+- (BOOL) derived
+{
+  return self.selectedA.leaf.flag && (self.selectedB.score > 0);
+}
+@end
+
+@interface VACObserver : NSObject
+{
+@public
+  NSUInteger calls;
+}
+@end
+@implementation VACObserver
+- (void) observeValueForKeyPath: (NSString *)keyPath
+                       ofObject: (id)object
+                         change: (NSDictionary *)change
+                        context: (void *)context
+{
+  (void) keyPath; (void) object; (void) change; (void) context;
+  calls++;
+}
+@end
+
+int main(void)
+{
+  CREATE_AUTORELEASE_POOL(pool);
+
+  VACRoot *root = AUTORELEASE([VACRoot new]);
+  root.holder = AUTORELEASE([VACHolder new]);
+
+  VACLeaf *leaf = AUTORELEASE([VACLeaf new]);
+  leaf.value = 1;
+  leaf.flag = YES;
+  VACNode *node = AUTORELEASE([VACNode new]);
+  node.leaf = leaf;
+
+  VACObserver *obs = AUTORELEASE([VACObserver new]);
+  [root addObserver: obs forKeyPath: @"derived" options: 0 context: NULL];
+
+  // Materialize graph after observer registration while holder.node is nil.
+  root.holder.node = node;
+
+  obs->calls = 0;
+  leaf.value = 2;
+  PASS(obs->calls == 1,
+       "selectedB.score branch should be wired (leaf.value notifies derived)");
+
+  obs->calls = 0;
+  leaf.flag = NO;
+  PASS(obs->calls == 1,
+       "selectedA.leaf.flag branch should be wired (leaf.flag notifies derived)");
+
+  [root removeObserver: obs forKeyPath: @"derived"];
+  DESTROY(pool);
+  return 0;
+}

--- a/Tests/base/NSKVOSupport/visitedAliasCollision.m
+++ b/Tests/base/NSKVOSupport/visitedAliasCollision.m
@@ -2,17 +2,27 @@
 #import "ObjectTesting.h"
 
 @interface VACLeaf : NSObject
+{
+  NSInteger _value;
+  BOOL _flag;
+}
 @property (nonatomic, assign) NSInteger value;
 @property (nonatomic, assign) BOOL flag;
 @end
 @implementation VACLeaf
+@synthesize value = _value;
+@synthesize flag = _flag;
 @end
 
 @interface VACNode : NSObject
+{
+  VACLeaf *_leaf;
+}
 @property (nonatomic, retain) VACLeaf *leaf;
 @property (nonatomic, readonly) NSInteger score;
 @end
 @implementation VACNode
+@synthesize leaf = _leaf;
 + (NSSet *) keyPathsForValuesAffectingScore
 {
   return [NSSet setWithObject: @"leaf.value"];
@@ -24,12 +34,19 @@
 @end
 
 @interface VACHolder : NSObject
+{
+  VACNode *_node;
+}
 @property (nonatomic, retain) VACNode *node;
 @end
 @implementation VACHolder
+@synthesize node = _node;
 @end
 
 @interface VACRoot : NSObject
+{
+  VACHolder *_holder;
+}
 @property (nonatomic, retain) VACHolder *holder;
 @property (nonatomic, readonly) VACNode *selectedA;
 @property (nonatomic, readonly) VACNode *selectedB;
@@ -37,6 +54,7 @@
 @end
 
 @implementation VACRoot
+@synthesize holder = _holder;
 + (NSSet *) keyPathsForValuesAffectingSelectedA
 {
   return [NSSet setWithObject: @"holder.node"];


### PR DESCRIPTION
This PR solves two KVO bugs described in #608.

I used the suggested solution from the original issue, while keying the nodes using the object pointer and the key name.

Additionally, I added a bunch of tests here. These are essentially fuzzing attempts by an LLM and have been very useful counter examples for why previous approaches I tried locally didn't work. I compared the results of running each of these against Apple's objc implementation and the behavior now matches Apple.

Let me know if the tests should be kept and whether I should add a change log entry.