### PR TITLE
NSURL: avoid NULL deref resolving a relative URL against a scheme-less base

### DIFF
--- a/Source/NSURL.m
+++ b/Source/NSURL.m
@@ -979,10 +979,13 @@ static NSUInteger	urlAlign;
       start = end;
 
       if (buf->scheme != 0 && base != 0
-        && 0 != strcmp(buf->scheme, base->scheme))
+        && (base->scheme == 0 || 0 != strcmp(buf->scheme, base->scheme)))
         {
-          /* The relative URL is of a different scheme to the base ...
-           * so it's actually an absolute URL without a base.
+          /* The relative URL has a scheme which the base lacks or which
+           * differs from the base ... so it's actually an absolute URL
+           * without a base.  (base->scheme may be NULL when the base was
+           * itself parsed from a scheme-less string, so it must be checked
+           * before strcmp.)
            */
           DESTROY(_baseURL);
           base = 0;

--- a/Tests/base/NSURL/relative-scheme-base.m
+++ b/Tests/base/NSURL/relative-scheme-base.m
@@ -1,0 +1,27 @@
+#import "ObjectTesting.h"
+#import <Foundation/NSString.h>
+#import <Foundation/NSURL.h>
+
+int main()
+{
+  START_SET("NSURL relative URL over a scheme-less base")
+
+  NSURL	*base = [NSURL URLWithString: @"foo"];
+  NSURL	*child;
+
+  PASS(base != nil && [base scheme] == nil,
+    "a scheme-less base URL parses and reports no scheme")
+
+  /* A relative string that carries its own scheme used to be compared with
+   * strcmp() against the base's scheme, which is NULL for a scheme-less base,
+   * crashing the process.  The relative URL should instead be treated as an
+   * absolute URL (its scheme differs from the base's absent one). */
+  child = [NSURL URLWithString: @"http:bar" relativeToURL: base];
+  PASS(child != nil,
+    "a scheme-bearing relative URL over a scheme-less base does not crash")
+  PASS_EQUAL([child absoluteString], @"http:bar",
+    "the relative URL is resolved as an absolute URL")
+
+  END_SET("NSURL relative URL over a scheme-less base")
+  return 0;
+}


### PR DESCRIPTION
`-[NSURL initWithString:relativeToURL:]` dereferences NULL when the base URL has no scheme.

When the relative string carries its own scheme, the parser compares it with the base's scheme to decide whether the relative URL is really absolute:

```objc
if (buf->scheme != 0 && base != 0
  && 0 != strcmp(buf->scheme, base->scheme))   // base->scheme may be NULL
```

The guard only checks `base != 0`, not `base->scheme != 0`. A base `NSURL` parsed from a scheme-less string has `scheme == NULL` (the field is zero-initialised and only set when a `scheme:` prefix is present), so `strcmp()` dereferences NULL.

Reachable from the public API:

```objc
NSURL *base  = [NSURL URLWithString: @"foo"];                        // scheme == nil
NSURL *child = [NSURL URLWithString: @"http:bar" relativeToURL: base]; // crash
```

AddressSanitizer: `SEGV ... READ ... in strcmp` ← `NSURL.m:982` ← `+URLWithString:relativeToURL:`.

This checks `base->scheme` before the `strcmp`: a relative URL that carries a scheme the base lacks is treated as an absolute URL — the same handling already used when the two schemes merely differ. With the fix, the example above resolves to the absolute `http:bar`.

### Test

`Tests/base/NSURL/relative-scheme-base.m` builds the scheme-less base, resolves a scheme-bearing relative URL against it, and checks it does not crash and resolves to `http:bar`. The NULL dereference crashes deterministically, so the test aborts before the fix and passes (3/3) after.
