### PR TITLE
NSCharacterSet: range-check the standard set index when decoding (OOB read + wild retain)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2026-06-19 Todd White <todd.white@thalion.global>
+
+	* Source/NSCharacterSet.m (-[NSCharacterSet initWithCoder:]): the abstract
+	class decoded an int from the archive and used it directly as an index into
+	the fixed-size cache_set[] array of standard sets with no bounds check, so a
+	crafted archive could read and -retain an out-of-bounds slot.  Range-check
+	the index.
+	* Tests/base/NSCharacterSet/coderindex.m: new regression test.
+
 2026-06-18 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Documentation/Base.gsdoc: minor tidy

--- a/Source/NSCharacterSet.m
+++ b/Source/NSCharacterSet.m
@@ -1074,6 +1074,12 @@ static gs_mutex_t cache_lock = GS_MUTEX_INIT_STATIC;
        */
       DESTROY(self);
       [aCoder decodeValueOfObjCType: @encode(int) at: &index];
+      if (index < 0 || index >= MAX_STANDARD_SETS)
+	{
+	  [NSException raise: NSInvalidArgumentException
+		      format: @"invalid standard character set index (%d)"
+	    @" in archive", index];
+	}
       self = RETAIN([abstractClass _staticSet: 0 length: 0 number: index]);
     }
   else

--- a/Tests/base/NSCharacterSet/coderindex.m
+++ b/Tests/base/NSCharacterSet/coderindex.m
@@ -1,0 +1,45 @@
+/*
+ * coderindex.m - regression test for -[NSCharacterSet initWithCoder:].
+ *
+ * The abstract NSCharacterSet -initWithCoder: decoded an int from the archive
+ * and used it directly as an index into the fixed-size cache_set[] array of
+ * standard character sets, with no bounds check, so a crafted archive could
+ * read (and -retain) an arbitrary out-of-bounds slot.  The index is now range
+ * checked.
+ */
+
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+
+/* Minimal coder that feeds one attacker-chosen int to -initWithCoder:. */
+@interface BadIndexCoder : NSCoder
+{
+@public
+  int	value;
+}
+@end
+
+@implementation BadIndexCoder
+- (void) decodeValueOfObjCType: (const char*)type at: (void*)data
+{
+  *(int*)data = value;
+}
+@end
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("NSCharacterSet initWithCoder index bounds")
+  BadIndexCoder	*c = [BadIndexCoder new];
+
+  c->value = 99999;	/* far past the 21 standard character sets */
+  PASS_EXCEPTION(
+    [[NSCharacterSet alloc] initWithCoder: c],
+    NSInvalidArgumentException,
+    "an out-of-range standard character set index in an archive is rejected")
+
+  RELEASE(c);
+  END_SET("NSCharacterSet initWithCoder index bounds")
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

The abstract `-[NSCharacterSet initWithCoder:]` decodes an `int` from the archive and uses it directly as an index into the fixed-size cache of standard character sets:

```objc
if ([self class] == abstractClass)
  {
    int index;
    DESTROY(self);
    [aCoder decodeValueOfObjCType: @encode(int) at: &index];
    self = RETAIN([abstractClass _staticSet: 0 length: 0 number: index]);
  }
```

`_staticSet:length:number:` indexes `static NSCharacterSet *cache_set[MAX_STANDARD_SETS]` (21 entries) with `number` and **no bounds or sign check**. A crafted archive supplying an out-of-range `index` causes an out-of-bounds read of memory past the static array, and `RETAIN()` then sends `-retain` to whatever (possibly non-nil garbage) pointer is read — a wild message send. The only existing gate is a class-identity check, not an index check. Reachable when unarchiving an untrusted archive (e.g. via NSUnarchiver / distributed objects).

## Fix

Reject an `index` outside `0..MAX_STANDARD_SETS` before using it.

## Validation (Ubuntu 24.04, clang 18, libobjc2, current master)

- **Unpatched:** decoding an out-of-range index aborts — the out-of-bounds cache slot is read and `-retain`ed.
- **Patched:** it raises `NSInvalidArgumentException`; the test passes.

Adds `Tests/base/NSCharacterSet/coderindex.m` (a minimal coder that feeds an out-of-range index to `-initWithCoder:`) and a ChangeLog entry.
