### PR TITLE
NSSerializer: reject a zero C-string length when deserializing (OOB read)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2026-06-19 Todd White <todd.white@thalion.global>
+
+	* Source/NSSerializer.m (deserializeFromInfo): the ST_CSTRING case read a
+	byte count from the (untrusted) data and built the string with length
+	size-1; a crafted count of 0 made size-1 underflow to a huge length over a
+	zero-byte buffer (an out-of-bounds read).  Reject a zero C-string length.
+	* Tests/base/NSSerializer/cstring.m: new regression test.
+
 2026-06-18 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Documentation/Base.gsdoc: minor tidy

--- a/Source/NSSerializer.m
+++ b/Source/NSSerializer.m
@@ -550,6 +550,16 @@ deserializeFromInfo(_NSDeserializerInfo* info)
 	  char		*b;
 	
 	  size = (*info->deiImp)(info->data, deiSel, info->cursor);
+	  /* A serialised C string always stores its length as the byte count
+	   * including the nul terminator, so size is at least 1.  A zero here
+	   * means corrupt data; reject it rather than letting 'size - 1' below
+	   * underflow to a huge length. */
+	  if (size == 0)
+	    {
+	      [NSException raise: NSInvalidArgumentException
+			  format: @"invalid (zero) C string length in"
+	      @" serialized property list"];
+	    }
 	  b = NSZoneMalloc(NSDefaultMallocZone(), size);
 	  (*info->debImp)(info->data, debSel, b, size, info->cursor);
 	  s = [[StringClass alloc] initWithBytesNoCopy: b

--- a/Tests/base/NSSerializer/cstring.m
+++ b/Tests/base/NSSerializer/cstring.m
@@ -1,0 +1,35 @@
+/*
+ * cstring.m - regression test for +[NSDeserializer deserializePropertyList...].
+ *
+ * The ST_CSTRING case of the deserializer read a byte count from the
+ * (untrusted) data and built the string with `length: size - 1'.  A crafted
+ * length of 0 made `size - 1' underflow to a huge value, so the string was
+ * created over a zero-byte buffer claiming ~4 billion bytes - an out-of-bounds
+ * read.  A zero C-string length is now rejected.
+ */
+
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("NSDeserializer C-string length")
+  NSMutableData	*d = [NSMutableData data];
+  /* byte 0: no uniquing (old format); byte 1: ST_CSTRING tag (1) */
+  unsigned char	hdr[2] = { 0x00, 0x01 };
+  id		result = @"unset";
+
+  [d appendBytes: hdr length: 2];
+  [d serializeInt: 0];	/* C-string byte count; a valid one is always >= 1 */
+
+  PASS_EXCEPTION(
+    (result = [NSDeserializer deserializePropertyListFromData: d
+                                            mutableContainers: NO]),
+    NSInvalidArgumentException,
+    "a zero C-string length in serialized data is rejected, not used as size - 1")
+
+  END_SET("NSDeserializer C-string length")
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

The `ST_CSTRING` case of the NSDeserializer reads a byte count from the (untrusted) serialized data and builds the string with `length: size - 1`:

```objc
case ST_CSTRING:
  size = (*info->deiImp)(info->data, deiSel, info->cursor);
  b = NSZoneMalloc(NSDefaultMallocZone(), size);
  (*info->debImp)(info->data, debSel, b, size, info->cursor);
  s = [[StringClass alloc] initWithBytesNoCopy: b
                                        length: size - 1
                                      encoding: NSASCIIStringEncoding
                                  freeWhenDone: YES];
```

`size` is unsigned, so a crafted count of `0` makes `size - 1` underflow to `0xFFFFFFFF`. `NSZoneMalloc(0)` returns a zero-byte buffer, and the string is then constructed claiming ~4 billion bytes over it — an out-of-bounds read (the ASCII validation scan, and any later use of the bogus-length string). Reachable from `+[NSDeserializer deserializePropertyListFromData:...]` on untrusted data.

## Fix

A valid serialised C string always stores a byte count of at least 1 (it includes the nul terminator), so reject a count of 0 before the subtraction.

## Validation (Ubuntu 24.04, clang 18, libobjc2, current master)

- **Unpatched:** a serialized C string with length `0` is accepted, producing a string with a bogus ~4-billion-byte length (the regression test's `PASS_EXCEPTION` fails — no exception).
- **Patched:** it raises `NSInvalidArgumentException`; the test passes.

Adds `Tests/base/NSSerializer/cstring.m` (builds a minimal malformed blob with `serializeInt: 0` and deserializes it) and a ChangeLog entry.
