### PR TITLE
NSPropertyList: bound OpenStep typed-value token length

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2026-06-29 Todd White <todd.white@thalion.global>
+
+	* Source/NSPropertyList.m (parsePlItem): the GNUstep-extended
+	OpenStep typed values <*I...>, <*D...> and <*R...> copied their
+	token body into a stack buffer (char buf[len+1] / unichar buf[len])
+	whose size was taken straight from the token length, so a token of
+	a few hundred KB overflowed the stack.  The token is reachable from
+	+propertyListWithData:options:format:error: with attacker-supplied
+	data.  A valid typed value is a short number or date, so reject an
+	over-long token before allocating the buffer.
+	* Tests/base/NSPropertyList/openstep-typed-value-bounds.m: new
+	regression test.
+
 2026-06-21 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Documentation/BaseAdditions.gsdoc:

--- a/Source/NSPropertyList.m
+++ b/Source/NSPropertyList.m
@@ -1133,6 +1133,16 @@ static id parsePlItem(pldata* pld) NS_RETURNS_RETAINED
 		    len -= 2;
 		    ptr++;
 		  }
+		/* The buffers used to parse these typed values below are
+		 * stack-allocated and sized from len, while a valid value is
+		 * a short number or date.  Reject an over-long token rather
+		 * than overflow the stack.
+		 */
+		if (len > 4096)
+		  {
+		    pld->err = @"typed value too long";
+		    return nil;
+		  }
 		if (type == 'I')
 		  {
 		    char	buf[len+1];

--- a/Tests/base/NSPropertyList/openstep-typed-value-bounds.m
+++ b/Tests/base/NSPropertyList/openstep-typed-value-bounds.m
@@ -1,0 +1,112 @@
+/*
+ * openstep-typed-value-bounds.m - regression test for the OpenStep
+ * (old-style ASCII) property list parser's GNUstep-extended typed
+ * values <*Type...>.
+ *
+ * When parsePlItem() meets a <*I...>, <*D...> or <*R...> token it
+ * measures the token body as
+ *
+ *     len = (distance to the closing '>')
+ *
+ * straight from the input and then parses it through a stack buffer
+ * sized from that length:
+ *
+ *     char    buf[len+1];   // <*I... integer
+ *     unichar buf[len];     // <*D... date   (2*len bytes)
+ *     char    buf[len+1];   // <*R... real
+ *
+ * These are C99 variable-length arrays on the stack, bounded only by
+ * the size of the input.  A token such as <*I000...0> with a few
+ * hundred KB of digits therefore allocates a same-sized array on the
+ * stack and the copy loop walks past the stack guard page -> SIGSEGV.
+ * The token is fully attacker-controlled and reachable from the public
+ * +propertyListWithData:options:format:error: (any data that is not
+ * binary or XML is parsed as NSPropertyListOpenStepFormat).
+ *
+ * A legitimate typed value is a short number (NSNumber -stringValue) or
+ * a fixed-format date, so the fix rejects an implausibly long token
+ * before allocating the buffer rather than overflowing the stack.
+ *
+ * The over-long tokens here do not crash on the test framework's main
+ * thread (its stack is large enough for an 8 KB array); the bug was
+ * demonstrated with AddressSanitizer (stack-overflow at the copy loop)
+ * and on a small-stacked secondary thread.  This test pins the
+ * observable contract of the fix: a valid typed value still parses, and
+ * an over-long one is rejected (returns nil) instead of being parsed.
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+static id
+parsePlist(NSData *d)
+{
+  return [NSPropertyListSerialization propertyListWithData: d
+						   options: NSPropertyListImmutable
+						    format: NULL
+						     error: NULL];
+}
+
+static NSData *
+asciiPlist(const char *s)
+{
+  return [NSData dataWithBytes: s length: strlen(s)];
+}
+
+/* <*<type><body>> with 'count' repetitions of 'fill' as the body. */
+static NSData *
+longTypedValue(char type, char fill, unsigned count)
+{
+  NSMutableData	*m = [NSMutableData dataWithCapacity: count + 8];
+  char		head[4];
+  char		*body;
+
+  head[0] = '<'; head[1] = '*'; head[2] = type;
+  [m appendBytes: head length: 3];
+  body = malloc(count);
+  memset(body, fill, count);
+  [m appendBytes: body length: count];
+  free(body);
+  [m appendBytes: ">" length: 1];
+  return m;
+}
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("NSPropertyList OpenStep typed-value bounds")
+  id	result;
+
+  /* Positive control: a normal extended integer still parses. */
+  result = parsePlist(asciiPlist("<*I12345>"));
+  PASS(result != nil
+    && [result isKindOfClass: [NSNumber class]]
+    && [result longLongValue] == 12345LL,
+    "<*I12345> parses to the integer 12345")
+
+  /* Positive control: a normal extended real still parses. */
+  result = parsePlist(asciiPlist("<*R2.5>"));
+  PASS(result != nil
+    && [result isKindOfClass: [NSNumber class]]
+    && [result doubleValue] == 2.5,
+    "<*R2.5> parses to the real 2.5")
+
+  /* Positive control: a normal extended date still parses. */
+  result = parsePlist(asciiPlist("<*D2001-02-03 04:05:06 +0000>"));
+  PASS(result != nil, "<*D2001-02-03 04:05:06 +0000> parses to a date")
+
+  /* Attack 1: an extended integer whose token is far longer than any
+   * real value.  Without the bound the parser sizes a stack VLA from
+   * the token length and overflows the stack; with it the over-long
+   * token is rejected.
+   */
+  PASS_EQUAL(parsePlist(longTypedValue('I', '0', 8192)), nil,
+    "over-long <*I...> token rejected instead of overflowing the stack")
+
+  /* Attack 2: the <*R...> real equivalent (same VLA). */
+  PASS_EQUAL(parsePlist(longTypedValue('R', '9', 8192)), nil,
+    "over-long <*R...> token rejected instead of overflowing the stack")
+
+  END_SET("NSPropertyList OpenStep typed-value bounds")
+  return 0;
+}


### PR DESCRIPTION
## Problem

The old-style (OpenStep) property-list parser handles the GNUstep-extended
typed values `<*I...>` (integer), `<*D...>` (date) and `<*R...>` (real) by
copying the token body into a stack buffer whose size is taken straight
from the token length:

```c
len = pld->pos - min;        /* distance to the closing '>' */
...
char    buf[len+1];          /* <*I... and <*R... */
unichar buf[len];            /* <*D...  (2*len bytes) */
```

`len` is bounded only by the size of the input, and these are C99
variable-length arrays on the stack, so a token of a few hundred KB
overflows the stack.

The token is attacker-controlled and reachable from the public
`+propertyListWithData:options:format:error:`: any data that is not a
binary or XML plist is parsed as `NSPropertyListOpenStepFormat`, and a
typed value may be the top-level item.

### Reproduced

Built `libs-base` with AddressSanitizer and parsed `<*I` + 1 MB of `0` + `>`
on a worker thread with a 512 KB stack:

```
ERROR: AddressSanitizer: stack-overflow ... in parsePlItem NSPropertyList.m:1140
    #0 parsePlItem NSPropertyList.m:1140                                  (buf[i] = (char)ptr[i])
    #1 +[NSPropertyListSerialization propertyListWithData:options:format:error:] NSPropertyList.m:2851
    #2 worker thread (512 KB stack)
```

The main thread does not crash until the token exceeds its (much larger)
stack, but any secondary thread with a normal smaller stack crashes on a
sub-megabyte token.

## Fix

A valid typed value is a short number or a fixed-format date (the writer
emits `[NSNumber stringValue]` / a `%Y-%m-%d %H:%M:%S %z` date), so reject
an over-long token before allocating the buffer rather than overflow the
stack. A single guard covers all three branches.

## Test

`Tests/base/NSPropertyList/openstep-typed-value-bounds.m` checks that a
normal `<*I...>`, `<*R...>` and `<*D...>` still parse, and that an
over-long `<*I...>` / `<*R...>` token is rejected (returns `nil`) instead
of being parsed. Validated before/after with an ASan build:

- without the fix: the two over-long cases are parsed instead of rejected (2 failed, 3 passed)
- with the fix: 5/5 pass, and the full `NSPropertyList` suite is 17/17.
