### PR TITLE
NSValue: heap-allocate the serialized buffer when decoding (stack VLA overflow)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2026-06-20 Todd White <todd.white@thalion.global>
+
+	* Source/NSValue.m (-[NSValue initWithCoder:]): in the version >= 2 decode
+	path, when the unpacked type size was <= 64 the serialized bytes were placed
+	in a stack VLA whose length came straight from the (untrusted) archive, so a
+	large size overran the stack.  Heap-allocate the serialized buffer, as the
+	> 64 case already does.
+	* Tests/base/NSValue/TestInfo: add the marker so the directory is run.
+	* Tests/base/NSValue/codervla.m: new regression test.
+
 2026-06-20 Richard Frith-Macdonald <rfm@gnu.org>
 
         * Headers/Foundation/NSDecimalNumber.h:

--- a/Source/NSValue.m
+++ b/Source/NSValue.m
@@ -733,7 +733,11 @@ static gs_mutex_t               placeholderLock = GS_MUTEX_INIT_STATIC;
 
 	  [coder decodeValueOfObjCType: @encode(unsigned) at: &size];
 	  {
-	    unsigned char	serialized[size];
+	    /* size is decoded from the (untrusted) archive, so the serialized
+	     * buffer is heap allocated, as in the tsize > 64 case below, rather
+	     * than placed in a stack VLA that an arbitrary size could overflow. */
+	    unsigned char	*serialized
+	      = (unsigned char*)NSZoneMalloc(NSDefaultMallocZone(), size);
 
 	    [coder decodeArrayOfObjCType: @encode(unsigned char)
 				   count: size
@@ -745,6 +749,7 @@ static gs_mutex_t               placeholderLock = GS_MUTEX_INIT_STATIC;
 		      ofObjCType: objctype
 			atCursor: &cursor
 			 context: nil];
+	    NSZoneFree(NSDefaultMallocZone(), serialized);
 	  }
 	  o = [o initWithBytes: data objCType: objctype];
 	}

--- a/Tests/base/NSValue/codervla.m
+++ b/Tests/base/NSValue/codervla.m
@@ -1,0 +1,86 @@
+/*
+ * codervla.m - regression test for -[NSValue initWithCoder:].
+ *
+ * In the (default, version >= 2) decode path, when the value's unpacked type
+ * size was <= 64 the method placed the serialized bytes in a stack VLA
+ * `unsigned char serialized[size]' whose length came straight from the
+ * (untrusted) archive.  A large size therefore overran the stack.  The
+ * serialized buffer is now heap allocated, as the > 64 case already was.
+ *
+ * The test drives -initWithCoder: with a minimal coder that supplies a small
+ * "c" (char) object type and then an enormous serialized size.  Unpatched this
+ * blows the stack; patched the (large but heap) buffer is handled cleanly.
+ */
+
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+
+/* 64 MB: far larger than any thread stack, but a trivial heap allocation. */
+#define HUGE_SIZE (64u * 1024u * 1024u)
+
+@interface VLACoder : NSCoder
+{
+  int	unsignedCalls;
+}
+@end
+
+@implementation VLACoder
+- (void) decodeValueOfObjCType: (const char*)type at: (void*)data
+{
+  if (strcmp(type, @encode(unsigned)) == 0)
+    {
+      /* First unsigned decoded is the length of the object-type string;
+       * the second is the serialized-buffer size (the attack value). */
+      if (unsignedCalls++ == 0)
+	{
+	  *(unsigned*)data = 2;
+	}
+      else
+	{
+	  *(unsigned*)data = HUGE_SIZE;
+	}
+    }
+}
+- (void) decodeArrayOfObjCType: (const char*)type
+			 count: (NSUInteger)count
+			    at: (void*)data
+{
+  /* The object-type string: a plain char value ("c"); valueClassWithObjCType:
+   * maps this to the generic concrete value class, which is what reaches the
+   * serialized-buffer branch. */
+  if (strcmp(type, @encode(signed char)) == 0 && count >= 2)
+    {
+      char	*p = (char*)data;
+
+      p[0] = 'c';
+      p[1] = '\0';
+    }
+  /* @encode(unsigned char): the serialized payload - left untouched. */
+}
+- (NSInteger) versionForClassName: (NSString*)className
+{
+  return 3;
+}
+- (NSZone*) objectZone
+{
+  return NSDefaultMallocZone();
+}
+@end
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("NSValue initWithCoder serialized size")
+  VLACoder	*c = [VLACoder new];
+  NSValue	*v;
+
+  v = [[NSValue alloc] initWithCoder: c];
+  PASS(v != nil,
+    "decoding an NSValue with a large serialized size does not overflow the stack")
+
+  RELEASE(v);
+  RELEASE(c);
+  END_SET("NSValue initWithCoder serialized size")
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

In `-[NSValue initWithCoder:]`, the default (version ≥ 2) decode path handles small values on the stack. When the value's unpacked type size is ≤ 64, the *serialized* bytes are placed in a stack VLA whose length comes straight from the (untrusted) archive:

```objc
if (tsize <= 64)
  {
    unsigned char data[tsize];                 // bounded by tsize<=64 -- safe

    [coder decodeValueOfObjCType: @encode(unsigned) at: &size];   // from archive
    {
      unsigned char serialized[size];          // <-- unbounded stack VLA
      [coder decodeArrayOfObjCType: @encode(unsigned char) count: size at: serialized];
      ...
    }
  }
```

A crafted archive supplying a large `size` makes `serialized[size]` overflow the stack (stack-clash / crash, potential corruption). Reachable when unarchiving an NSValue with a non-standard object type (so the class is the generic concrete value class rather than one of the NSPoint/NSSize/NSRange/NSRect early-return cases).

The sibling `tsize > 64` branch already heap-allocates this buffer with `NSZoneMalloc(size)` / `NSZoneFree`, so the ≤ 64 branch is simply inconsistent.

## Fix

Heap-allocate (and free) the serialized buffer in the ≤ 64 branch, exactly as the > 64 branch already does. The bounded `data[tsize]` stack buffer is unchanged.

## Validation (Ubuntu 24.04, clang 18, libobjc2, current master)

- **Unpatched:** decoding an NSValue whose serialized `size` is 64 MB aborts — the stack VLA overflows the stack.
- **Patched:** the buffer is heap-allocated and the decode completes; the regression test passes.

Adds `Tests/base/NSValue/codervla.m` (a minimal coder that drives `-initWithCoder:` with a small `char` object type and an enormous serialized size) and a ChangeLog entry. Also adds `Tests/base/NSValue/TestInfo` — that marker was missing, so the directory (including the existing `basic.m`) was being skipped by the test runner.
