### PR TITLE
in _emptyChild use do/while and explicitely set _child to nil to harden a bit

### DIFF
--- a/Source/NSAutoreleasePool.m
+++ b/Source/NSAutoreleasePool.m
@@ -197,23 +197,26 @@ pop_pool_from_cache(struct autorelease_thread_vars *tv)
    */
   if (nil != _child)
     {
-      NSAutoreleasePool	*pool = _child;
+      // First, collect all child pools by following _child links.
+      // This gives us order from nearest child to deepest child.
+      NSAutoreleasePool **childList = NULL;
+      NSUInteger count = 0;
+      NSAutoreleasePool *pool = _child;
+      while (nil != pool)
+        {
+          childList = realloc(childList, (count + 1) * sizeof(NSAutoreleasePool *));
+          childList[count] = pool;
+          count++;
+          pool = pool->_child;
+        }
 
-      /* Find other end of linked list ... oldest child.
-       */
-      while (nil != pool->_child)
-	{
-	  pool = pool->_child;
-	}
-      /* Deallocate the children in the list.
-       */
-      do
-	{
-	  pool = pool->_parent;
-	  [pool->_child dealloc];
-	  pool->_child = nil;
-	}
-      while (pool != self);
+      // Deallocate children in reverse order (deepest first, i.e. oldest first).
+      // This matches the original behaviour and avoids stack overflow.
+      for (NSUInteger i = count; i > 0; i--)
+        {
+          [childList[i-1] dealloc];
+        }
+      free(childList);
     }
 }
 

--- a/Source/NSAutoreleasePool.m
+++ b/Source/NSAutoreleasePool.m
@@ -207,11 +207,13 @@ pop_pool_from_cache(struct autorelease_thread_vars *tv)
 	}
       /* Deallocate the children in the list.
        */
-      while (pool != self)
+      do
 	{
 	  pool = pool->_parent;
 	  [pool->_child dealloc];
+	  pool->_child = nil;
 	}
+      while (pool != self);
     }
 }
 


### PR DESCRIPTION
Open for discussion, Richard.

This fix was in the works with @fredkiefer  while trying to address https://github.com/gnustep/libs-gui/issues/435 where in the meanwhile a workaround is proposed in https://github.com/gnustep/libs-gui/pull/436

Change is proposed by Fred and is quite certainly correct, but doesn't help.

The removal of a notification (probably never set) causes this strange loop:

```
#0  0x0000000826854030 in GSCurrentThread () at NSThread.m:679
#1  0x000000082675cdc9 in -[NSAutoreleasePool dealloc] (self=0x5, _cmd=0x826980458 <objc_selector_dealloc_v160:8>)
    at NSAutoreleasePool.m:595
#2  0x000000082675ca26 in -[NSAutoreleasePool _emptyChild] (self=0x38cd631e388, _cmd=<optimized out>)
    at NSAutoreleasePool.m:218
#3  0x000000082675ccde in -[NSAutoreleasePool emptyPool] (self=0x38cd631e388, _cmd=<optimized out>)
    at NSAutoreleasePool.m:295
#4  0x000000082675ce1e in -[NSAutoreleasePool dealloc] (self=0x38cd631e388, 
    _cmd=0x826980458 <objc_selector_dealloc_v160:8>) at NSAutoreleasePool.m:603
#5  0x000000082675ca26 in -[NSAutoreleasePool _emptyChild] (self=0x38cd631e388, _cmd=<optimized out>)
    at NSAutoreleasePool.m:218
#6  0x000000082675ccde in -[NSAutoreleasePool emptyPool] (self=0x38cd631e388, _cmd=<optimized out>)
    at NSAutoreleasePool.m:295
#7  0x000000082675ce1e in -[NSAutoreleasePool dealloc] (self=0x38cd631e388, 
    _cmd=0x826980458 <objc_selector_dealloc_v160:8>) at NSAutoreleasePool.m:603

```