### PR TITLE
NSXMLParser: fix unsigned underflow in comment/CDATA look-ahead bounds

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2026-06-20 Todd White <todd.white@thalion.global>
+
+	* Source/NSXMLParser.m (-[NSXMLParser parse]): the '<' tag handler
+	tested cp < cend - 8' when looking ahead for
+	"!--" and "![CDATA[", but cend is an unsigned NSUInteger, so a tag
+	with fewer than 3 (resp. 8) bytes remaining made the subtraction
+	underflow to a huge value, the guard passed, and the following
+	strncmp() read past the end of the buffer.  Test cp + 8 < cend' instead, equivalent whenever there are enough bytes
+	but without the underflow.
+	* Tests/base/NSXMLParser/cend-bounds.m: new regression test.
+
 2026-06-20 Richard Frith-Macdonald <rfm@gnu.org>
 
         * Headers/Foundation/NSDecimalNumber.h:

--- a/Source/NSXMLParser.m
+++ b/Source/NSXMLParser.m
@@ -1428,14 +1428,14 @@ NSLog(@"_processTag <%@%@ %@>", flag?@"/": @"", tag, attributes);
 	      this->ignorable = YES;
 	      this->whitespace = YES;
 
-              if (this->cp < this->cend-3
+              if (this->cp + 3 < this->cend
                 && strncmp((char *)addr(this->cp), "!--", 3) == 0)
                 {
                   /* start of comment skip all characters until "-->"
                    */
                   this->cp += 3;
 		  tp = this->cp;
-                  while (this->cp < this->cend-3
+                  while (this->cp + 3 < this->cend
                          && strncmp((char *)addr(this->cp), "-->", 3) != 0)
                     {
                       this->cp++;  // search
@@ -1461,14 +1461,14 @@ NSLog(@"_processTag <%@%@ %@>", flag?@"/": @"", tag, attributes);
                   c = cget();		// get first character after comment
                   continue;
                 }
-              if (this->cp < this->cend-8
+              if (this->cp + 8 < this->cend
                 && strncmp((char *)addr(this->cp), "![CDATA[", 8) == 0)
 		{
                   /* start of CDATA skip all characters until "]>"
                    */
                   this->cp += 8;
 		  tp = this->cp;
-                  while (this->cp < this->cend-3
+                  while (this->cp + 3 < this->cend
                     && strncmp((char *)addr(this->cp), "]]>", 3) != 0)
                     {
                       this->cp++;  // search

--- a/Tests/base/NSXMLParser/cend-bounds.m
+++ b/Tests/base/NSXMLParser/cend-bounds.m
@@ -1,0 +1,111 @@
+/*
+ * cend-bounds.m - regression guard for the NSXMLParser '<' tag handler
+ * bounds check.
+ *
+ * On entry to the '<' case the cursor cp sits just past the '<'.  The
+ * comment / CDATA look-ahead used `cp < cend - 3` and `cp < cend - 8`,
+ * but cend is an unsigned NSUInteger, so for input with fewer than 3
+ * (resp. 8) bytes after the '<' the subtraction underflows to a huge
+ * value, the guard passes, and strncmp() reads three bytes at cp -
+ * past the end of the buffer.  The fix tests `cp + 3 < cend` /
+ * `cp + 8 < cend`, which is identical whenever cend >= 3 but cannot
+ * underflow.
+ *
+ * The over-read has no functional effect on a normal heap (the bytes
+ * read just fail to match "!--"/"![CDATA["), so the memory-safety side
+ * is demonstrated separately under AddressSanitizer.  This test guards
+ * the behaviour the fix must preserve: well-formed comments and CDATA
+ * are still detected, and a truncated tag is handled without crashing
+ * or hanging.
+ */
+
+#import <Foundation/NSObject.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSXMLParser.h>
+#import "ObjectTesting.h"
+
+@interface CendHandler : NSObject
+{
+@public
+  int		comments;
+  int		cdata;
+  NSString	*lastComment;
+  NSString	*lastCDATA;
+}
+@end
+
+@implementation CendHandler
+- (void) parser: (NSXMLParser *)parser foundComment: (NSString *)comment
+{
+  comments++;
+  ASSIGN(lastComment, comment);
+}
+- (void) parser: (NSXMLParser *)parser foundCDATA: (NSData *)block
+{
+  cdata++;
+  ASSIGN(lastCDATA, [[[NSString alloc] initWithData: block
+    encoding: NSUTF8StringEncoding] autorelease]);
+}
+- (void) dealloc
+{
+  RELEASE(lastComment);
+  RELEASE(lastCDATA);
+  [super dealloc];
+}
+@end
+
+/* Parse a raw C-string document; returns the handler (autoreleased) so
+ * the caller can inspect what fired.  Never raises.
+ */
+static CendHandler *
+parseBytes(const char *xml)
+{
+  NSData	*d = [NSData dataWithBytes: xml length: strlen(xml)];
+  NSXMLParser	*p = [[NSXMLParser alloc] initWithData: d];
+  CendHandler	*h = [[CendHandler new] autorelease];
+
+  [p setDelegate: h];
+  [p parse];
+  RELEASE(p);
+  return h;
+}
+
+int
+main(int argc, char *argv[])
+{
+  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
+  CendHandler		*h;
+  unsigned		i;
+  const char		*truncated[] = {
+    "<", "<!", "<!-", "<!--", "<![", "<![CDATA", "<![CDATA[", 0
+  };
+
+  START_SET("NSXMLParser comment/CDATA bounds")
+
+  /* Regression: a well-formed comment and CDATA section are still
+   * detected after the bounds expression was rewritten.
+   */
+  h = parseBytes("<r><!--hello--><![CDATA[world]]></r>");
+  PASS(h->comments == 1 && [h->lastComment isEqual: @"hello"],
+    "well-formed comment is still detected")
+  PASS(h->cdata == 1 && [h->lastCDATA isEqual: @"world"],
+    "well-formed CDATA is still detected")
+
+  /* Robustness: a tag truncated to fewer than 3/8 bytes after '<' (the
+   * inputs that made cend-3 / cend-8 underflow) is parsed without
+   * crashing or hanging, and produces no spurious comment/CDATA.
+   */
+  for (i = 0; truncated[i] != 0; i++)
+    {
+      h = parseBytes(truncated[i]);
+      PASS(h->comments == 0 && h->cdata == 0,
+        "truncated tag \"%s\" yields no spurious comment/CDATA", truncated[i])
+    }
+
+  END_SET("NSXMLParser comment/CDATA bounds")
+
+  [arp release];
+  return 0;
+}


### PR DESCRIPTION
## Summary

In `-[NSXMLParser parse]`, the `'<'` tag handler looks ahead for `"!--"` (comment) and `"![CDATA["` using:

```objc
if (this->cp < this->cend-3 && strncmp((char *)addr(this->cp), "!--", 3) == 0)
...
if (this->cp < this->cend-8 && strncmp((char *)addr(this->cp), "![CDATA[", 8) == 0)
```

`this->cend` is an unsigned `NSUInteger` (the data length). When a `<` is followed by fewer than 3 (resp. 8) bytes — e.g. the document `"<"` — `this->cend - 3` underflows to a value near `2^64`, the guard passes, and `strncmp()` reads 3 bytes at `this->cp`, past the end of the buffer.

## Fix

Test `cp + 3 < cend` / `cp + 8 < cend`, which is algebraically identical whenever `cend` is large enough but cannot underflow. The same idiom is used at all four look-ahead sites (the two outer guards plus the two inner search loops) for consistency.

## Test

`Tests/base/NSXMLParser/cend-bounds.m`: a well-formed comment and CDATA section are still detected after the rewrite, and the truncated tags `"<"`, `"<!"`, `"<!-"`, `"<!--"`, `"<!["`, `"<![CDATA"`, `"<![CDATA["` parse with no crash/hang and no spurious comment/CDATA callbacks.

## Validation (Ubuntu 24.04, clang 18, libobjc2)

- **Positive/regression control** (patched, in-tree lib): 9/9 assertions pass.
- **Memory safety**: with the unsigned `cp < cend - 3` expression and a one-byte buffer, AddressSanitizer reports a `heap-buffer-overflow` READ in `strncmp`; the fixed `cp + 3 < cend` expression skips the look-ahead with no read. The over-read has no functional effect on a normal heap (the bytes read simply fail to match), so a portable in-tree *negative* control is not feasible — the ASan replica demonstrates the memory-safety side.
