### PR TITLE
NSPropertyList: bounds-check binary plist big array/dict element counts

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,18 @@
+2026-06-20 Todd White <todd.white@thalion.global>
+
+	* Source/NSPropertyList.m (-[GSBinaryPLParser objectAtIndex:]): the
+	0xAF "big array" and 0xDF "big dictionary" cases read an element
+	count straight from the (untrusted) data and used it both to size the
+	NSAllocateCollectable() buffer and to bound the loop that reads that
+	many object-index entries, with no check that the data could hold
+	them.  A crafted marker declaring billions of elements over a few
+	bytes made the loop read object indices far past the end of the
+	buffer (and on 32-bit wrapped the sizeof(id)*count product to an
+	undersized allocation).  Reject a count that cannot fit in the bytes
+	remaining for the index entries before allocating or reading.
+	* Tests/base/NSPropertyList/bplist-bigcontainer-bounds.m: new
+	regression test.
+
 2026-06-20 Richard Frith-Macdonald <rfm@gnu.org>
 
         * Headers/Foundation/NSDecimalNumber.h:

--- a/Source/NSPropertyList.m
+++ b/Source/NSPropertyList.m
@@ -3466,6 +3466,11 @@ NSAssert(counter + len <= _length, NSInvalidArgumentException);
       id	*objects;
 
       len = [self readCountAt: &counter];
+      if (counter > _length || len > (_length - counter) / index_size)
+	{
+	  [NSException raise: NSGenericException
+		format: @"Invalid binary property list array size %lu", len];
+	}
       objects = NSAllocateCollectable(sizeof(id) * len, NSScannedOption);
       PUSH_OBJ(index);
       for (i = 0; i < len; i++)
@@ -3531,6 +3536,11 @@ NSAssert(counter + len <= _length, NSInvalidArgumentException);
       id	*values;
 
       len = [self readCountAt: &counter];
+      if (counter > _length || len > (_length - counter) / (2 * index_size))
+	{
+	  [NSException raise: NSGenericException
+		format: @"Invalid binary property list dictionary size %lu", len];
+	}
       keys = NSAllocateCollectable(sizeof(id) * len * 2, NSScannedOption);
       values = keys + len;
       PUSH_OBJ(index);

--- a/Tests/base/NSPropertyList/bplist-bigcontainer-bounds.m
+++ b/Tests/base/NSPropertyList/bplist-bigcontainer-bounds.m
@@ -1,0 +1,151 @@
+/*
+ * bplist-bigcontainer-bounds.m - regression test for the binary
+ * property list "big" array (0xAF) and dictionary (0xDF) element
+ * counts.
+ *
+ * When GSBinaryPLParser -objectAtIndex: meets a 0xAF or 0xDF marker it
+ * reads an element count straight from the data and then both
+ *
+ *     objects = NSAllocateCollectable(sizeof(id) * count, ...)
+ *
+ * and a loop that calls -readObjectIndexAt: count (array) or 2*count
+ * (dictionary) times.  Neither the allocation nor the loop was bounded
+ * against the amount of data actually present, so a crafted marker that
+ * declares billions of elements over a handful of bytes makes the loop
+ * read object indices far past the end of the buffer (and, on 32-bit,
+ * wraps the sizeof(id)*count product to an undersized allocation).  The
+ * fix bounds count by the bytes remaining for the index entries:
+ *
+ *     count > (_length - counter) / index_size           (array)
+ *     count > (_length - counter) / (2 * index_size)      (dictionary)
+ *
+ * which never forms the overflowing product and rejects the implausible
+ * count before allocating or reading.
+ *
+ * These buffers cannot be produced by +dataWithPropertyList:; the test
+ * assembles them directly as raw bytes.
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+/* Build a bplist whose single (root) object is a "big" container
+ * marker (0xAF array or 0xDF dictionary) declaring 'count' elements via
+ * a 0x12 four-byte length, over an otherwise empty body.  A one-entry
+ * offset table and a 32-byte trailer make the buffer pass the
+ * structural checks in -initWithData: so that parsing reaches
+ * -objectAtIndex: and the big-container branch.
+ */
+static NSData *
+craftBigContainer(uint8_t marker, uint32_t count)
+{
+  unsigned char	buf[47];
+  unsigned char	*b = buf;
+  unsigned char	*tr;
+
+  memset(buf, 0, sizeof(buf));
+  memcpy(b, "bplist00", 8);
+
+  /* object 0 at offset 8: marker, 0x12, then a 4-byte big-endian count */
+  b[8]  = marker;
+  b[9]  = 0x12;
+  b[10] = (unsigned char)((count >> 24) & 0xff);
+  b[11] = (unsigned char)((count >> 16) & 0xff);
+  b[12] = (unsigned char)((count >>  8) & 0xff);
+  b[13] = (unsigned char)( count        & 0xff);
+
+  /* one-entry offset table at offset 14: object 0 lives at offset 8 */
+  b[14] = 0x08;
+
+  /* 32-byte trailer at offset 15: offset_size, index_size both 1,
+   * object_count 1, root_index 0, table_start 14 (low bytes only). */
+  tr = b + 15;
+  tr[6]  = 1;
+  tr[7]  = 1;
+  tr[15] = 1;
+  tr[23] = 0;
+  tr[31] = 14;
+
+  return [NSData dataWithBytes: buf length: sizeof(buf)];
+}
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("NSPropertyList binary plist big-container bounds")
+  NSMutableArray	*bigArray;
+  NSMutableDictionary	*bigDict;
+  NSData		*serialized;
+  NSData		*crafted;
+  unsigned		i;
+
+  /* Positive control: a real array large enough to be encoded with the
+   * 0xAF "big array" marker must still round-trip.  Guards against a fix
+   * that tightens the bound so far that valid input is rejected.
+   */
+  bigArray = [NSMutableArray array];
+  for (i = 0; i < 20; i++)
+    {
+      [bigArray addObject: [NSNumber numberWithUnsignedInt: i]];
+    }
+  serialized = [NSPropertyListSerialization
+                 dataWithPropertyList: bigArray
+                               format: NSPropertyListBinaryFormat_v1_0
+                              options: 0
+                                error: NULL];
+  PASS(serialized != nil, "20-element array serialized as a big-array bplist")
+  PASS_EQUAL([NSPropertyListSerialization
+               propertyListWithData: serialized
+                            options: NSPropertyListImmutable
+                              format: NULL
+                                error: NULL],
+    bigArray,
+    "valid big-array bplist round-trips through the parser")
+
+  /* Positive control: the dictionary equivalent for the 0xDF branch. */
+  bigDict = [NSMutableDictionary dictionary];
+  for (i = 0; i < 20; i++)
+    {
+      [bigDict setObject: [NSNumber numberWithUnsignedInt: i]
+                  forKey: [NSString stringWithFormat: @"k%u", i]];
+    }
+  serialized = [NSPropertyListSerialization
+                 dataWithPropertyList: bigDict
+                               format: NSPropertyListBinaryFormat_v1_0
+                              options: 0
+                                error: NULL];
+  PASS(serialized != nil, "20-entry dictionary serialized as a big-dict bplist")
+  PASS_EQUAL([NSPropertyListSerialization
+               propertyListWithData: serialized
+                            options: NSPropertyListImmutable
+                              format: NULL
+                                error: NULL],
+    bigDict,
+    "valid big-dict bplist round-trips through the parser")
+
+  /* Attack 1: a 0xAF big array that declares ~268M elements over a
+   * 47-byte buffer.  Without the bound the parser allocates for and
+   * walks billions of object indices past the end of the data.
+   */
+  crafted = craftBigContainer(0xAF, 0x0FFFFFFFu);
+  PASS_EQUAL(([NSPropertyListSerialization
+                    propertyListWithData: crafted
+                                 options: NSPropertyListImmutable
+                                  format: NULL
+                                   error: NULL]),
+    nil,
+    "0xAF big array with implausible element count rejected")
+
+  /* Attack 2: the 0xDF big-dictionary equivalent. */
+  crafted = craftBigContainer(0xDF, 0x0FFFFFFFu);
+  PASS_EQUAL(([NSPropertyListSerialization
+                    propertyListWithData: crafted
+                                 options: NSPropertyListImmutable
+                                  format: NULL
+                                   error: NULL]),
+    nil,
+    "0xDF big dictionary with implausible element count rejected")
+
+  END_SET("NSPropertyList binary plist big-container bounds")
+  return 0;
+}


### PR DESCRIPTION
## Summary

`-[GSBinaryPLParser objectAtIndex:]` handles the binary-plist `0xAF` "big array" and `0xDF` "big dictionary" markers by reading an element count straight from the (untrusted) data and then using it both to size the allocation:

```objc
len = [self readCountAt: &counter];
objects = NSAllocateCollectable(sizeof(id) * len, NSScannedOption);   // 0xAF
keys    = NSAllocateCollectable(sizeof(id) * len * 2, NSScannedOption); // 0xDF
```

and to bound the loop that reads that many object-index entries via `-readObjectIndexAt:`. Neither the allocation nor the loop is checked against the amount of data actually present, so a crafted marker declaring billions of elements over a handful of bytes makes the loop read object indices far past the end of the buffer. On 32-bit the `sizeof(id) * len` product also wraps to an undersized allocation.

This is the big-container sibling of the string-object bounds issue in #628 (same method).

## Fix

Reject a count that cannot fit in the bytes remaining for the index entries, before allocating or reading — the same shape used elsewhere in the parser:

```objc
if (counter > _length || len > (_length - counter) / index_size)        // array
if (counter > _length || len > (_length - counter) / (2 * index_size))  // dictionary
```

Dividing the non-negative `(_length - counter)` by `index_size` never forms the overflowing product, and the implausible count is rejected before any allocation or read.

## Test

`Tests/base/NSPropertyList/bplist-bigcontainer-bounds.m` (raw bytes — these buffers can't be produced by `+dataWithPropertyList:`):
- positive controls: a real 20-element array and 20-entry dictionary, both large enough to be encoded with the `0xAF`/`0xDF` markers, round-trip;
- attacks: crafted `0xAF`/`0xDF` buffers declaring ~268M elements over 47 bytes are rejected.

## Validation (Ubuntu 24.04, clang 18, libobjc2)

- **Positive control** (patched, in-tree lib): 6/6 assertions pass.
- **Negative control** (unpatched, in-tree lib): the two rejection assertions fail — the crafted buffers raise `NSRangeException` out of `propertyListWithData:` instead of returning nil.
- **Memory safety** (ASan replica of the read loop, built `-DNS_BLOCK_ASSERTIONS` so the `NSAssert` in `-readObjectIndexAt:` is compiled out, as in a release build): unpatched reports a `heap-buffer-overflow` READ in `readObjectIndexAt` as the loop walks the cursor past the buffer end; patched rejects the count with no allocation or read.
