### PR TITLE
GSMime: fix quoted-printable encoded-word decode overrun (stack overflow)

### DIFF
--- a/Source/Additions/GSMime.m
+++ b/Source/Additions/GSMime.m
@@ -338,12 +338,12 @@ decodeWord(unsigned char *dst, const unsigned char *src,
 
   if (enc == WE_QUOTED)
     {
-      while (*src && (src != end))
+      while (src < end && *src)
 	{
 	  if (*src == '=')
 	    {
 	      src++;
-	      if (*src == '\0')
+	      if (src >= end || *src == '\0')
 		{
 		  break;
 		}
@@ -351,7 +351,7 @@ decodeWord(unsigned char *dst, const unsigned char *src,
                 {
                   break;
                 }
-              if (!isxdigit(src[0]) || !isxdigit(src[1]))
+              if (src + 1 >= end || !isxdigit(src[0]) || !isxdigit(src[1]))
                 {
                   /* Strictly speaking the '=' must be followed by
                    * two hexadecimal characters, but RFC2045 says that

--- a/Tests/base/GSMime/encoded_word_bounds.m
+++ b/Tests/base/GSMime/encoded_word_bounds.m
@@ -1,0 +1,56 @@
+#if     defined(GNUSTEP_BASE_LIBRARY)
+#import <Foundation/Foundation.h>
+#import <GNUstepBase/GSMime.h>
+#import "Testing.h"
+
+/* Parse a single-header message and return the decoded value of `name`. */
+static NSString *
+decodeHeaderValue(NSString *headerLine, NSString *name)
+{
+  GSMimeParser		*parser = [GSMimeParser mimeParser];
+  NSMutableString	*msg = [NSMutableString stringWithString: headerLine];
+
+  [msg appendString: @"\r\n\r\n"];
+  [parser parse: [msg dataUsingEncoding: NSASCIIStringEncoding]];
+  return [[[parser mimeDocument] headerNamed: name] value];
+}
+
+int main()
+{
+  START_SET("GSMime encoded-word bounds")
+
+  /* A well-formed quoted-printable encoded word still decodes correctly. */
+  PASS_EQUAL(decodeHeaderValue(@"Subject: =?utf-8?Q?Hello=20World?=", @"subject"),
+    @"Hello World",
+    "quoted-printable encoded word decodes correctly");
+
+  /* A malformed encoded word whose quoted-printable text ends in a bare '='
+     used to make decodeWord step past the end of the word and keep decoding
+     the following header bytes into a stack buffer sized only to the word
+     (a stack-buffer-overflow).  Parsing it without overflowing is the
+     regression check. */
+  {
+    GSMimeParser	*parser = [GSMimeParser mimeParser];
+    NSMutableString	*m;
+    int			i;
+
+    m = [NSMutableString stringWithString: @"Subject: =?utf-8?Q?A=?="];
+    for (i = 0; i < 200; i++)
+      {
+	[m appendString: @"Z"];
+      }
+    [m appendString: @"\r\n\r\n"];
+    [parser parse: [m dataUsingEncoding: NSASCIIStringEncoding]];
+    PASS([parser mimeDocument] != nil,
+      "a malformed quoted-printable encoded word is parsed without overflow");
+  }
+
+  END_SET("GSMime encoded-word bounds")
+  return 0;
+}
+#else
+int main(void)
+{
+  return 0;
+}
+#endif


### PR DESCRIPTION
## Summary

`decodeWord` (`Source/Additions/GSMime.m`) decodes an RFC 2047 encoded word
into `dst`, a buffer the caller sizes to the word:

```c
unsigned char  buf[tmp - src + 1];      /* sized to the encoded word */
ptr = decodeWord(buf, src, tmp, encoding);
```

The quoted-printable branch loops with `while (*src && (src != end))`, but the
`=`-handler advances `src` by two or three bytes per iteration:

```c
if (*src == '=')
  {
    src++;                                  /* (1) */
    ...
    if (!isxdigit(src[0]) || !isxdigit(src[1])) { *dst++ = '='; *dst = *src; }
    else { ... src++; ... }                 /* (2) */
  }
...
dst++; src++;                               /* (3) */
```

So when a `=` sits at the end of the word, `src` can step **over** `end` and
the `src != end` test never catches it; the loop then keeps decoding the bytes
*after* the word (the `?=` terminator and everything following it in the
header) into `buf`, overflowing it.

## Reproduction (AddressSanitizer)

```objc
GSMimeParser *p = [GSMimeParser mimeParser];
[p parse: [@"Subject: =?utf-8?Q?A=?=ZZZZ…ZZZZ\r\n\r\n"
            dataUsingEncoding: NSASCIIStringEncoding]];
```

```
ERROR: AddressSanitizer: dynamic-stack-buffer-overflow ... WRITE
  #0 decodeWord            Source/Additions/GSMime.m:362
  #1 -[GSMimeParser(Private) _decodeHeader]  ...:3079
  #2 -[GSMimeParser parseHeaders:remaining:] ...:1589
  #3 -[GSMimeParser parse:]                  ...:1466
```

`GSMimeParser` parses HTTP, `NSURL` and mail input, so the malformed header is
attacker-controlled.

## Fix

Bound the loop with `src < end`, and guard the `=` lookahead so neither the two
hex digits (`src[0]`, `src[1]`) nor the included character are read past `end`:

```c
while (src < end && *src)
  ...
    src++;
    if (src >= end || *src == '\0') break;
    ...
    if (src + 1 >= end || !isxdigit(src[0]) || !isxdigit(src[1]))
```

The base64 branch (which advances `src` by exactly one) is unchanged.

## Test

`Tests/base/GSMime/encoded_word_bounds.m` checks a well-formed quoted-printable
word still decodes correctly, and that the malformed word above is parsed
without overflowing (it aborts under AddressSanitizer without the fix).
