### PR TITLE
NSData: deserializeInts: writes into the caller's buffer (stack smash)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2026-06-19 Todd White <todd.white@thalion.global>
+
+	* Source/NSData.m (-[NSData deserializeInts:count:atCursor:],
+	-[NSData deserializeInts:count:atIndex:]): both passed &intBuffer (the
+	address of the local pointer parameter) to -deserializeBytes:length:
+	atCursor: instead of intBuffer, so the decoded bytes were written over the
+	pointer on the stack rather than into the caller's buffer.  Pass intBuffer.
+	* Tests/base/NSData/deserializeints.m: new regression test.
+
 2026-06-18 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Documentation/Base.gsdoc: minor tidy

--- a/Source/NSData.m
+++ b/Source/NSData.m
@@ -1865,7 +1865,7 @@ failure:
 {
   unsigned i;
 
-  [self deserializeBytes: &intBuffer
+  [self deserializeBytes: intBuffer
 		  length: numInts * sizeof(unsigned)
 		atCursor: cursor];
   for (i = 0; i < numInts; i++)
@@ -1883,7 +1883,7 @@ failure:
 {
   unsigned i;
 
-  [self deserializeBytes: &intBuffer
+  [self deserializeBytes: intBuffer
 		  length: numInts * sizeof(int)
 		atCursor: &index];
   for (i = 0; i < numInts; i++)

--- a/Tests/base/NSData/deserializeints.m
+++ b/Tests/base/NSData/deserializeints.m
@@ -1,0 +1,41 @@
+/*
+ * deserializeints.m - regression test for -[NSData deserializeInts:count:...].
+ *
+ * -deserializeInts:count:atCursor: and -deserializeInts:count:atIndex: passed
+ * &intBuffer (the address of the local pointer parameter) to
+ * -deserializeBytes:length:atCursor: instead of intBuffer, so the decoded
+ * bytes were written over the pointer variable on the stack rather than into
+ * the caller's buffer - smashing the stack and leaving the caller's buffer
+ * untouched.  The bytes are now written into the caller's buffer.
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("NSData deserializeInts")
+  /* three 32-bit ints in big-endian (network) byte order */
+  unsigned char	bytes[12] = {
+    0x01, 0x02, 0x03, 0x04,
+    0x05, 0x06, 0x07, 0x08,
+    0x09, 0x0a, 0x0b, 0x0c };
+  NSData	*d = [NSData dataWithBytes: bytes length: 12];
+  int		out[3];
+  unsigned	cursor = 0;
+
+  out[0] = out[1] = out[2] = 0;
+  [d deserializeInts: out count: 3 atCursor: &cursor];
+  PASS(out[0] == 0x01020304 && out[1] == 0x05060708 && out[2] == 0x090a0b0c,
+    "deserializeInts:count:atCursor: writes into the caller's buffer")
+
+  out[0] = out[1] = out[2] = 0;
+  [d deserializeInts: out count: 3 atIndex: 0];
+  PASS(out[0] == 0x01020304 && out[1] == 0x05060708 && out[2] == 0x090a0b0c,
+    "deserializeInts:count:atIndex: writes into the caller's buffer")
+
+  END_SET("NSData deserializeInts")
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

`-[NSData deserializeInts:count:atCursor:]` and `-[NSData deserializeInts:count:atIndex:]` pass **`&intBuffer`** — the address of the local pointer parameter — to `-deserializeBytes:length:atCursor:` instead of `intBuffer`:

```objc
- (void) deserializeInts: (int*)intBuffer count: (unsigned int)numInts atCursor: (unsigned int*)cursor
{
  unsigned i;
  [self deserializeBytes: &intBuffer length: numInts * sizeof(unsigned) atCursor: cursor];
  for (i = 0; i < numInts; i++)
    intBuffer[i] = NSSwapBigIntToHost(intBuffer[i]);
}
```

`-deserializeBytes:length:atCursor:` copies `length` bytes into the address given as its first argument. So `numInts * sizeof(int)` bytes are written over the 8-byte stack slot holding the `intBuffer` pointer (smashing the stack), and the caller's buffer is never written. The loop then dereferences the now-corrupted `intBuffer`, a wild read/write.

## Fix

Pass `intBuffer` (the caller's buffer) rather than `&intBuffer`, in both overloads. Two-character change per method.

## Validation (Ubuntu 24.04, clang 18, libobjc2, current master)

- **Unpatched:** `-deserializeInts:` aborts — the regression test crashes when the corrupted pointer is dereferenced.
- **Patched:** the caller's buffer is filled correctly; both assertions pass.

Adds `Tests/base/NSData/deserializeints.m` (round-trips three big-endian ints through both overloads) and a ChangeLog entry.
