### PR TITLE
GSFormat: fix buffer underflow on large field width/precision

### DIFF
--- a/Source/GSFormat.m
+++ b/Source/GSFormat.m
@@ -832,6 +832,7 @@ NSDictionary *locale)
   /* Buffer intermediate results.  */
   unichar work_buffer[1000];
   unichar *workend;
+  unichar *workmalloc = 0;
   int workend_malloced = 0;
 
   /* State for restartable multibyte character handling functions.  */
@@ -1149,12 +1150,13 @@ NSDictionary *locale)
 
             if (want > 168384)
               {
-                workend = (unichar *)malloc(want);
+                workmalloc = (unichar *)malloc(want);
                 workend_malloced = 1;
+                workend = workmalloc + want / sizeof (unichar);
               }
             else
               {
-                workend = (unichar *)alloca(want);
+                workend = (unichar *)alloca(want) + want / sizeof (unichar);
               }
 	  }
 
@@ -1944,7 +1946,7 @@ NSDictionary *locale)
   }
 
 all_done:
-  if (workend_malloced) free(workend);
+  if (workend_malloced) free(workmalloc);
   /* Unlock the stream.  */
 #ifdef __va_copy
   va_end(ap_save);

--- a/Tests/base/NSString/format_large_width.m
+++ b/Tests/base/NSString/format_large_width.m
@@ -1,0 +1,23 @@
+#import "Testing.h"
+#import <Foundation/NSString.h>
+
+/* A field width larger than GSFormat's internal work_buffer takes the
+   buffer-grow path.  That path used to point the conversion cursor at the
+   START of the freshly allocated buffer while the integer converter writes
+   BACKWARDS, overflowing the allocation (AddressSanitizer reports a
+   heap-buffer-overflow in _itowa_word).  Check that a large field-width
+   conversion produces the expected result. */
+int main()
+{
+  START_SET("GSFormat large field width")
+  NSString	*s = [NSString stringWithFormat: @"%100000d", 5];
+
+  PASS([s length] == 100000,
+    "a %%100000d field-width conversion has the expected length");
+  PASS([s hasSuffix: @"5"],
+    "a large field-width integer conversion ends with the formatted value");
+  PASS([s characterAtIndex: 0] == ' ',
+    "a large field-width integer conversion is space-padded");
+  END_SET("GSFormat large field width")
+  return 0;
+}


### PR DESCRIPTION
## Summary

In `GSPrivateFormat` (`Source/GSFormat.m`), when a conversion's field width or
precision is larger than the fixed `work_buffer`, the buffer is grown with
`malloc`/`alloca`:

```c
if (want > 168384)
  { workend = (unichar *)malloc(want); workend_malloced = 1; }
else
  { workend = (unichar *)alloca(want); }
```

This points `workend` at the **start** of the new allocation. But the integer
converters (`_itowa` / `_itowa_word`) write the digits **backwards** from
`workend` — which is why the static-buffer case correctly initialises it to the
**end** of the array:

```c
workend = &work_buffer[sizeof (work_buffer) / sizeof (unichar)];   /* the end */
```

So the grown path writes *before* the allocation — a heap (or stack, via the
`alloca` branch) buffer underflow. `if (workend_malloced) free(workend);` then
also frees a pointer that is not the allocation start.

## Reproduction (AddressSanitizer)

```objc
[NSString stringWithFormat: @"%100000d", 5];
```

```
ERROR: AddressSanitizer: heap-buffer-overflow ... WRITE of size 2
  #0 _itowa_word     Source/GSFormat.m:277
  #1 GSPrivateFormat Source/GSFormat.m:1324
  ...
  #4 +[NSString stringWithFormat:]  Source/NSString.m:1559
allocated by:
  #1 GSPrivateFormat Source/GSFormat.m:1152   (the malloc grow path)
```

A field width that large is unusual but entirely valid, and the width can be
data-driven (`%*d`), so this is reachable from ordinary formatting.

## Fix

Record the allocation start, point `workend` at the **end** of the grown buffer
(matching the static-buffer case), and free the recorded start:

```c
workmalloc = (unichar *)malloc(want);
workend_malloced = 1;
workend = workmalloc + want / sizeof (unichar);
...
workend = (unichar *)alloca(want) + want / sizeof (unichar);
...
if (workend_malloced) free(workmalloc);
```

## Test

`Tests/base/NSString/format_large_width.m` checks `%100000d` produces a
correctly sized, space-padded result; it aborts under AddressSanitizer without
the fix and passes with it.
