### PR TITLE
NSAttributedString: bound the NSAttributeInfo varint decode (OOB read)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2026-06-20 Todd White <todd.white@thalion.global>
+
+	* Source/NSAttributedString.m (-[NSAttributedString initWithCoder:],
+	-[NSMutableAttributedString initWithCoder:]): the variable-length integer
+	decode loops for NSAttributeInfo (`while (*p & 0x80)' and the trailing
+	`*p++') had no `p < end' bound, so an NSAttributeInfo value ending in a
+	continuation byte read past the end of the buffer.  Bound both loops (and
+	the trailing byte) by end.
+	* Tests/base/NSAttributedString/coderinfo.m: new regression test.
+
 2026-06-20 Richard Frith-Macdonald <rfm@gnu.org>
 
         * Headers/Foundation/NSDecimalNumber.h:

--- a/Source/NSAttributedString.m
+++ b/Source/NSAttributedString.m
@@ -266,20 +266,26 @@ appendUIntData(NSMutableData *d, NSUInteger i)
               NSRange r;
 
 	      len = shift = 0;
-	      while (*p & 0x80)
+	      while (p < end && (*p & 0x80))
 		{
 		  len += (*p++ - 128) << shift;
 		  shift += 7;
 		}
-	      len += *p++ << shift;
+	      if (p < end)
+		{
+		  len += *p++ << shift;
+		}
 
 	      idx = shift = 0;
-	      while (*p & 0x80)
+	      while (p < end && (*p & 0x80))
 		{
 		  idx += (*p++ - 128) << shift;
 		  shift += 7;
 		}
-	      idx += *p++ << shift;
+	      if (p < end)
+		{
+		  idx += *p++ << shift;
+		}
 
               r = NSMakeRange(pos, len);
 	      [m setAttributes: [attributes objectAtIndex: idx] range: r];
@@ -776,20 +782,26 @@ appendUIntData(NSMutableData *d, NSUInteger i)
               NSRange r;
 
 	      len = shift = 0;
-	      while (*p & 0x80)
+	      while (p < end && (*p & 0x80))
 		{
 		  len += (*p++ - 128) << shift;
 		  shift += 7;
 		}
-	      len += *p++ << shift;
+	      if (p < end)
+		{
+		  len += *p++ << shift;
+		}
 
 	      idx = shift = 0;
-	      while (*p & 0x80)
+	      while (p < end && (*p & 0x80))
 		{
 		  idx += (*p++ - 128) << shift;
 		  shift += 7;
 		}
-	      idx += *p++ << shift;
+	      if (p < end)
+		{
+		  idx += *p++ << shift;
+		}
 
               r = NSMakeRange(pos, len);
 	      [self setAttributes: [attributes objectAtIndex: idx] range: r];

--- a/Tests/base/NSAttributedString/coderinfo.m
+++ b/Tests/base/NSAttributedString/coderinfo.m
@@ -1,0 +1,96 @@
+/*
+ * coderinfo.m - regression test for -[NSAttributedString initWithCoder:].
+ *
+ * The keyed-decoding path unpacks per-attribute-run lengths and indices from
+ * the NSAttributeInfo data as a sequence of variable-length integers.  The
+ * inner decode loops `while (*p & 0x80)' (and the following `*p++') had no
+ * `p < end' bound, so an NSAttributeInfo value ending in a continuation byte
+ * (high bit set) read past the end of the buffer.  The loops are now bounded.
+ *
+ * To make the over-read observable rather than silently reading adjacent heap,
+ * the single 0x80 byte is placed at the very end of a page whose successor
+ * page is unmapped, so any read past it faults.  (Unix only; on other
+ * platforms the test is skipped.)
+ */
+
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+
+#if defined(__unix__) || defined(__APPLE__)
+#include <sys/mman.h>
+#include <unistd.h>
+#define HAVE_GUARD_PAGE 1
+#endif
+
+/* Minimal keyed coder supplying just the keys -initWithCoder: reads. */
+@interface InfoCoder : NSCoder
+{
+@public
+  NSData	*info;
+}
+@end
+
+@implementation InfoCoder
+- (BOOL) allowsKeyedCoding			{ return YES; }
+- (BOOL) containsValueForKey: (NSString*)k	{ return YES; }
+- (id) decodeObjectForKey: (NSString*)k
+{
+  if ([k isEqual: @"NSString"])
+    {
+      return @"AB";
+    }
+  if ([k isEqual: @"NSAttributeInfo"])
+    {
+      return info;
+    }
+  if ([k isEqual: @"NSAttributes"])
+    {
+      return [NSArray arrayWithObject: [NSDictionary dictionary]];
+    }
+  return nil;
+}
+@end
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("NSAttributedString NSAttributeInfo over-read")
+#if HAVE_GUARD_PAGE
+  long		pg = sysconf(_SC_PAGESIZE);
+  unsigned char	*base;
+
+  base = mmap(NULL, 2 * pg, PROT_READ | PROT_WRITE,
+    MAP_PRIVATE | MAP_ANON, -1, 0);
+  if (base == MAP_FAILED)
+    {
+      SKIP("could not mmap a guard page")
+    }
+  else
+    {
+      InfoCoder		*c;
+      NSAttributedString	*s;
+      unsigned char	*infoByte = base + pg - 1;
+
+      /* Make the second page inaccessible; put a lone continuation byte at the
+       * last accessible byte so a read past it hits the guard page. */
+      mprotect(base + pg, pg, PROT_NONE);
+      *infoByte = 0x80;
+
+      c = [InfoCoder new];
+      c->info = [NSData dataWithBytesNoCopy: infoByte length: 1 freeWhenDone: NO];
+
+      s = [[NSAttributedString alloc] initWithCoder: c];
+      PASS(s != nil,
+	"decoding NSAttributeInfo that ends in a continuation byte does not read past the buffer")
+
+      RELEASE(s);
+      RELEASE(c);
+      munmap(base, 2 * pg);
+    }
+#else
+  SKIP("guard-page mechanism is Unix only")
+#endif
+  END_SET("NSAttributedString NSAttributeInfo over-read")
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

The keyed-decoding path of `-[NSAttributedString initWithCoder:]` (and the `NSMutableAttributedString` override) unpacks per-attribute-run lengths and indices from the `NSAttributeInfo` data as a sequence of variable-length integers. The outer loop is bounded (`while (p < end)`), but the inner varint loops and the trailing read are not:

```objc
while (*p & 0x80)              // no p < end check
  {
    len += (*p++ - 128) << shift;
    shift += 7;
  }
len += *p++ << shift;          // no p < end check
```

An `NSAttributeInfo` value that ends in a continuation byte (high bit set) makes the inner loop read — and keep advancing — past the end of the buffer. With the data ending exactly on a `0x80`, `*p++` advances `p` to `end` and the loop condition re-reads `*end` (one past the buffer), continuing further while subsequent out-of-bounds bytes also have the high bit set. Reachable when decoding an untrusted archive (the same byte sequence appears in both the immutable and mutable `initWithCoder:`).

## Fix

Bound both inner loops and the trailing byte by `end` (`while (p < end && (*p & 0x80))` / `if (p < end)`), in both methods. A truncated record then stops cleanly instead of over-reading.

## Validation (Ubuntu 24.04, clang 18, libobjc2, current master)

The regression test places a lone `0x80` continuation byte at the very end of a page whose successor page is unmapped (`mmap` + `mprotect`), so any read past the byte faults — making the over-read observable rather than silently reading adjacent heap.

- **Unpatched:** decoding faults (SIGSEGV on the guard page).
- **Patched:** the decode is bounded and completes; the test passes.

Adds `Tests/base/NSAttributedString/coderinfo.m` (guard-page mechanism is Unix-only; the test `SKIP`s elsewhere) and a ChangeLog entry.
