### PR TITLE
GSString: range-check before the tiny-string fast path in GSCString substring

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2026-06-20 Todd White <todd.white@thalion.global>
+
+	* Source/GSString.m (-[GSCString substringFromRange:],
+	-[GSCString substringWithRange:]): both ran the tiny-string fast path
+	- createTinyString((char*)_contents.c + aRange.location,
+	aRange.length) - before validating aRange against the receiver length.
+	createTinyString reads up to 9 bytes from that pointer, so an
+	out-of-range range read past the end of the character buffer.  Perform
+	GS_RANGE_CHECK first, as the GSMutableString implementations do.
+	* Tests/base/NSString/substring-bounds.m: new regression test.
+
 2026-06-20 Richard Frith-Macdonald <rfm@gnu.org>
 
         * Headers/Foundation/NSDecimalNumber.h:

--- a/Source/GSString.m
+++ b/Source/GSString.m
@@ -3880,6 +3880,8 @@ agree, create a new GSCInlineString otherwise.
 
 - (NSString*) substringFromRange: (NSRange)aRange
 {
+  GS_RANGE_CHECK(aRange, _count);
+
   if (!_flags.wide)
     {
       id tinyString;
@@ -3893,7 +3895,6 @@ agree, create a new GSCInlineString otherwise.
     }
   if (_flags.owned)
     {
-      GS_RANGE_CHECK(aRange, _count);
       return substring_c((GSStr)self, aRange);
     }
   return [super substringWithRange: aRange];
@@ -3901,9 +3902,10 @@ agree, create a new GSCInlineString otherwise.
 
 - (NSString*) substringWithRange: (NSRange)aRange
 {
+  GS_RANGE_CHECK(aRange, _count);
+
   if (_flags.owned)
     {
-      GS_RANGE_CHECK(aRange, _count);
       return substring_c((GSStr)self, aRange);
     }
   if (!_flags.wide)

--- a/Tests/base/NSString/substring-bounds.m
+++ b/Tests/base/NSString/substring-bounds.m
@@ -1,0 +1,98 @@
+/*
+ * substring-bounds.m - regression test for the GSCString substring range
+ * check.
+ *
+ * -[GSCString substringFromRange:] and -[GSCString substringWithRange:]
+ * ran the "tiny string" fast path - createTinyString((char*)_contents.c
+ * + aRange.location, aRange.length) - before validating aRange against
+ * the receiver's length.  createTinyString reads up to 9 bytes from that
+ * pointer, so an out-of-range range read past the end of the character
+ * buffer.  The GS_RANGE_CHECK is now performed first, matching the
+ * GSMutableString implementations.
+ *
+ * To make the over-read observable rather than silently reading adjacent
+ * heap, the string bytes are placed at the very end of a page whose
+ * successor page is unmapped, so any read past them faults.  (Unix only;
+ * elsewhere the guard-page part is skipped.)
+ */
+
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+
+#if defined(__unix__) || defined(__APPLE__)
+#include <sys/mman.h>
+#include <unistd.h>
+#include <string.h>
+#define HAVE_GUARD_PAGE 1
+#endif
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("GSCString substring range check")
+
+  /* Positive control: in-range substrings of a non-owned C-string still
+   * work (a non-owned, non-wide GSCString is what exercises the tiny
+   * fast path).
+   */
+  {
+    char	bytes[] = "hello world";
+    NSString	*s = [[NSString alloc] initWithBytesNoCopy: bytes
+						       length: 11
+						     encoding: NSISOLatin1StringEncoding
+						 freeWhenDone: NO];
+
+    PASS_EQUAL([s substringWithRange: NSMakeRange(0, 5)], @"hello",
+      "in-range -substringWithRange: returns the substring")
+    PASS_EQUAL([s substringFromRange: NSMakeRange(6, 5)], @"world",
+      "in-range -substringFromRange: returns the substring")
+    RELEASE(s);
+  }
+
+#if HAVE_GUARD_PAGE
+  {
+    long		pg = sysconf(_SC_PAGESIZE);
+    unsigned char	*base;
+
+    base = mmap(NULL, 2 * pg, PROT_READ | PROT_WRITE,
+      MAP_PRIVATE | MAP_ANON, -1, 0);
+    if (base == MAP_FAILED)
+      {
+	SKIP("could not mmap a guard page")
+      }
+    else
+      {
+	unsigned	len = 16;	/* > 9 so the receiver is a heap GSCString */
+	unsigned char	*p = base + pg - len;	/* bytes end at the page edge */
+	NSString	*s;
+
+	mprotect(base + pg, pg, PROT_NONE);
+	memcpy(p, "0123456789abcdef", len);
+	s = [[NSString alloc] initWithBytesNoCopy: p
+					   length: len
+					 encoding: NSISOLatin1StringEncoding
+				     freeWhenDone: NO];
+
+	/* An out-of-range length: the tiny-string fast path would read up
+	 * to 9 bytes from _contents.c + location, past the page edge and
+	 * into the guard page.  The range check must reject it first.
+	 */
+	PASS_EXCEPTION([s substringWithRange: NSMakeRange(10, 9)],
+	  NSRangeException,
+	  "-substringWithRange: range-checks before the tiny-string fast path")
+	PASS_EXCEPTION([s substringFromRange: NSMakeRange(10, 9)],
+	  NSRangeException,
+	  "-substringFromRange: range-checks before the tiny-string fast path")
+
+	RELEASE(s);
+	munmap(base, 2 * pg);
+      }
+  }
+#else
+  SKIP("guard-page mechanism is Unix only")
+#endif
+
+  END_SET("GSCString substring range check")
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

`-[GSCString substringFromRange:]` and `-[GSCString substringWithRange:]` run the "tiny string" fast path before validating the requested range:

```objc
- (NSString*) substringFromRange: (NSRange)aRange
{
  if (!_flags.wide)
    {
      id tinyString;
      tinyString = createTinyString((char*)_contents.c + aRange.location,
        aRange.length);                       // <-- no range check yet
      if (tinyString) { return tinyString; }
    }
  if (_flags.owned)
    {
      GS_RANGE_CHECK(aRange, _count);          // too late / skipped
      ...
```

`createTinyString(str, length)` reads up to 9 bytes from `str` (it dereferences `str[8]` for `length == 9` and `str[i]` for `i < length`). Because `str = _contents.c + aRange.location` and `length = aRange.length` come straight from the caller's `NSRange`, an out-of-range range reads past the end of the character buffer and folds the over-read bytes into the returned tagged-pointer string.

`-substringWithRange:` has the same defect on the non-owned branch. The sibling `GSMutableString` implementations already do `GS_RANGE_CHECK` first; these two did not.

Reachable via e.g. `-[NSString initWithBytesNoCopy:length:encoding:freeWhenDone:NO]` (a non-owned `GSCString`) followed by `-substringWithRange:`/`-substringFromRange:` (and `-substringFromIndex:`/`-substringToIndex:`, which funnel through them) with an out-of-range range. The fast path is active under the libobjc2 tagged-pointer runtime.

## Fix

Hoist `GS_RANGE_CHECK(aRange, _count)` to the first statement of both methods (and drop the now-redundant check in the owned branch), matching `GSMutableString`.

## Test

`Tests/base/NSString/substring-bounds.m`: in-range substrings still work; an out-of-range range raises `NSRangeException`.

## Validation (Ubuntu 24.04, clang 18, libobjc2; tiny strings active)

- **Positive control** (patched, in-tree lib): 4/4 pass.
- **Negative control** (unpatched in-tree lib): the out-of-range substring runs against a non-owned `GSCString` whose 16 bytes end exactly at a page boundary backed by a `PROT_NONE` guard page; `createTinyString` reads past the page and the test program **aborts (SIGSEGV)** — the harness reports "1 Failed file". The patched build rejects the range before the read. (The installed system copy already carries an older audit-era check, so the negative control must be run against a clean build of current master.)
