### PR TITLE
NSJSONSerialization: reject over-long numeric tokens (stack buffer overflow)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2026-06-19 Todd White <todd.white@thalion.global>
+
+	* Source/NSJSONSerialization.m (parseNumber): the BUFFER() macro raised a
+	parse error when the 255-byte numeric buffer was full but did not stop, so
+	a numeric token longer than the buffer overran the stack array.  Return as
+	soon as the error is raised so an over-long token is rejected instead of
+	overflowing the buffer.
+	* Tests/base/NSJSONSerialization/number.m: new regression test.
+
 2026-06-18 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Documentation/Base.gsdoc: minor tidy

--- a/Source/NSJSONSerialization.m
+++ b/Source/NSJSONSerialization.m
@@ -549,10 +549,13 @@ parseNumber(ParserState *state)
 
   // Define a macro to add a character to the buffer, because we'll need to do
   // it a lot.  This generates a parse error if the maximum size is exceeded.
+  // A numeric token longer than the buffer is rejected (rather than allowed
+  // to overrun the buffer) by returning as soon as the error is raised.
 #define BUFFER(x) do {\
   if (parsedSize == sizeof(number))\
     {\
       parseError(state);\
+      return nil;\
     }\
   number[parsedSize++] = (char)x; } while (0)
   // JSON numbers must start with a - or a digit

--- a/Tests/base/NSJSONSerialization/number.m
+++ b/Tests/base/NSJSONSerialization/number.m
@@ -1,0 +1,75 @@
+/*
+ * number.m - regression test for NSJSONSerialization numeric-token length.
+ *
+ * parseNumber() accumulates the characters of a JSON numeric token into a
+ * fixed 255-byte stack buffer via the BUFFER() macro. The macro's overflow
+ * guard raised a parse error when the buffer was full but did not stop, so
+ * control fell through to the store and a numeric token longer than the
+ * buffer kept writing past the end of the stack array - an unbounded stack
+ * buffer overflow on attacker-controlled input. The guard now rejects the
+ * token (returns with the error set) instead of overrunning the buffer.
+ *
+ *   - a normal number still parses.
+ *   - a numeric token far longer than the internal buffer is rejected with
+ *     an error rather than overflowing the buffer (and does not crash).
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+/* Build "[<digits copies of '1'>]" so the numeric token is `digits`
+ * characters long.
+ */
+static NSData *
+buildLongNumberJSON(unsigned digits)
+{
+  NSMutableString	*s;
+  unsigned		i;
+
+  s = [NSMutableString stringWithCapacity: digits + 2];
+  [s appendString: @"["];
+  for (i = 0; i < digits; i++)
+    {
+      [s appendString: @"1"];
+    }
+  [s appendString: @"]"];
+  return [s dataUsingEncoding: NSUTF8StringEncoding];
+}
+
+#define	ISARRAY(X) [X isKindOfClass: [NSArray class]]
+#define	ISERROR(X) [X isKindOfClass: [NSError class]]
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("NSJSONSerialization number length")
+  NSData	*data;
+  NSError	*error;
+  id		result;
+
+  data = [@"[123]" dataUsingEncoding: NSUTF8StringEncoding];
+  error = @"dummy";
+  result = [NSJSONSerialization JSONObjectWithData: data
+					   options: 0
+					     error: &error];
+  PASS(ISARRAY(result) && [[result objectAtIndex: 0] intValue] == 123,
+    "a normal JSON number parses")
+  PASS(error == nil, "a normal JSON number cleared the error out-parameter")
+
+  /* A 4096-character numeric token is far longer than the 255-byte buffer:
+   * it must be rejected via the error out-parameter rather than overflowing
+   * the stack buffer.
+   */
+  data = buildLongNumberJSON(4096);
+  error = @"dummy";
+  result = [NSJSONSerialization JSONObjectWithData: data
+					   options: 0
+					     error: &error];
+  PASS(result == nil, "an over-long JSON numeric token was rejected")
+  PASS(ISERROR(error),
+    "an over-long JSON numeric token populated the error out-parameter")
+
+  END_SET("NSJSONSerialization number length")
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

`parseNumber()` accumulates a JSON numeric token into a fixed 255-byte stack buffer (`char number[255]`) via the `BUFFER()` macro. The overflow guard raises a parse error when the buffer is full but does not stop:

```c
#define BUFFER(x) do {\
  if (parsedSize == sizeof(number))\
    {\
      parseError(state);\
    }\
  number[parsedSize++] = (char)x; } while (0)
```

`parseError()` only sets `state->error` and returns normally, so control falls through to `number[parsedSize++] = (char)x`, writing one byte past the end of the buffer — and then continuing for every further character. The digit-consuming loops (`while (isdigit(c = consumeChar(state))) { BUFFER(c); }`) test only `isdigit()` and never inspect `state->error`, so a numeric token longer than 255 characters overruns the stack buffer without bound. This is an attacker-controlled stack buffer overflow reachable from `+JSONObjectWithData:` / `+JSONObjectWithStream:` on untrusted JSON.

## Fix

Return from `parseNumber()` as soon as the error is raised, so an over-long numeric token is rejected via the error out-parameter instead of overflowing the buffer. One added line.

## Validation (Ubuntu 24.04, clang 18, libobjc2, current master)

- **Unpatched:** parsing a 4096-character numeric token via `+JSONObjectWithData:` segfaults — the new regression test runs 2 assertions, then the process takes SIGSEGV (core dumped).
- **Patched:** the token is rejected via the error out-parameter; the regression test passes all 4 assertions with no crash.
- An AddressSanitizer replica of the exact `BUFFER()` loop reports `stack-buffer-overflow WRITE of size 1` one byte past the 255-byte buffer.

Adds `Tests/base/NSJSONSerialization/number.m` (a normal number still parses; an over-long token is rejected) and a ChangeLog entry.
