### PR TITLE
NSScanner: validate the supplied index in -setScanLocation:

### DIFF
--- a/Source/NSScanner.m
+++ b/Source/NSScanner.m
@@ -1332,7 +1332,7 @@ typedef GSString	*ivars;
  */
 - (void) setScanLocation: (NSUInteger)anIndex
 {
-  if (_scanLocation <= myLength())
+  if (anIndex <= myLength())
     _scanLocation = anIndex;
   else
     [NSException raise: NSRangeException

--- a/Tests/base/NSScanner/setScanLocation.m
+++ b/Tests/base/NSScanner/setScanLocation.m
@@ -1,0 +1,30 @@
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+
+/* -setScanLocation: validated the current _scanLocation (which is essentially
+   always within range) instead of the supplied index, so it accepted indices
+   beyond the end of the string and never raised the documented
+   NSRangeException. */
+
+int main(void)
+{
+  START_SET("NSScanner setScanLocation: bounds")
+  NSScanner		*sc = [NSScanner scannerWithString: @"hello"];   /* length 5 */
+
+  [sc setScanLocation: 3];
+  PASS([sc scanLocation] == 3,
+    "setScanLocation: accepts an index within the string")
+
+  [sc setScanLocation: 5];
+  PASS([sc scanLocation] == 5,
+    "setScanLocation: accepts the end of the string")
+
+  [sc setScanLocation: 2];
+  PASS_EXCEPTION([sc setScanLocation: 6], NSRangeException,
+    "setScanLocation: beyond the end raises NSRangeException")
+  PASS([sc scanLocation] == 2,
+    "scan location is unchanged after a rejected out-of-range set")
+
+  END_SET("NSScanner setScanLocation: bounds")
+  return 0;
+}


### PR DESCRIPTION
## Summary

`-[NSScanner setScanLocation:]` is documented to "raise an NSRangeException if
index is beyond the end of the scanned string", but it tested the wrong
variable:

```c
- (void) setScanLocation: (NSUInteger)anIndex
{
  if (_scanLocation <= myLength())   /* current location, not anIndex */
    _scanLocation = anIndex;
  else
    [NSException raise: NSRangeException ...];
}
```

`_scanLocation` is the *current* position, which is essentially always within
range, so the guard is almost always true: an out-of-range `anIndex` is
accepted and the scan location is silently moved past the end, and the
documented `NSRangeException` is never raised.

This is a correctness / API-contract defect, not a memory-safety one — the
scanning methods all re-check `_scanLocation < myLength()` before dereferencing,
so an out-of-range location does not itself cause an out-of-bounds access.

## Fix

Validate `anIndex` (the value being set). The end of the string
(`anIndex == myLength()`) remains a valid location.

## Test

`Tests/base/NSScanner/setScanLocation.m` checks that an in-range index and the
end of the string are accepted, that an index past the end raises
`NSRangeException`, and that a rejected set leaves the location unchanged. The
exception and unchanged-location assertions fail without the fix and pass with
it.
