### PR TITLE
NSXMLDTDNode: copy strings passed to the entity-ID setters

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,18 @@
+2026-06-29 Todd White <todd.white@thalion.global>
+
+	* Source/NSXMLDTDNode.m (-setNotationName:, -setPublicID:,
+	-setSystemID:): these stored XMLSTRING(arg) - the transient
+	[arg UTF8String] buffer - directly in the persistent libxml2 entity
+	fields, so once the autorelease pool that produced the string
+	drained the field dangled: a getter read freed memory and -dealloc
+	xmlFreeEntity freed a pointer libxml2 never allocated.  Copy the
+	argument with XMLStringCopy, as -[NSXMLDTD setPublicID:] and
+	-setSystemID: do.  -setSystemID: also wrote ExternalID instead of
+	SystemID, so -systemID never returned the value set; store it in
+	SystemID.
+	* Tests/base/NSXMLDTDNode/entity-id-persistence.m: new regression
+	test.
+
 2026-06-21 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Documentation/BaseAdditions.gsdoc:

--- a/Source/NSXMLDTDNode.m
+++ b/Source/NSXMLDTDNode.m
@@ -114,17 +114,17 @@ GS_PRIVATE_INTERNAL(NSXMLDTDNode)
 
 - (void) setNotationName: (NSString*)notationName
 {
-  internal->node.entity->name = XMLSTRING(notationName);
+  internal->node.entity->name = XMLStringCopy(notationName);
 }
 
 - (void) setPublicID: (NSString*)publicID
 {
-  internal->node.entity->ExternalID = XMLSTRING(publicID);
+  internal->node.entity->ExternalID = XMLStringCopy(publicID);
 }
 
 - (void) setSystemID: (NSString*)systemID
 {
-  internal->node.entity->ExternalID = XMLSTRING(systemID);
+  internal->node.entity->SystemID = XMLStringCopy(systemID);
 }
 
 - (NSString*) systemID

--- a/Tests/base/NSXMLDTDNode/entity-id-persistence.m
+++ b/Tests/base/NSXMLDTDNode/entity-id-persistence.m
@@ -1,0 +1,74 @@
+/*
+ * entity-id-persistence.m - regression test for -[NSXMLDTDNode
+ * setNotationName:], -setPublicID: and -setSystemID:.
+ *
+ * Each setter stored XMLSTRING(arg), i.e. the transient
+ * [arg UTF8String] buffer, straight into the persistent libxml2 entity
+ * fields (entity->name / ExternalID).  That buffer is owned by the
+ * (autoreleased) argument string, so once the pool that produced it
+ * drained the field dangled: a later getter read freed memory
+ * (AddressSanitizer: heap-use-after-free in -notationName ->
+ * StringFromXMLStringPtr -> strlen) and -dealloc's xmlFreeEntity freed
+ * a pointer libxml2 never allocated.  -setSystemID: had a second bug: it
+ * wrote ExternalID rather than SystemID, so -systemID never returned the
+ * value that was set.  The fix copies the argument with XMLStringCopy
+ * (as -[NSXMLDTD setPublicID:]/-setSystemID: already do) and stores the
+ * system ID in the SystemID field.
+ *
+ * The setters are reached from ordinary public API, no parsing of
+ * untrusted input is required.
+ */
+
+#import "ObjectTesting.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSXMLNode.h>
+#import <Foundation/NSXMLDTDNode.h>
+#import "GNUstepBase/GNUstep.h"
+#import "GNUstepBase/GSConfig.h"
+
+int main()
+{
+  START_SET("NSXMLDTDNode entity-declaration IDs persist")
+#if !GS_USE_LIBXML
+    SKIP("library built without libxml2")
+#else
+  NSXMLDTDNode	*node;
+  NSUInteger	 i;
+
+  node = [[NSXMLDTDNode alloc] initWithKind: NSXMLEntityDeclarationKind
+				    options: 0];
+
+  /* Set the three IDs from strings whose lifetime ends with this inner
+   * pool, so a setter that failed to copy is left holding freed memory.
+   */
+  ENTER_POOL
+    [node setNotationName: [NSString stringWithFormat: @"gif%d", 89]];
+    [node setPublicID: [NSString stringWithFormat: @"-//ACME//DTD %d//EN", 1]];
+    [node setSystemID: [NSString stringWithFormat: @"http://acme/%d.dtd", 2]];
+  LEAVE_POOL
+
+  /* Churn the allocator so a freed UTF8String buffer is reused: an
+   * unbounded copy would now read back something other than the value
+   * that was set (in addition to the AddressSanitizer abort).
+   */
+  ENTER_POOL
+    for (i = 0; i < 256; i++)
+      {
+	(void)[NSString stringWithFormat: @"padpadpadpadpadpad%lu",
+	  (unsigned long)i];
+      }
+  LEAVE_POOL
+
+  PASS_EQUAL([node notationName], @"gif89",
+    "setNotationName: copies its argument and it survives the pool")
+  PASS_EQUAL([node publicID], @"-//ACME//DTD 1//EN",
+    "setPublicID: copies its argument and it survives the pool")
+  PASS_EQUAL([node systemID], @"http://acme/2.dtd",
+    "setSystemID: stores into the system-ID field and copies its argument")
+
+  [node release];
+#endif
+  END_SET("NSXMLDTDNode entity-declaration IDs persist")
+  return 0;
+}


### PR DESCRIPTION
## Problem

`-[NSXMLDTDNode setNotationName:]`, `-setPublicID:` and `-setSystemID:`
store `XMLSTRING(arg)` — the transient `[arg UTF8String]` buffer —
directly into the persistent libxml2 entity fields:

```objc
- (void) setNotationName: (NSString*)notationName
{
  internal->node.entity->name = XMLSTRING(notationName);        // transient buffer
}
- (void) setPublicID: (NSString*)publicID
{
  internal->node.entity->ExternalID = XMLSTRING(publicID);
}
- (void) setSystemID: (NSString*)systemID
{
  internal->node.entity->ExternalID = XMLSTRING(systemID);      // also: wrong field
}
```

`-[NSString UTF8String]` returns a buffer owned by the (usually
autoreleased) argument, so once that pool drains the entity field
dangles. This is reached from ordinary public API; no parsing of
untrusted input is required.

### Reproduced (AddressSanitizer)

Storing an autoreleased string and reading it back after the pool drained:

```
ERROR: AddressSanitizer: heap-use-after-free READ of size 12
    #0 strlen
    #1 StringFromXMLStringPtr NSXMLPrivate.h:94
    #2 -[NSXMLDTDNode notationName] NSXMLDTDNode.m:102
  freed by: object_dispose            (the argument string was deallocated)
```

and at `-dealloc`, `xmlFreeEntity` frees the same non-owned pointer:

```
ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed
    ... object_dispose -> ... -> xmlFreeEntity
```

## Fix

Copy the argument with `XMLStringCopy`, exactly as the sibling
`-[NSXMLDTD setPublicID:]` / `-setSystemID:` already do (those store an
owning `malloc`-ed copy that `xmlFreeEntity` can free).

`-setSystemID:` additionally wrote the `ExternalID` field rather than
`SystemID`, so `-systemID` never returned the value that was set and a
`setPublicID:` / `setSystemID:` pair clobbered each other. Store the
system ID in `SystemID`.

## Test

`Tests/base/NSXMLDTDNode/entity-id-persistence.m` sets the three IDs from
strings whose autorelease pool then drains, churns the allocator, and
checks the values survive. Validated before/after with an ASan build:

- without the fix: `publicID`/`systemID` fail deterministically (the
  wrong-field bug), and `-release` aborts under ASan with the invalid free
- with the fix: 3/3 pass; the full NSXMLNode/NSXMLDocument/NSXMLElement
  suites (245/36/132) remain green.

The test is gated on `GS_USE_LIBXML` and `SKIP`s when libxml2 is absent.
