### PR TITLE
NSData: guard cross-ref length check against unsigned underflow (OOB read)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2026-06-19 Todd White <todd.white@thalion.global>
+
+	* Source/NSData.m (-[NSDataStatic
+	deserializeTypeTag:andCrossRef:atCursor:]): the 32-bit cross-reference
+	read was guarded with `*cursor >= length-3', but length is an unsigned
+	NSUInteger, so a buffer shorter than 3 bytes made length-3 underflow and
+	defeated the guard, reading past the end of the buffer.  Reject a
+	too-short buffer before the subtraction.
+	* Tests/base/NSData/typetag.m: new regression test.
+
 2026-06-18 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Documentation/Base.gsdoc: minor tidy

--- a/Source/NSData.m
+++ b/Source/NSData.m
@@ -3799,7 +3799,9 @@ getBytes(void* dst, void* src, unsigned len, unsigned limit, unsigned *pos)
 	    {
 	      uint32_t	x;
 
-	      if (*cursor >= length-3)
+	      /* length is unsigned, so guard the length-3 subtraction against
+	       * underflow for a short buffer before using it as a bound. */
+	      if (length < 4 || *cursor >= length-3)
 		{
 		  [NSException raise: NSRangeException
 			      format: @"Range: (%u, 1) Size: %"PRIuPTR,

--- a/Tests/base/NSData/typetag.m
+++ b/Tests/base/NSData/typetag.m
@@ -1,0 +1,37 @@
+/*
+ * typetag.m - regression test for -[NSData deserializeTypeTag:andCrossRef:...].
+ *
+ * The NSDataStatic override of -deserializeTypeTag:andCrossRef:atCursor:
+ * guarded its 4-byte cross-reference read with `*cursor >= length-3'.  As
+ * `length' is unsigned, a buffer shorter than 3 bytes made `length-3'
+ * underflow to a huge value, defeating the guard and reading up to 4 bytes
+ * past the end of the buffer.  The subtraction is now guarded against
+ * underflow.
+ */
+
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("NSData deserializeTypeTag short buffer")
+  /* Tag byte 0x70 == _GSC_MAYX | _GSC_X_4: a 32-bit cross-reference follows.
+   * In a 2-byte no-copy (static) buffer, decoding that cross-reference would
+   * read 4 bytes starting one past the tag - off the end of the buffer.
+   */
+  unsigned char	bytes[2] = { 0x70, 0x00 };
+  NSData	*d = [NSData dataWithBytesNoCopy: bytes length: 2 freeWhenDone: NO];
+  unsigned char	tag = 0;
+  unsigned int	ref = 0;
+  unsigned int	cursor = 0;
+
+  PASS_EXCEPTION(
+    [d deserializeTypeTag: &tag andCrossRef: &ref atCursor: &cursor],
+    NSRangeException,
+    "a cross-ref tag in too short a buffer raises rather than reading out of bounds")
+
+  END_SET("NSData deserializeTypeTag short buffer")
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

The `NSDataStatic` override of `-deserializeTypeTag:andCrossRef:atCursor:` guards its 32-bit cross-reference read like this:

```objc
default:   // _GSC_X_4: a 32-bit cross-reference
  {
    uint32_t x;
    if (*cursor >= length-3)
      { [NSException raise: NSRangeException ...]; }
    x = *(uint32_t*)(bytes + *cursor);   // reads 4 bytes
    ...
  }
```

`length` is an unsigned `NSUInteger`, so for a buffer shorter than 3 bytes `length-3` **underflows** to a huge value, the guard passes, and `*(uint32_t*)(bytes + *cursor)` reads up to 4 bytes past the end of the buffer. This is reachable when deserializing an untrusted `NSData` whose tag byte requests a 32-bit cross-reference (`_GSC_MAYX | _GSC_X_4`). (The `_GSC_X_2` case's `length-1` only underflows at `length == 0`, which the leading `*cursor >= length` guard already rejects.)

## Fix

Reject a too-short buffer before performing the subtraction: `if (length < 4 || *cursor >= length-3)`.

## Validation (Ubuntu 24.04, clang 18, libobjc2, current master)

- **Unpatched:** deserializing a 32-bit cross-ref tag from a 2-byte buffer reads out of bounds and returns without raising — the regression test's `PASS_EXCEPTION` fails.
- **Patched:** it raises `NSRangeException`; the test passes.

Adds `Tests/base/NSData/typetag.m` and a ChangeLog entry.
