### PR TITLE
NSPropertyList: bounds-check binary plist string objects (OOB read)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2026-06-20 Todd White <todd.white@thalion.global>
+
+	* Source/NSPropertyList.m (-[GSBinaryPLParser objectAtIndex:]): the four
+	string object cases (short and long UTF-8 and UTF-16, markers 0x50-0x5F and
+	0x60-0x6F) read len bytes from the object body without checking that the
+	body stayed within the data, unlike the sibling data cases, so a string
+	object declaring a length past the end read out of bounds.  Validate the
+	length against the remaining data before reading.
+	* Tests/base/NSPropertyList/bplist-string-bounds.m: new regression test.
+
 2026-06-20 Richard Frith-Macdonald <rfm@gnu.org>
 
         * Headers/Foundation/NSDecimalNumber.h:

--- a/Source/NSPropertyList.m
+++ b/Source/NSPropertyList.m
@@ -3353,6 +3353,11 @@ NSAssert(counter + len <= _length, NSInvalidArgumentException);
 	  s = [NSString alloc];
 	}
       len = next - 0x50;
+      if (counter > _length || len > _length - counter)
+	{
+	  [NSException raise: NSInvalidArgumentException
+	    format: @"binary plist string extends beyond the supplied data"];
+	}
       s = [s initWithBytes: _bytes + counter
                     length: len
                   encoding: NSUTF8StringEncoding];
@@ -3372,6 +3377,11 @@ NSAssert(counter + len <= _length, NSInvalidArgumentException);
 	  s = [NSString alloc];
 	}
       len = [self readCountAt: &counter];
+      if (counter > _length || len > _length - counter)
+	{
+	  [NSException raise: NSInvalidArgumentException
+	    format: @"binary plist string extends beyond the supplied data"];
+	}
       s = [s initWithBytes: _bytes + counter
                     length: len
                   encoding: NSUTF8StringEncoding];
@@ -3391,6 +3401,11 @@ NSAssert(counter + len <= _length, NSInvalidArgumentException);
 	  s = [NSString alloc];
 	}
       len = next - 0x60;
+      if (counter > _length || len > (_length - counter) / sizeof(unichar))
+	{
+	  [NSException raise: NSInvalidArgumentException
+	    format: @"binary plist string extends beyond the supplied data"];
+	}
       s = [s initWithBytes: _bytes + counter
                     length: len * sizeof(unichar)
                   encoding: NSUTF16BigEndianStringEncoding];
@@ -3410,6 +3425,11 @@ NSAssert(counter + len <= _length, NSInvalidArgumentException);
 	  s = [NSString alloc];
 	}
       len = [self readCountAt: &counter];
+      if (counter > _length || len > (_length - counter) / sizeof(unichar))
+	{
+	  [NSException raise: NSInvalidArgumentException
+	    format: @"binary plist string extends beyond the supplied data"];
+	}
       s = [s initWithBytes: _bytes + counter
                     length: len * sizeof(unichar)
                   encoding: NSUTF16BigEndianStringEncoding];

--- a/Tests/base/NSPropertyList/bplist-string-bounds.m
+++ b/Tests/base/NSPropertyList/bplist-string-bounds.m
@@ -1,0 +1,59 @@
+/*
+ * bplist-string-bounds.m - regression test for the binary property list parser.
+ *
+ * In -[GSBinaryPLParser objectAtIndex:] the string object cases (short/long
+ * UTF-8 and UTF-16, markers 0x50-0x5F and 0x60-0x6F) read `len' bytes from the
+ * object body with no check that the body stays within the data - unlike the
+ * sibling data cases (0x40-0x4F).  A crafted string object claiming a length
+ * past the end of the data therefore read out of bounds.  The string cases now
+ * validate the length against the remaining data.
+ */
+
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("binary plist string length bounds")
+  /* A minimal bplist00 whose single (root) object is a long UTF-8 string
+   * (marker 0x5F) declaring a 0x00FFFFFF (16 MB) length, with no string body.
+   * Layout:
+   *   [0..7]   "bplist00"
+   *   [8]      0x5F            long UTF-8 string
+   *   [9]      0x12            4-byte count follows
+   *   [10..13] 00 FF FF FF     length = 0x00FFFFFF
+   *   [14]     0x08            offset table: object 0 is at offset 8
+   *   [15..46] 32-byte trailer (offset_size=1, index_size=1,
+   *            object_count=1, root_index=0, table_start=14)
+   */
+  unsigned char	buf[47];
+  NSData	*d;
+  NSError	*err = (NSError*)@"sentinel";
+  id		result = @"sentinel";
+
+  memset(buf, 0, sizeof(buf));
+  memcpy(buf, "bplist00", 8);
+  buf[8]  = 0x5F;
+  buf[9]  = 0x12;
+  buf[10] = 0x00; buf[11] = 0xFF; buf[12] = 0xFF; buf[13] = 0xFF;
+  buf[14] = 0x08;
+  buf[15 + 6]  = 0x01;	/* offset_size */
+  buf[15 + 7]  = 0x01;	/* index_size  */
+  buf[15 + 15] = 0x01;	/* object_count = 1 */
+  buf[15 + 31] = 14;	/* table_start = 14 */
+
+  d = [NSData dataWithBytes: buf length: sizeof(buf)];
+  result = [NSPropertyListSerialization propertyListWithData: d
+                                                    options: 0
+                                                     format: NULL
+                                                      error: &err];
+  PASS(result == nil,
+    "a binary plist string claiming a length past the data is rejected")
+  PASS(err != nil && [err isKindOfClass: [NSError class]],
+    "the over-long binary plist string sets the error out-parameter")
+
+  END_SET("binary plist string length bounds")
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

In `-[GSBinaryPLParser objectAtIndex:]`, the **data** object cases (markers `0x40`-`0x4F`) check `counter + len <= _length` before reading the body, but the four **string** object cases do not:

```objc
else if (next == 0x5F)
  {
    ...
    len = [self readCountAt: &counter];
    s = [s initWithBytes: _bytes + counter   // reads len bytes, unchecked
                  length: len
                encoding: NSUTF8StringEncoding];
    ...
  }
```

This affects short UTF-8 (`0x50`-`0x5E`), long UTF-8 (`0x5F`), short UTF-16 (`0x60`-`0x6E`) and long UTF-16 (`0x6F`). A binary property list whose string object declares a `len` past the end of the data reads out of bounds (`len`, or `len * sizeof(unichar)`, bytes from the body). Reachable from `+[NSPropertyListSerialization propertyListWithData:...]` on untrusted data.

## Fix

Validate the declared length against the remaining data before reading, overflow-safely, and raise `NSInvalidArgumentException` on a bad length — in all four string cases. (For the UTF-16 cases the byte count is `len * sizeof(unichar)`, so the check divides rather than multiplies to avoid its own overflow.)

## Validation (Ubuntu 24.04, clang 18, libobjc2, current master)

The regression test feeds a 47-byte `bplist00` whose root object is a long UTF-8 string declaring a 16 MB length with no body.

- **Unpatched:** parsing reads ~16 MB past the 47-byte buffer and crashes.
- **Patched:** the parser rejects it, returning `nil` with the error out-parameter set (2 assertions pass).

The crash in the unpatched run confirms the crafted plist genuinely reaches the string-object case (so the new check is exercised, not bypassed by an earlier rejection).

Adds `Tests/base/NSPropertyList/bplist-string-bounds.m` and a ChangeLog entry.

## Note

The sibling data cases use `NSAssert` for their bound, which is compiled out under `NS_BLOCK_ASSERTIONS` (release builds). Because these string reads are on untrusted input, the new checks are real runtime checks rather than assertions; happy to convert the data-case asserts to match if you'd prefer that done here too.
