### PR TITLE
NSDecimal: fix mantissa buffer overflow on maximum-length values

### DIFF
--- a/Source/NSDecimal.m
+++ b/Source/NSDecimal.m
@@ -295,10 +295,19 @@ GSDecimalRound(GSDecimal *result, int scale, NSRoundingMode mode)
       if (l == 0)
         {
           int x;
-             
+
           x = result->length;
           result->length += 1;
           l += 1;
+          if (x >= NSDecimalMaxDigit)
+            {
+              /* No room to prepend a digit into the fixed-size mantissa: stop
+                 the shift at the last element, dropping the least significant
+                 digit.  Only the prepended digit survives the rounding below
+                 (length becomes l == 1), so the dropped digit cannot change
+                 the result. */
+              x = NSDecimalMaxDigit - 1;
+            }
           while (x > 0)
             {
                result->cMantissa[x] = result->cMantissa[x-1];
@@ -1462,12 +1471,36 @@ GSSimpleAdd(NSDecimal *result, const NSDecimal *left, const NSDecimal *right,
 
       if (carry)
 	{
-	  // The number must be shifted to the right
+	  BOOL	roundUp = NO;
+
+	  // The number must be shifted right to make room for the carried-out
+	  // leading digit.
 	  if (NSDecimalMaxDigit == result->length)
 	    {
-	      NSDecimalRound(result, result,
-			     NSDecimalMaxDigit - 1 - result->exponent,
-			     mode);
+	      // No room for another digit: drop the least significant one
+	      // (remembering whether it rounds the result up) and raise the
+	      // exponent.  The prepended carry digit is 1, so the round-up
+	      // below cannot overflow the mantissa again.
+	      switch (mode)
+		{
+		  case NSRoundDown:
+		    roundUp = result->isNegative;
+		    break;
+		  case NSRoundUp:
+		    roundUp = !result->isNegative;
+		    break;
+		  case NSRoundBankers:
+		    if (5 != result->cMantissa[result->length - 1])
+		      roundUp = (result->cMantissa[result->length - 1] > 5);
+		    else
+		      roundUp = ((result->cMantissa[result->length - 2] % 2) != 0);
+		    break;
+		  default:
+		    roundUp = (result->cMantissa[result->length - 1] >= 5);
+		    break;
+		}
+	      result->length--;
+	      result->exponent++;
 	    }
 
 	  if (127 == result->exponent)
@@ -1482,6 +1515,19 @@ GSSimpleAdd(NSDecimal *result, const NSDecimal *left, const NSDecimal *right,
 	    }
 	  result->cMantissa[0] = 1;
 	  result->length++;
+
+	  if (roundUp)
+	    {
+	      for (i = result->length - 1; i >= 0; i--)
+		{
+		  if (result->cMantissa[i] != 9)
+		    {
+		      result->cMantissa[i]++;
+		      break;
+		    }
+		  result->cMantissa[i] = 0;
+		}
+	    }
 	}
     }
 

--- a/Tests/base/NSDecimalNumber/mantissa_overflow.m
+++ b/Tests/base/NSDecimalNumber/mantissa_overflow.m
@@ -1,0 +1,59 @@
+/*
+ * mantissa_overflow.m - regression tests for two NSDecimal operations that
+ * wrote one element past the fixed cMantissa[] array on a maximum-length
+ * (38-digit) value.
+ *
+ *  - GSSimpleAdd: adding two full 38-digit mantissas carries out to a 39th
+ *    digit; the length==38 guard called NSDecimalRound with a scale that made
+ *    the round a no-op, so the carry-shift wrote past cMantissa[].
+ *  - GSDecimalRound: rounding a full 38-digit value at a scale that leaves no
+ *    significant digits took a left-shift that prepended a digit without
+ *    checking the array bound.
+ *
+ * Both are AddressSanitizer heap-buffer-overflow writes reachable from the
+ * public NSDecimalAdd / NSDecimalRound functions.  As well as not overflowing,
+ * the operations must still produce the correct value, and ordinary
+ * (non-maximal) operations must be unaffected.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Foundation/NSDecimal.h>
+#import "ObjectTesting.h"
+
+int main(void)
+{
+  START_SET("NSDecimal max-length mantissa")
+  NSDecimal	a, r, e;
+  NSString	*nines = @"99999999999999999999999999999999999999";   /* 38 nines */
+
+  /* F-DEC1: carry-out when adding two full mantissas -> 2e38. */
+  NSDecimalFromString(&a, nines, nil);
+  NSDecimalAdd(&r, &a, &a, NSRoundPlain);
+  NSDecimalFromString(&e, @"200000000000000000000000000000000000000", nil);
+  PASS(r.validNumber && NSDecimalCompare(&r, &e) == NSOrderedSame,
+    "adding two maximum-length mantissas gives 2e38 without overflow");
+
+  /* An ordinary carrying add (not at the mantissa limit) is unaffected. */
+  NSDecimalFromString(&a, @"999", nil);
+  NSDecimalAdd(&r, &a, &a, NSRoundPlain);
+  NSDecimalFromString(&e, @"1998", nil);
+  PASS(NSDecimalCompare(&r, &e) == NSOrderedSame,
+    "an ordinary carrying add (999 + 999) still gives 1998");
+
+  /* F-DEC2: rounding a full mantissa at a scale that keeps no digits -> 1e38. */
+  NSDecimalFromString(&a, nines, nil);
+  NSDecimalRound(&r, &a, -38, NSRoundPlain);
+  NSDecimalFromString(&e, @"100000000000000000000000000000000000000", nil);
+  PASS(r.validNumber && NSDecimalCompare(&r, &e) == NSOrderedSame,
+    "rounding a maximum-length mantissa at scale -38 gives 1e38 without overflow");
+
+  /* An ordinary l==0 round (not at the limit) is unaffected. */
+  NSDecimalFromString(&a, @"999", nil);
+  NSDecimalRound(&r, &a, -3, NSRoundPlain);
+  NSDecimalFromString(&e, @"1000", nil);
+  PASS(NSDecimalCompare(&r, &e) == NSOrderedSame,
+    "an ordinary round up to a new digit (999 at scale -3) still gives 1000");
+
+  END_SET("NSDecimal max-length mantissa")
+  return 0;
+}


### PR DESCRIPTION
## Summary

Two `NSDecimal` operations write one element past the fixed
`cMantissa[NSDecimalMaxDigit]` array (38 bytes, the last field of the struct)
when given a maximum-length 38-digit mantissa.

### GSSimpleAdd — carry-out overflow

When the sum carries out to a 39th digit and the result already holds 38
digits, the guard tries to make room:

```c
if (NSDecimalMaxDigit == result->length)
  {
    NSDecimalRound(result, result, NSDecimalMaxDigit - 1 - result->exponent, mode);
  }
```

That scale leaves `l = scale + exponent + length = 37 + length > length`, so
`GSDecimalRound`'s `if (result->length <= l) return;` makes the round a **no-op**.
The carry-shift then runs with `length == 38` and writes `cMantissa[38]`.

### GSDecimalRound — `l == 0` left-shift overflow

Rounding a full-length value at a scale that keeps no significant digits
prepends a leading zero by shifting the mantissa right:

```c
x = result->length;            /* 38 */
result->length += 1;           /* 39 */
while (x > 0) { result->cMantissa[x] = result->cMantissa[x-1]; x--; }  /* writes cMantissa[38] */
```

## Reproduction (AddressSanitizer)

```objc
NSDecimal a, r;
NSDecimalFromString(&a, @"99999999999999999999999999999999999999", nil); /* 38 nines */
NSDecimalAdd(&r, &a, &a, NSRoundPlain);          /* heap-buffer-overflow, GSSimpleAdd:1481 */
NSDecimalRound(&r, &a, -38, NSRoundPlain);       /* heap-buffer-overflow, GSDecimalRound:304 */
```

Both are reachable from the public `NSDecimalAdd` / `NSDecimalRound` and the
`NSDecimalNumber` wrappers (e.g. `[big decimalNumberByAdding: big]`).

## Fix

- **GSSimpleAdd**: make room correctly — decide rounding from the least
  significant digit, drop it, raise the exponent, then prepend the carried `1`.
  The prepended digit is `1`, so the subsequent round-up cannot overflow the
  mantissa again. (The previous code's no-op round also produced a wrong value
  when it *did* round, because round-then-prepend doesn't compose; the rewrite
  fixes the value too — `99…9 + 99…9` now yields `2e38`.)
- **GSDecimalRound**: stop the prepend shift at the last array element. The
  dropped least significant digit cannot change the single digit that survives
  (length becomes 1), and the length used for the exponent adjustment is kept,
  so `round(99…9, scale −38)` still yields `1e38`.

## Test

`Tests/base/NSDecimalNumber/mantissa_overflow.m` checks both operations produce
the correct value without overflowing, and that ordinary (non-maximal) add and
round are unaffected. It aborts under AddressSanitizer without the fix and
passes with it (4/4).
