### PR TITLE
NSXMLDocument: fix double free in -objectByApplyingXSLT:

### DIFF
--- a/Source/NSXMLDocument.m
+++ b/Source/NSXMLDocument.m
@@ -470,11 +470,11 @@ GS_PRIVATE_INTERNAL(NSXMLDocument)
   resultDoc = xsltApplyStylesheet(stylesheet, internal->node.doc,
                                   (const char **)params);
   
-  // Cleanup...
+  // Cleanup...  xsltParseStylesheetDoc() took ownership of stylesheetDoc, so
+  // xsltFreeStylesheet() frees it too; freeing it again here was a double free.
+  // xsltCleanupGlobals()/xmlCleanupParser() tear down process-global library
+  // state and must not be called from a library while documents are still live.
   xsltFreeStylesheet(stylesheet);
-  xmlFreeDoc(stylesheetDoc);
-  xsltCleanupGlobals();
-  xmlCleanupParser();
   NSZoneFree([self zone], params);
 
   return [NSXMLNode _objectForNode: (xmlNodePtr)resultDoc];

--- a/Tests/base/NSXMLDocument/applyingXSLT.m
+++ b/Tests/base/NSXMLDocument/applyingXSLT.m
@@ -1,0 +1,51 @@
+#import "ObjectTesting.h"
+#import <Foundation/NSData.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSXMLDocument.h>
+#import <Foundation/NSXMLElement.h>
+#import "GNUstepBase/GSConfig.h"
+
+int main()
+{
+  START_SET("NSXMLDocument applyingXSLT")
+#if !GS_USE_LIBXML
+  SKIP("library built without libxml2")
+#else
+  NSError	*err = nil;
+  NSData	*xml = [@"<?xml version=\"1.0\"?><doc><item>hello</item></doc>"
+    dataUsingEncoding: NSUTF8StringEncoding];
+  NSXMLDocument	*doc = [[[NSXMLDocument alloc] initWithData: xml
+                                                     options: 0
+                                                       error: &err] autorelease];
+  NSData	*xslt = [(@"<?xml version=\"1.0\"?>"
+    "<xsl:stylesheet version=\"1.0\""
+    " xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">"
+    "<xsl:template match=\"/\">"
+    "<out><xsl:value-of select=\"//item\"/></out>"
+    "</xsl:template></xsl:stylesheet>")
+    dataUsingEncoding: NSUTF8StringEncoding];
+  NSXMLDocument	*result;
+
+  PASS(doc != nil, "parsed the source document")
+
+  /* Applying a stylesheet used to free the parsed stylesheet document twice:
+   * xsltParseStylesheetDoc() passes ownership of the document to the
+   * stylesheet, so xsltFreeStylesheet() already frees it and the method's
+   * explicit xmlFreeDoc() was a double free.  Reaching here with the
+   * transformed result, rather than aborting, is the regression check. */
+  result = [doc objectByApplyingXSLT: xslt arguments: nil error: &err];
+  if (result == nil)
+    {
+      SKIP("XSLT support not built (libxslt unavailable)")
+    }
+  else
+    {
+      PASS_EQUAL([[result rootElement] name], @"out",
+        "the stylesheet produced the expected root element")
+      PASS_EQUAL([[result rootElement] stringValue], @"hello",
+        "the stylesheet produced the expected content")
+    }
+#endif
+  END_SET("NSXMLDocument applyingXSLT")
+  return 0;
+}


### PR DESCRIPTION
`-[NSXMLDocument objectByApplyingXSLT:arguments:error:]` double-frees the parsed stylesheet document.

`xsltParseStylesheetDoc()` takes ownership of the `xmlDocPtr` it is given — the returned stylesheet keeps it, and `xsltFreeStylesheet()` frees it. The method then frees the same document a second time:

```objc
xsltFreeStylesheet(stylesheet);   // frees stylesheet->doc (== stylesheetDoc)
xmlFreeDoc(stylesheetDoc);        // double free
```

AddressSanitizer confirms it on any stylesheet application — the region is freed in `xmlFreeNodeList` ← `xmlFreeDoc` ← `xsltFreeStylesheet` (NSXMLDocument.m:474), then freed again at NSXMLDocument.m:475.

This removes the redundant `xmlFreeDoc()`. It also drops the per-call `xsltCleanupGlobals()` / `xmlCleanupParser()` that followed: those reclaim process-global library state and, per the libxml2 documentation, must not be called from a library while the application may still be using libxml2 — here the receiver's own document and the freshly produced result document are still live.

### Test

`Tests/base/NSXMLDocument/applyingXSLT.m` applies a stylesheet and checks the transformed output. It is gated on `GS_USE_LIBXML` and skips cleanly when libxslt is not built (the method returns nil).

Validated under AddressSanitizer: before the fix the test aborts with a double free (only the initial parse assertion runs); after, it passes 3/3 and produces the expected `<out>hello</out>`.
