### PR TITLE
NSCalendarDate: grow the format buffer by at least the requested size (heap overflow)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2026-06-20 Todd White <todd.white@thalion.global>
+
+	* Source/NSCalendarDate.m (Grow): the helper that enlarges the date
+	formatting buffer always grew by a fixed 512 unichars, so a format field
+	longer than that increment (e.g. a long month or weekday name supplied
+	through the locale) left the buffer too small and the following
+	-getCharacters: wrote past its end.  Grow by at least the requested size.
+	* Tests/base/NSCalendarDate/growname.m: new regression test.
+
 2026-06-20 Richard Frith-Macdonald <rfm@gnu.org>
 
         * Headers/Foundation/NSDecimalNumber.h:

--- a/Source/NSCalendarDate.m
+++ b/Source/NSCalendarDate.m
@@ -1888,20 +1888,25 @@ static void Grow(DescriptionInfo *info, unsigned size)
 {
   if (info->offset + size >= info->length)
     {
+      /* Grow by at least 'size' so a single field larger than the fixed
+       * increment (e.g. a long locale-supplied month or weekday name) does
+       * not leave the buffer too small for the caller's write. */
+      unsigned	want = info->length + (size > 512 ? size : 512);
+
       if (info->t == info->base)
 	{
 	  unichar	*old = info->t;
 
 	  info->t = NSZoneMalloc(NSDefaultMallocZone(),
-	    (info->length + 512) * sizeof(unichar));
+	    want * sizeof(unichar));
 	  memcpy(info->t, old, info->length*sizeof(unichar));
 	}
       else
 	{
 	  info->t = NSZoneRealloc(NSDefaultMallocZone(), info->t,
-	    (info->length + 512) * sizeof(unichar));
+	    want * sizeof(unichar));
 	}
-      info->length += 512;
+      info->length = want;
     }
 }
 

--- a/Tests/base/NSCalendarDate/growname.m
+++ b/Tests/base/NSCalendarDate/growname.m
@@ -1,0 +1,50 @@
+/*
+ * growname.m - regression test for -[NSCalendarDate descriptionWithCalendarFormat:locale:].
+ *
+ * The internal Grow() helper, used to enlarge the output buffer while
+ * formatting a date, always grew by a fixed 512 unichars.  A format field
+ * whose text is longer than that increment - e.g. a long month/weekday name
+ * supplied through the locale - left the buffer too small, so the following
+ * -getCharacters: wrote past the end of the buffer.  Grow() now grows by at
+ * least the requested size.
+ */
+
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("NSCalendarDate format buffer growth")
+  NSCalendarDate	*date;
+  NSString		*longName;
+  NSMutableArray	*months;
+  NSDictionary		*locale;
+  NSString		*s;
+  unsigned		i;
+
+  /* A month name far longer than Grow()'s 512-unichar increment. */
+  longName = [@"" stringByPaddingToLength: 200000
+			       withString: @"X"
+			      startingAtIndex: 0];
+  months = [NSMutableArray arrayWithCapacity: 12];
+  [months addObject: longName];		/* January */
+  for (i = 1; i < 12; i++)
+    {
+      [months addObject: @"M"];
+    }
+  locale = [NSDictionary dictionaryWithObject: months
+				      forKey: NSMonthNameArray];
+
+  date = [NSCalendarDate dateWithYear: 2020 month: 1 day: 1
+			         hour: 12 minute: 0 second: 0
+			     timeZone: [NSTimeZone timeZoneForSecondsFromGMT: 0]];
+
+  s = [date descriptionWithCalendarFormat: @"%B" locale: locale];
+  PASS([s length] == 200000,
+    "a locale month name longer than the buffer increment does not overflow")
+
+  END_SET("NSCalendarDate format buffer growth")
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

The `Grow()` helper used by `-[NSCalendarDate descriptionWithCalendarFormat:locale:]` to enlarge the output buffer always grows by a fixed 512 unichars:

```c
static void Grow(DescriptionInfo *info, unsigned size)
{
  if (info->offset + size >= info->length)
    {
      ... realloc to (info->length + 512) ...
      info->length += 512;
    }
}
```

`size` is the number of unichars the caller is about to write. When `size` exceeds the increment (or `offset + size` exceeds `length` by more than 512), `Grow()` returns with the buffer still too small. The `%B`/`%A`/`%p` format handlers then write a locale-supplied month/weekday/AM-PM name past the end of the buffer:

```c
name = [months objectAtIndex: info->md - 1];
v = [name length];
Grow(info, v);
[name getCharacters: info->t + info->offset];   // writes v unichars
```

So a long name supplied through the `locale` dictionary overflows the heap buffer.

## Fix

Grow by at least the requested `size` (`info->length + MAX(512, size)`), so the buffer is always large enough for the caller's write. One helper, covering every caller.

## Validation (Ubuntu 24.04, clang 18, libobjc2, current master)

- **Unpatched:** formatting a date with `%B` against a locale whose January name is 200,000 characters overruns the buffer and crashes.
- **Patched:** the buffer grows to fit and the formatted string is produced (length 200,000); the test passes.

Adds `Tests/base/NSCalendarDate/growname.m` and a ChangeLog entry.
