### PR TITLE
NSInvocation: reject an invalid method signature when decoding (nil-self OOB write)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2026-06-19 Todd White <todd.white@thalion.global>
+
+	* Source/NSInvocation.m (-[NSInvocation initWithCoder:]): when the decoded
+	method-type string was missing or unparseable, the method signature and the
+	replacement invocation were nil, but the method went on to decode the
+	target, selector and arguments through ivars off the nil self (a near-NULL
+	out-of-bounds write).  Reject a nil signature before touching the ivars.
+	* Tests/base/NSInvocation/codersig.m: new regression test.
+
 2026-06-18 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Documentation/Base.gsdoc: minor tidy

--- a/Source/NSInvocation.m
+++ b/Source/NSInvocation.m
@@ -762,6 +762,15 @@ _arg_addr(NSInvocation *inv, int index)
 
   DESTROY(self);
   self = RETAIN([NSInvocation invocationWithMethodSignature: newSig]);
+  if (self == nil)
+    {
+      /* The decoded method type was missing or unparseable, so there is no
+       * signature and hence no instance: reject the archive rather than
+       * decoding the remaining values through ivars off a nil self.
+       */
+      [NSException raise: NSInvalidArgumentException
+		  format: @"invalid method signature in archived NSInvocation"];
+    }
 
   [aCoder decodeValueOfObjCType: @encode(id) at: &_target];
 

--- a/Tests/base/NSInvocation/codersig.m
+++ b/Tests/base/NSInvocation/codersig.m
@@ -1,0 +1,52 @@
+/*
+ * codersig.m - regression test for -[NSInvocation initWithCoder:].
+ *
+ * -initWithCoder: decoded the method-type string, built a method signature
+ * from it, and replaced self with +invocationWithMethodSignature:.  When the
+ * type string was missing or unparseable the signature (and hence the
+ * invocation) was nil, but the method went on to decode the target/selector
+ * and arguments "through" ivars off the nil self - a near-NULL out-of-bounds
+ * write.  A nil signature is now rejected.
+ */
+
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+
+/* Minimal coder that feeds an empty method-type string to -initWithCoder:. */
+@interface BadSigCoder : NSCoder
+@end
+
+@implementation BadSigCoder
+- (void) decodeValueOfObjCType: (const char*)type at: (void*)data
+{
+  if (type[0] == '*')		/* @encode(char*): the method type string */
+    {
+      /* empty string, NSZoneMalloc'd so -initWithCoder: can NSZoneFree it */
+      char	*s = NSZoneMalloc(NSDefaultMallocZone(), 1);
+
+      s[0] = '\0';
+      *(char**)data = s;
+    }
+  else
+    {
+      *(void**)data = 0;
+    }
+}
+@end
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("NSInvocation initWithCoder bad signature")
+  BadSigCoder	*c = [BadSigCoder new];
+
+  PASS_EXCEPTION(
+    [[NSInvocation alloc] initWithCoder: c],
+    NSInvalidArgumentException,
+    "an invalid method type string in an archive is rejected, not decoded through a nil invocation")
+
+  RELEASE(c);
+  END_SET("NSInvocation initWithCoder bad signature")
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

`-[NSInvocation initWithCoder:]` decodes a method-type string from the archive, builds a method signature from it, and replaces `self` with the result of `+invocationWithMethodSignature:`:

```objc
[aCoder decodeValueOfObjCType: @encode(char*) at: &types];
newSig = [NSMethodSignature signatureWithObjCTypes: types];
...
DESTROY(self);
self = RETAIN([NSInvocation invocationWithMethodSignature: newSig]);

[aCoder decodeValueOfObjCType: @encode(id) at: &_target];     // self may be nil
[aCoder decodeValueOfObjCType: @encode(SEL) at: &_selector];
...
```

An empty (or otherwise unparseable) `types` string makes `+signatureWithObjCTypes:` return nil, so `+invocationWithMethodSignature:nil` returns nil and `self` becomes nil. The method then decodes the target, selector and arguments into `_target`/`_selector`/… — i.e. through `self->_target` etc. with `self == nil` — a write at a small fixed offset off the null pointer (a near-NULL out-of-bounds write). These are raw `self`-relative stores, not Objective-C message sends, so nil-messaging semantics do not make them safe. Reachable when unarchiving an untrusted archive.

## Fix

Reject a nil signature (nil invocation) before touching any ivars.

## Validation (Ubuntu 24.04, clang 18, libobjc2, current master)

- **Unpatched:** decoding an invocation whose method-type string is empty aborts — the target is written through a nil `self`.
- **Patched:** it raises `NSInvalidArgumentException`; the test passes.

Adds `Tests/base/NSInvocation/codersig.m` (a minimal coder that feeds an empty method-type string to `-initWithCoder:`) and a ChangeLog entry.
