### PR TITLE
NSLogv: fix startup data race on the logging lock

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2026-06-16 Todd White <todd.white@thalion.global>
+
+	* Source/NSLog.m:
+	Fix a startup data race in NSLogv().  GSLogLock() published the
+	global 'myLock' before caching the separate lock/unlock IMPs, but
+	NSLogv() took an unlocked 'nil == myLock' fast path and then called
+	through 'lockImp'.  Two threads logging for the first time
+	concurrently could observe 'myLock' set while 'lockImp' was still
+	NULL and crash.  Use the recursive lock returned by GSLogLock()
+	directly and drop the cached IMP globals.
+
 2026-06-13 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Headers/GNUstepBase/GSObjCRuntime.h:

--- a/Source/NSLog.m
+++ b/Source/NSLog.m
@@ -87,8 +87,6 @@ extern NSThread	*GSCurrentThread();
 int _NSLogDescriptor = 2;
 
 static NSRecursiveLock	*myLock = nil;
-static IMP              lockImp = 0;
-static IMP              unlockImp = 0;
 
 /**
  * Returns the lock used to protect the GNUstep NSLogv() implementation.
@@ -107,8 +105,6 @@ GSLogLock()
       if (myLock == nil)
 	{
 	  myLock = [NSRecursiveLock new];
-          lockImp = [myLock methodForSelector: @selector(lock)];
-          unlockImp = [myLock methodForSelector: @selector(unlock)];
 	}
       GS_MUTEX_UNLOCK(setupLock);
     }
@@ -335,6 +331,7 @@ NSLogv(NSString* format, va_list args)
 {
   NSMutableString	*prefix;
   NSString              *message;
+  NSRecursiveLock       *lock;
   NSString              *threadName = nil;
   NSThread              *t = nil;
   /* NB. On systems like Android where there is no operating system thread
@@ -432,16 +429,17 @@ NSLogv(NSString* format, va_list args)
       [prefix appendString: @"\n"];
     }
 
-  if (nil == myLock)
-    {
-      GSLogLock();
-    }
-
-  (*lockImp)(myLock, @selector(lock));
+  /* GSLogLock() returns a fully initialised lock; use it directly rather
+   * than file-scope lock/unlock IMPs that were published after 'myLock'.
+   * A second thread taking the lock-free 'nil == myLock' fast path could
+   * otherwise observe 'myLock' set but call through a still-NULL lockImp.
+   */
+  lock = GSLogLock();
+  [lock lock];
 
   _NSLog_printf_handler(prefix);
 
-  (*unlockImp)(myLock, @selector(unlock));
+  [lock unlock];
 
   [prefix release];
 }


### PR DESCRIPTION
## The bug

`GSLogLock()` (`Source/NSLog.m`) initialises three file-scope globals under `setupLock`:

```objc
myLock    = [NSRecursiveLock new];
lockImp   = [myLock methodForSelector: @selector(lock)];
unlockImp = [myLock methodForSelector: @selector(unlock)];
```

`myLock` is published **before** `lockImp`/`unlockImp` are set. `NSLogv()` then takes an *unlocked* fast path:

```objc
if (nil == myLock)
  {
    GSLogLock();
  }
(*lockImp)(myLock, @selector(lock));
```

When two threads make their **first** `NSLog()` call concurrently, the second can observe `myLock` already non-nil (so it skips `GSLogLock()`) and then call through `lockImp` while it is still `NULL` → SIGSEGV.

This is easy to hit in a program that starts several threads at once: GNUstep's `-[NSThread _setName:]` itself calls `NSLog()` (`"Truncating thread name … to 15 characters"`) from inside the thread launcher, so a burst of thread starts produces a burst of concurrent first-`NSLog` calls. Backtrace of the crashing thread:

```
#0  0x0000000000000000
#1  NSLogv (NSLog.m:440)        // (*lockImp)(myLock, @selector(lock)), lockImp == NULL
#2  NSLog
#3  -[NSThread _setName:]
#4  nsthreadLauncher
```

## The fix

`GSLogLock()` already returns a fully-initialised lock, so `NSLogv()` can use that object directly. This removes the second, separately-published pointer (`lockImp`) that could be read before it was set; the now-unused IMP globals are dropped.

```diff
-static NSRecursiveLock	*myLock = nil;
-static IMP              lockImp = 0;
-static IMP              unlockImp = 0;
+static NSRecursiveLock	*myLock = nil;
@@ GSLogLock()
 	  myLock = [NSRecursiveLock new];
-          lockImp = [myLock methodForSelector: @selector(lock)];
-          unlockImp = [myLock methodForSelector: @selector(unlock)];
 	}
@@ NSLogv()
-  if (nil == myLock)
-    {
-      GSLogLock();
-    }
-
-  (*lockImp)(myLock, @selector(lock));
-
-  _NSLog_printf_handler(prefix);
-
-  (*unlockImp)(myLock, @selector(unlock));
+  lock = GSLogLock();
+  [lock lock];
+
+  _NSLog_printf_handler(prefix);
+
+  [lock unlock];
```

(`myLock` itself is published the same way it was before, so this introduces no new publication assumption — it just stops relying on a *second* global being visible in lock-step with the first.)

## Validation (Ubuntu 24.04, clang 18, libobjc2)

Reproducer: start 16 `NSThread`s, each with a >15-char name so `-[NSThread _setName:]` logs a truncation warning → several threads' first `NSLog` fire concurrently. One process == one race attempt (the lock initialises once per process), driven in a loop.

- **Shipped library, natural timing:** 1 SIGSEGV in 300 launches (intermittent, as expected for a ~1-instruction window).
- **Race window artificially widened** (a `usleep` inserted between the `myLock` assignment and the IMP caching) to make it deterministic, verified via a stderr marker that the rebuilt library was the one running:
  - **unpatched:** 25 / 25 launches crash
  - **patched** (same widening in place): 0 / 40 launches crash

## Note on a regression test

I have not added a `Tests/base` case. The failure is an inherent data race with a sub-microsecond window, so a portable test could not act as a reliable negative control — it would pass on the unpatched library the overwhelming majority of the time, which is worse than no test. The standalone reproducer is available if it would be useful, and I'm happy to adjust the fix (e.g. an ordering/barrier approach that keeps the IMP cache) or add a best-effort stress test if you'd prefer.