### PR TITLE
GSMime: append, don't overwrite, when decoding a body across several calls

### DIFF
--- a/Source/Additions/GSMime.m
+++ b/Source/Additions/GSMime.m
@@ -590,7 +590,7 @@ wordData(NSString *word, BOOL *encoded)
    * Expand destination data buffer to have capacity to handle info.
    */
   [dData setLength: size + (3 * (end + 8 - src))/4];
-  dst = (unsigned char*)[dData mutableBytes];
+  dst = (unsigned char*)[dData mutableBytes] + size;
   beg = dst;
 
   /*
@@ -690,7 +690,7 @@ wordData(NSString *word, BOOL *encoded)
    * Expand destination data buffer to have capacity to handle info.
    */
   [dData setLength: size + (end - src)];
-  dst = (unsigned char*)[dData mutableBytes];
+  dst = (unsigned char*)[dData mutableBytes] + size;
   beg = dst;
 
   while (src < end)

--- a/Tests/base/GSMime/streamed-decode.m
+++ b/Tests/base/GSMime/streamed-decode.m
@@ -1,0 +1,41 @@
+#if	defined(GNUSTEP_BASE_LIBRARY)
+#import <Foundation/Foundation.h>
+#import <GNUstepBase/GSMime.h>
+#import "Testing.h"
+
+int main()
+{
+  START_SET("GSMime streamed body decode")
+
+  NSString	*msg =
+    @"Content-Type: text/plain\r\n"
+     "Content-Transfer-Encoding: base64\r\n"
+     "\r\n"
+     "SGVsbG8sIFdvcmxkIQ==\r\n";		/* base64 of "Hello, World!" */
+  NSData	*d = [msg dataUsingEncoding: NSASCIIStringEncoding];
+  const char	*b = [d bytes];
+  NSUInteger	len = [d length];
+  NSRange	blank = [msg rangeOfString: @"\r\n\r\n"];
+  NSUInteger	split = blank.location + 4 + 4;	/* 4 base64 chars in part 1 */
+  GSMimeParser	*p = [GSMimeParser mimeParser];
+
+  /* Feed the message in two parts, splitting the base64 body.  The base64 and
+   * quoted-printable decoders used to write each chunk's decoded output at the
+   * start of the destination buffer, discarding the previous chunk; a body
+   * arriving across several parse: calls must instead decode as a whole. */
+  [p parse: [NSData dataWithBytes: b length: split]];
+  [p parse: [NSData dataWithBytes: b + split length: len - split]];
+  [p parse: nil];
+
+  PASS_EQUAL([[p mimeDocument] content], @"Hello, World!",
+    "a base64 body split across parse: calls decodes correctly")
+
+  END_SET("GSMime streamed body decode")
+  return 0;
+}
+#else
+int main(void)
+{
+  return 0;
+}
+#endif


### PR DESCRIPTION
A MIME body encoded with base64 or quoted-printable decodes incorrectly when it arrives across more than one `-parse:` call.

`GSMimeBase64DecoderContext` and `GSMimeQuotedDecoderContext` set their output cursor to the **start** of the destination buffer:

```objc
[dData setLength: size + ...];
dst = (unsigned char*)[dData mutableBytes];   // should be + size
beg = dst;
```

`size` is the amount already decoded into `dData`. Because the body decoder is invoked once per `-parse:` call (i.e. once per network packet for a streamed message), each call overwrote the previously decoded bytes, so only the last chunk's output survived. A base64 body `SGVsbG8sIFdvcmxkIQ==` ("Hello, World!") split across two `-parse:` calls decoded to `lo, World!`.

The base `GSMimeCodingContext` (`mutableBytes + size`) and the chunked decoder (`buf + size`) already append correctly; this makes the base64 and quoted-printable contexts do the same.

### Test

`Tests/base/GSMime/streamed-decode.m` feeds a base64 body in two parts, splitting the encoded data, and checks the document content is `Hello, World!`. It fails before the fix (decodes to `lo, World!`) and passes after.
