### PR TITLE
NSDecimal: bound mantissa when parsing a decimal string (stack buffer overflow)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2026-06-19 Todd White <todd.white@thalion.global>
+
+	* Source/NSDecimal.m (GSDecimalFromString): the digit-copying loops wrote
+	into the fixed-size cMantissa[] array of a stack decimal without bounding
+	the destination index, so a numeric string with more digits than the
+	mantissa can hold overran the buffer.  Stop filling the mantissa at its
+	capacity (sizeof cMantissa): excess integer digits raise the exponent to
+	preserve magnitude and excess fractional digits are dropped.
+	* Tests/base/NSDecimalNumber/string.m: new regression test.
+
 2026-06-18 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Documentation/Base.gsdoc: minor tidy

--- a/Source/NSDecimal.m
+++ b/Source/NSDecimal.m
@@ -1046,16 +1046,26 @@ GSDecimalFromString(GSDecimal *result, NSString *numberValue,
       i = 0;
       while ((*s) && (isdigit(*s)))
         {
-	  result->cMantissa[i++] = *s - '0';
-	  result->length++;
+	  if (i < (int)sizeof(result->cMantissa))
+	    {
+	      result->cMantissa[i++] = *s - '0';
+	      result->length++;
+	    }
+	  else
+	    {
+	      result->exponent++;
+	    }
 	  s++;
 	}
       s = [[numberValue substringFromIndex: NSMaxRange(found)] lossyCString];
       while ((*s) && (isdigit(*s)))
         {
-	  result->cMantissa[i++] = *s - '0';
-	  result->length++;
-	  result->exponent--;
+	  if (i < (int)sizeof(result->cMantissa))
+	    {
+	      result->cMantissa[i++] = *s - '0';
+	      result->length++;
+	      result->exponent--;
+	    }
 	  s++;
 	}	
     }
@@ -1071,8 +1081,15 @@ GSDecimalFromString(GSDecimal *result, NSString *numberValue,
       i = 0;
       while ((*s) && (isdigit(*s)))
         {
-	  result->cMantissa[i++] = *s - '0';
-	  result->length++;
+	  if (i < (int)sizeof(result->cMantissa))
+	    {
+	      result->cMantissa[i++] = *s - '0';
+	      result->length++;
+	    }
+	  else
+	    {
+	      result->exponent++;
+	    }
 	  s++;
 	}
     }

--- a/Tests/base/NSDecimalNumber/string.m
+++ b/Tests/base/NSDecimalNumber/string.m
@@ -1,0 +1,62 @@
+/*
+ * string.m - regression test for +[NSDecimalNumber decimalNumberWithString:].
+ *
+ * NSDecimalFromString() -> GSDecimalFromString() copied the digits of the
+ * supplied string into the fixed-size cMantissa[] array of a stack decimal
+ * with no bound on the destination index, so a numeric string with more
+ * digits than the mantissa can hold overran the buffer - a stack buffer
+ * overflow on attacker-controlled text reachable from
+ * +decimalNumberWithString: and from property-list / archive decoding.
+ * The digit loops now stop filling the mantissa at its capacity (excess
+ * integer digits raise the exponent; excess fractional digits are dropped).
+ *
+ *   - a normal decimal string still parses to the right value.
+ *   - a string with far more digits than the mantissa holds is parsed
+ *     without overflowing the buffer (and does not crash).
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+/* "<prefix><n copies of '1'>" */
+static NSString *
+longDigits(NSString *prefix, unsigned n)
+{
+  NSMutableString	*s;
+  unsigned		i;
+
+  s = [NSMutableString stringWithCapacity: n + [prefix length]];
+  [s appendString: prefix];
+  for (i = 0; i < n; i++)
+    {
+      [s appendString: @"1"];
+    }
+  return s;
+}
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("NSDecimalNumber decimalNumberWithString")
+  NSDecimalNumber	*d;
+
+  d = [NSDecimalNumber decimalNumberWithString: @"123.45"];
+  PASS(d != nil
+    && [d doubleValue] > 123.44 && [d doubleValue] < 123.46,
+    "a normal decimal string parses to the right value")
+
+  /* 300 fractional digits is far more than the mantissa can hold; it must be
+   * parsed (with reduced precision) without overflowing the buffer. */
+  d = [NSDecimalNumber decimalNumberWithString: longDigits(@"0.", 300)];
+  PASS(d != nil,
+    "a 300-fractional-digit string is parsed without overflowing the mantissa")
+
+  /* 300 integer digits likewise must not overflow the buffer. */
+  d = [NSDecimalNumber decimalNumberWithString: longDigits(@"", 300)];
+  PASS(d != nil,
+    "a 300-integer-digit string is parsed without overflowing the mantissa")
+
+  END_SET("NSDecimalNumber decimalNumberWithString")
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

`NSDecimalFromString()` → `GSDecimalFromString()` copies the digits of the supplied string into the fixed-size `cMantissa[]` array of a stack decimal, with no bound on the destination index:

```c
while ((*s) && (isdigit(*s)))
  {
    result->cMantissa[i++] = *s - '0';
    result->length++;
    s++;
  }
```

`cMantissa` is `NSDecimalMaxDigit` (38) bytes in the default build, or `2*NSDecimalMaxDigit` (76) when built with GMP. A numeric string with more digits than the mantissa can hold overruns the array — a stack buffer overflow on attacker-controlled text, reachable from `+[NSDecimalNumber decimalNumberWithString:]` and from property-list / archive decoding (`-initWithString:`). All three digit loops in the function (integer with/without separator, and fractional) have the same flaw.

## Fix

Bound each loop by `sizeof(result->cMantissa)` (so it adapts to both the 38- and 76-byte builds). Excess **integer** digits raise the exponent to preserve magnitude; excess **fractional** digits are dropped (the value already exceeds the mantissa's precision). This keeps each build's existing capacity and only prevents the overrun.

## Validation (Ubuntu 24.04, clang 18, libobjc2, **GMP build**, current master)

- **Unpatched:** parsing a 300-digit string via `+decimalNumberWithString:` aborts — the new regression test runs 1 assertion (a normal decimal), then the buffer overflow crashes the process.
- **Patched:** the over-long string is parsed without overrunning the mantissa; the regression test passes all 3 assertions with no crash.

Adds `Tests/base/NSDecimalNumber/string.m` (a normal decimal parses to the right value; 300-digit integer and fractional strings are parsed without overflow) and a ChangeLog entry.
