### PR TITLE
NSCoder: validate old-style array count when decoding a keyed archive (heap overflow)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2026-06-19 Todd White <todd.white@thalion.global>
+
+	* Source/NSCoder.m (-[_NSKeyedCoderOldStyleArray initWithCoder:]): the
+	destination buffer was allocated with -[NSMutableData initWithLength:
+	_c * _s] where _c (the decoded NS.count) and _s are both unsigned, so the
+	32-bit product could truncate and an attacker-chosen count made the buffer
+	far smaller than the _c elements the following loop wrote into it.  Reject
+	a count larger than the sequential element keys actually present, and
+	widen the product.
+	* Source/NSKeyedUnarchiver.m (-_containsRawKey:): new private helper that
+	probes the current object map without the leading-'$' escaping.
+	* Tests/base/NSKeyedArchiver/arrayoverflow.m: new regression test.
+
 2026-06-18 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Documentation/Base.gsdoc: minor tidy

--- a/Source/NSCoder.m
+++ b/Source/NSCoder.m
@@ -34,6 +34,7 @@
 #define	EXPOSE_NSCoder_IVARS	1
 #import "Foundation/NSData.h"
 #import "Foundation/NSCoder.h"
+#import "Foundation/NSException.h"
 #import "Foundation/NSSet.h"
 #import "Foundation/NSSerialization.h"
 #import "Foundation/NSUserDefaults.h"
@@ -477,6 +478,16 @@ static unsigned	systemVersion = MAX_SUPPORTED_SYSTEM_VERSION;
 
 
 #import	"GSPrivate.h"
+#import "Foundation/NSKeyedArchiver.h"
+
+/* Private hook implemented by NSKeyedUnarchiver, letting -initWithCoder: below
+ * check an attacker-controllable element count against the sequential
+ * ("$<index>") keys actually present in the archive.  Unlike
+ * -containsValueForKey:, it does not escape a leading '$'.
+ */
+@interface NSKeyedUnarchiver (GSCoderArrayCount)
+- (BOOL) _containsRawKey: (NSString*)aKey;
+@end
 
 @implementation	_NSKeyedCoderOldStyleArray
 - (const void*) bytes
@@ -511,7 +522,22 @@ static unsigned	systemVersion = MAX_SUPPORTED_SYSTEM_VERSION;
       _s = [aCoder decodeIntForKey: @"NS.size"];
       _s = objc_sizeof_type(_t);
 
-      _d = o = [[NSMutableData alloc] initWithLength: _c * _s];
+      /* _c is decoded from the (possibly untrusted) archive.  Each element is
+       * stored under the sequential key "$<index>", so the last one
+       * ("$<_c-1>") must be present; if it is not, _c is larger than the data
+       * actually encoded.  Reject such a count rather than letting the _c * _s
+       * allocation (whose bare 'unsigned' product can also wrap) and the fill
+       * loop below be driven by an arbitrary attacker-supplied value.
+       */
+      if (_c > 0
+	&& [aCoder respondsToSelector: @selector(_containsRawKey:)]
+	&& NO == [(NSKeyedUnarchiver*)aCoder _containsRawKey:
+	  [NSString stringWithFormat: @"$%u", _c - 1]])
+	{
+	  [NSException raise: NSInvalidArgumentException
+		      format: @"invalid array count (%u) in archive", _c];
+	}
+      _d = o = [[NSMutableData alloc] initWithLength: (NSUInteger)_c * _s];
       _a = address = [o mutableBytes];
       for (i = 0; i < _c; i++)
 	{

--- a/Source/NSKeyedUnarchiver.m
+++ b/Source/NSKeyedUnarchiver.m
@@ -459,6 +459,15 @@ static NSMapTable	*globalClassMap = 0;
   return NO;
 }
 
+- (BOOL) _containsRawKey: (NSString*)aKey
+{
+  /* Look the key up in the current object map without the leading-'$'
+   * escaping that GETVAL applies, so the internal sequential element keys
+   * ("$0", "$1", ...) can be probed.
+   */
+  return (nil == [_keyMap objectForKey: aKey]) ? NO : YES;
+}
+
 - (void) dealloc
 {
   DESTROY(_archive);

--- a/Tests/base/NSKeyedArchiver/arrayoverflow.m
+++ b/Tests/base/NSKeyedArchiver/arrayoverflow.m
@@ -1,0 +1,98 @@
+/*
+ * arrayoverflow.m - regression test for _NSKeyedCoderOldStyleArray decoding.
+ *
+ * -[NSKeyedArchiver encodeArrayOfObjCType:count:at:] stores a C array as an
+ * _NSKeyedCoderOldStyleArray.  Its -initWithCoder: allocated the destination
+ * buffer with -[NSMutableData initWithLength: _c * _s], where _c (the decoded
+ * NS.count) and _s (the element size) are both `unsigned`.  The 32-bit
+ * product truncated before being widened, so an attacker-chosen NS.count made
+ * the buffer far smaller than the _c elements the following loop wrote into it
+ * - a heap buffer overflow when unarchiving an untrusted archive.  The count
+ * is now validated against the size before allocating.
+ *
+ *   - a normal C array still round-trips through the keyed archiver.
+ *   - an archive whose NS.count * element-size overflows is rejected rather
+ *     than allocating an undersized buffer and overrunning it.
+ */
+
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+
+@interface ArrayHolder : NSObject <NSCoding>
+@end
+
+@implementation ArrayHolder
+- (void) encodeWithCoder: (NSCoder*)c
+{
+  double	a[3];
+
+  a[0] = 1.0; a[1] = 2.0; a[2] = 3.0;
+  [c encodeArrayOfObjCType: @encode(double) count: 3 at: a];
+}
+- (id) initWithCoder: (NSCoder*)c
+{
+  double	a[3];
+
+  [c decodeArrayOfObjCType: @encode(double) count: 3 at: a];
+  return self;
+}
+@end
+
+/* Build a keyed archive of an ArrayHolder, then rewrite the NS.count of the
+ * encoded C array to a value whose product with the 8-byte element size
+ * overflows 32 bits (0x20000000 * 8 == 0x100000000 -> 0).
+ */
+static NSData *
+tamperedArchive(void)
+{
+  NSData		*archive;
+  NSMutableDictionary	*plist;
+  NSMutableArray	*objects;
+  NSUInteger		i;
+
+  archive = [NSKeyedArchiver archivedDataWithRootObject:
+    [[[ArrayHolder alloc] init] autorelease]];
+  plist = [NSPropertyListSerialization
+    propertyListWithData: archive
+		 options: NSPropertyListMutableContainersAndLeaves
+		  format: NULL
+		   error: NULL];
+  objects = [plist objectForKey: @"$objects"];
+  for (i = 0; i < [objects count]; i++)
+    {
+      id	o = [objects objectAtIndex: i];
+
+      if ([o isKindOfClass: [NSDictionary class]]
+	&& [o objectForKey: @"NS.count"] != nil)
+	{
+	  [o setObject: [NSNumber numberWithUnsignedInt: 0x20000000U]
+		forKey: @"NS.count"];
+	}
+    }
+  return [NSPropertyListSerialization
+    dataWithPropertyList: plist
+		  format: NSPropertyListBinaryFormat_v1_0
+		 options: 0
+		   error: NULL];
+}
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("_NSKeyedCoderOldStyleArray count overflow")
+  NSData	*good;
+  id		obj;
+
+  good = [NSKeyedArchiver archivedDataWithRootObject:
+    [[[ArrayHolder alloc] init] autorelease]];
+  obj = [NSKeyedUnarchiver unarchiveObjectWithData: good];
+  PASS(obj != nil, "a normal C-array archive unarchives")
+
+  PASS_EXCEPTION([NSKeyedUnarchiver unarchiveObjectWithData: tamperedArchive()],
+    NSInvalidArgumentException,
+    "an overflowing array count in an archive is rejected, not overrun")
+
+  END_SET("_NSKeyedCoderOldStyleArray count overflow")
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

`-[NSKeyedArchiver encodeArrayOfObjCType:count:at:]` stores a C array as an `_NSKeyedCoderOldStyleArray`. Its `-initWithCoder:` allocates the destination buffer like this:

```objc
_c = [aCoder decodeIntForKey: @"NS.count"];   // attacker-controlled
...
_s = objc_sizeof_type(_t);                    // local element size
_d = o = [[NSMutableData alloc] initWithLength: _c * _s];
_a = address = [o mutableBytes];
for (i = 0; i < _c; i++) { [aCoder decodeValueOfObjCType: _t at: address]; address += _s; }
```

`_c` and `_s` are both `unsigned` (see `GSPrivate.h`), so `_c * _s` is a 32-bit multiply that **truncates** before being widened to the `NSUInteger` length. An attacker-chosen `NS.count` (e.g. `0x20000000` with an 8-byte element type → `0x100000000` → `0`) makes the buffer far smaller than the `_c` elements the following loop writes — a **heap buffer overflow** when unarchiving an untrusted keyed archive. The `count != expected` check in `-decodeArrayOfObjCType:count:at:` happens *after* this, so it does not help.

## Fix

The array's elements are stored under sequential keys `"$0"`, `"$1"`, …, so a valid `NS.count` of N requires `"$<N-1>"` to be present. Before allocating, reject a count whose last element key is missing — that bounds `_c` to the data actually encoded (preventing both the truncation and an oversized allocation) — and widen the `_c * _s` product. The check needs a small private helper on `NSKeyedUnarchiver` (`-_containsRawKey:`) because `-containsValueForKey:` escapes a leading `$` to `$$` to avoid colliding with these internal element keys.

## Validation (Ubuntu 24.04, clang 18, libobjc2, current master)

- **Unpatched:** unarchiving a keyed archive whose `NS.count` has been raised so `count * element-size` overflows aborts — the regression test runs 1 assertion, then the heap overflow crashes the process.
- **Patched:** the archive is rejected with an `NSInvalidArgumentException`; the regression test passes both assertions with no crash.
- An AddressSanitizer replica of the `_c * _s` allocation + fill loop reports `heap-buffer-overflow WRITE` past the truncated allocation.

Adds `Tests/base/NSKeyedArchiver/arrayoverflow.m` (a normal C array round-trips; a tampered count is rejected) and a ChangeLog entry.
