### PR TITLE
NSValue: reject a non-NUL-terminated object-type string when decoding

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2026-06-20 Todd White <todd.white@thalion.global>
+
+	* Source/NSValue.m (-[NSValue initWithCoder:]): the object-type
+	string length was decoded from the archive and, when <= 64, that many
+	bytes were copied into a 64-byte stack buffer; a length of exactly 64
+	filled the buffer with no room for a terminator, yet the bytes were
+	then used as a NUL-terminated C string (strncmp,
+	-valueClassWithObjCType:), reading past the end of the buffer.  Reject
+	a type string that is not NUL-terminated.
+	* Tests/base/NSValue/codertype.m: new regression test.
+	* Tests/base/NSValue/TestInfo: added so the NSValue tests are run.
+
 2026-06-20 Richard Frith-Macdonald <rfm@gnu.org>
 
         * Headers/Foundation/NSDecimalNumber.h:

--- a/Source/NSValue.m
+++ b/Source/NSValue.m
@@ -557,6 +557,20 @@ static gs_mutex_t               placeholderLock = GS_MUTEX_INIT_STATIC;
   [coder decodeArrayOfObjCType: @encode(signed char)
 			 count: size
 			    at: (void*)objctype];
+  /* The type string is used below as a NUL-terminated C string, but a
+   * crafted archive can supply size bytes with no terminator (when
+   * size == sizeof(type) the stack buffer is filled completely), which
+   * would over-read the buffer.  Reject a type that is not terminated.
+   */
+  if (0 == size || objctype[size - 1] != '\0')
+    {
+      if (size > 64)
+	{
+	  NSZoneFree(NSDefaultMallocZone(), (void*)objctype);
+	}
+      [NSException raise: NSInvalidArgumentException
+		  format: @"-[NSValue initWithCoder:] invalid type encoding"];
+    }
   if (strncmp(CGSIZE_ENCODING_PREFIX, objctype, strlen(CGSIZE_ENCODING_PREFIX)) == 0)
     c = [abstractClass valueClassWithObjCType: @encode(NSSize)];
   else if (strncmp(CGPOINT_ENCODING_PREFIX, objctype, strlen(CGPOINT_ENCODING_PREFIX)) == 0)

--- a/Tests/base/NSValue/codertype.m
+++ b/Tests/base/NSValue/codertype.m
@@ -1,0 +1,85 @@
+/*
+ * codertype.m - regression test for -[NSValue initWithCoder:].
+ *
+ * The decoder reads an objc-type-string length straight from the
+ * archive and copies that many bytes into a 64-byte stack buffer
+ * (`char type[64]') whenever the length is <= 64.  When the length is
+ * exactly 64 the buffer is filled completely, leaving no room for a
+ * terminator, yet the bytes are then used as a NUL-terminated C string
+ * (strncmp / valueClassWithObjCType:), reading past the end of the
+ * buffer.  The decoder now rejects a type string that is not
+ * NUL-terminated.
+ */
+
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+
+/* A coder that feeds -initWithCoder: a 64-byte object-type string with
+ * no NUL terminator - the input only a crafted archive could produce.
+ */
+@interface TypeCoder : NSCoder
+@end
+
+@implementation TypeCoder
+- (void) decodeValueOfObjCType: (const char*)type at: (void*)data
+{
+  /* The first (and only, before the fix raises) unsigned decoded is the
+   * length of the object-type string: claim a full 64 bytes. */
+  if (strcmp(type, @encode(unsigned)) == 0)
+    {
+      *(unsigned*)data = 64;
+    }
+}
+- (void) decodeArrayOfObjCType: (const char*)type
+			 count: (NSUInteger)count
+			    at: (void*)data
+{
+  /* Fill the whole type buffer with non-NUL bytes. */
+  if (strcmp(type, @encode(signed char)) == 0)
+    {
+      memset(data, 'A', count);
+    }
+}
+- (NSInteger) versionForClassName: (NSString*)className
+{
+  return 3;
+}
+- (NSZone*) objectZone
+{
+  return NSDefaultMallocZone();
+}
+@end
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("NSValue initWithCoder type-string termination")
+  TypeCoder	*tc;
+  NSValue	*original;
+  NSData	*archived;
+  NSValue	*restored;
+
+  /* Positive control: a real value still round-trips through
+   * NSArchiver/NSUnarchiver (a valid type string is NUL-terminated and
+   * must not be rejected).
+   */
+  original = [NSValue valueWithRange: NSMakeRange(3, 7)];
+  archived = [NSArchiver archivedDataWithRootObject: original];
+  restored = [NSUnarchiver unarchiveObjectWithData: archived];
+  PASS_EQUAL(restored, original,
+    "a valid NSValue still round-trips through the coder")
+
+  /* Attack: a 64-byte type string with no terminator must be rejected
+   * rather than over-read as a C string.
+   */
+  tc = [TypeCoder new];
+  PASS_EXCEPTION(
+    [[NSValue alloc] initWithCoder: tc],
+    NSInvalidArgumentException,
+    "an unterminated 64-byte type string is rejected, not over-read")
+  RELEASE(tc);
+
+  END_SET("NSValue initWithCoder type-string termination")
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

`-[NSValue initWithCoder:]` decodes the object-type string length from the archive and, when it is `<= 64`, copies that many bytes into a 64-byte stack buffer:

```objc
char  type[64];
...
[coder decodeValueOfObjCType: @encode(unsigned) at: &size];   // attacker-controlled
if (size <= 64) { objctype = type; } else { objctype = NSZoneMalloc(..., size); }
[coder decodeArrayOfObjCType: @encode(signed char) count: size at: (void*)objctype];
...
c = [abstractClass valueClassWithObjCType: objctype];          // reads objctype as a C string
```

A `size` of exactly 64 fills `type[64]` completely, leaving no room for a terminator, yet `objctype` is then consumed as a NUL-terminated C string by `strncmp` and `-valueClassWithObjCType:` (`strcmp`/`GSSelectorTypesMatch`), reading past the end of the buffer. (The `size > 64` heap branch allocates exactly `size` bytes and has the same defect.) The encoder always writes `strlen(type)+1` bytes including the NUL, so a non-terminated type string can only come from a crafted archive.

Reachable via `[[NSValue alloc] initWithCoder:]` and `+[NSUnarchiver unarchiveObjectWithData:]`.

## Fix

Reject a type string whose final byte is not NUL (and a zero length) before using it — freeing the heap buffer first on the `size > 64` path.

## Test

`Tests/base/NSValue/codertype.m`: a real `NSValue` still round-trips through `NSArchiver`/`NSUnarchiver`, and a coder feeding a 64-byte type string with no terminator is rejected. (`Tests/base/NSValue/TestInfo` is added so the directory runs — it is currently absent on master.)

## Validation (Ubuntu 24.04, clang 18, libobjc2)

- **Positive + negative control** (in-tree gnustep-tests): patched, 2/2 pass — valid round-trip plus the crafted coder rejected with `NSInvalidArgumentException`. Against the **unpatched** lib the same test binary **aborts (core dumped)** on the attack input.
- **Memory safety** (ASan replica): filling `char[64]` with no NUL and reading it as a C string reports a `stack-buffer-overflow` READ in `strlen`; the patched reject path performs no read.

> Note: `Tests/base/NSValue/TestInfo` is also added by my open PR #626 (independent NSValue finding). The file is empty, so an add/add across the two PRs resolves cleanly.
