### PR TITLE
NSPropertyList: fix one-byte over-read parsing old-style <hex> data

### DIFF
--- a/Source/NSPropertyList.m
+++ b/Source/NSPropertyList.m
@@ -1326,7 +1326,10 @@ static id parsePlItem(pldata* pld) NS_RETURNS_RETAINED
                 // We permit (but do not require) space between/after hex octets
 		(void)skipSpace(pld);
 	      }
-            if (pld->ptr[pld->pos] != '>')
+            // skipSpace() can consume a comment that runs to the end of the
+            // buffer (taking the closing '>' with it), leaving pos == end, so
+            // the terminator check must guard against reading past the end.
+            if (pld->pos >= pld->end || pld->ptr[pld->pos] != '>')
               {
                 NSZoneFree(NSDefaultMallocZone(), buf);
 		pld->err = @"unexpected character (wanted '>')";

--- a/Tests/base/NSPropertyList/data-comment-bounds.m
+++ b/Tests/base/NSPropertyList/data-comment-bounds.m
@@ -1,0 +1,66 @@
+#import "ObjectTesting.h"
+#import <Foundation/NSData.h>
+#import <Foundation/NSPropertyList.h>
+#import <Foundation/NSString.h>
+
+#if defined(__unix__) || defined(__APPLE__)
+#include <sys/mman.h>
+#include <unistd.h>
+#include <string.h>
+#endif
+
+int main()
+{
+  START_SET("NSPropertyList data comment over-read")
+
+  /* A well-formed <hex> data value still parses. */
+  {
+    NSData	*good = [@"<4142>" dataUsingEncoding: NSUTF8StringEncoding];
+    NSData	*expect = [NSData dataWithBytes: "AB" length: 2];
+    id		pl = [NSPropertyListSerialization propertyListWithData: good
+      options: 0 format: NULL error: NULL];
+
+    PASS_EQUAL(pl, expect, "a well-formed <hex> data value parses")
+  }
+
+#if defined(__unix__) || defined(__APPLE__)
+  /* While parsing <...> data, a '/' '*' comment can consume the closing '>'
+   * and run the parser to the end of the buffer; the terminator check then
+   * read one byte past the end.  Put the payload at the end of a page backed
+   * by a PROT_NONE guard page so the over-read faults deterministically
+   * instead of silently reading adjacent memory. */
+  {
+    static const char	payload[] = "<41/*>";
+    long		pg = sysconf(_SC_PAGESIZE);
+    char		*base = mmap(NULL, 2 * pg, PROT_READ | PROT_WRITE,
+      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+    if (base == MAP_FAILED)
+      {
+	SKIP("could not mmap a guard page")
+      }
+    else
+      {
+	size_t	len = sizeof(payload) - 1;
+	char	*p = base + pg - len;	/* payload ends at the page boundary */
+	NSData	*d;
+	id	pl;
+
+	memcpy(p, payload, len);
+	mprotect(base + pg, pg, PROT_NONE);	/* the byte after it faults */
+	d = [NSData dataWithBytesNoCopy: p length: len freeWhenDone: NO];
+	pl = [NSPropertyListSerialization propertyListWithData: d
+	  options: 0 format: NULL error: NULL];
+
+	PASS(pl == nil,
+	  "a comment eating the data terminator is rejected, not over-read")
+
+	mprotect(base + pg, pg, PROT_READ | PROT_WRITE);
+	munmap(base, 2 * pg);
+      }
+  }
+#endif
+
+  END_SET("NSPropertyList data comment over-read")
+  return 0;
+}


### PR DESCRIPTION
Parsing an old-style (OpenStep) `<...>` data value reads one byte past the end of the buffer.

After the initial scan finds the closing `>`, the hex octets are parsed with `skipSpace()` called between them to allow whitespace. `skipSpace()` also skips `/* ... */` comments — and a comment can contain the `>` that the initial scan found and run to the end of the buffer, leaving `pos == end`. Its return value is ignored (`(void)skipSpace(pld)`), so the terminator check then dereferences `ptr[pos]` with `pos == end`:

```objc
(void)skipSpace(pld);          // can consume the '>' and reach end
...
if (pld->ptr[pld->pos] != '>') // ptr[end] — one byte past the buffer
```

AddressSanitizer confirms it — `heap-buffer-overflow READ of size 1 in parsePlItem` (NSPropertyList.m:1329), reachable from the public `+propertyListWithData:options:format:error:` with input such as `<41/*>`.

This guards the dereference with a `pos < end` check; the over-long/unterminated input is then reported as the existing `unexpected character (wanted '>')` parse error.

### Test

`Tests/base/NSPropertyList/data-comment-bounds.m` places the malformed input at the end of a page backed by a `PROT_NONE` guard page, so the one-byte over-read faults deterministically rather than silently reading adjacent memory (Unix only; it skips elsewhere). It also parses a well-formed `<4142>` value as a positive control. Before the fix the test aborts on the guard page; after, it passes (2/2).
