### PR TITLE
GSMime: bound the RFC2047 encoded word decode buffer

### DIFF
--- a/Source/Additions/GSMime.m
+++ b/Source/Additions/GSMime.m
@@ -3073,9 +3073,14 @@ unfold(const unsigned char *src, const unsigned char *end, BOOL *folded)
 	       */
 	      if (tmp > src)
 		{
-		  unsigned char	buf[tmp - src + 1];
 		  unsigned char	*ptr;
 
+		  /* The encoded word length is controlled by the (untrusted)
+		   * header data, so GS_BEGINITEMBUF keeps a short word on the
+		   * stack but moves a long one to the heap, avoiding both a
+		   * stack overflow and an unconditional heap allocation.
+		   */
+		  GS_BEGINITEMBUF(buf, tmp - src + 1, unsigned char)
 		  ptr = decodeWord(buf, src, tmp, encoding);
 		  s = [NSStringClass allocWithZone: NSDefaultMallocZone()];
 		  s = [s initWithBytes: buf
@@ -3090,6 +3095,7 @@ unfold(const unsigned char *src, const unsigned char *end, BOOL *folded)
                       [hdr appendString: s];
                     }
 		  RELEASE(s);
+		  GS_ENDITEMBUF()
 		}
 	      /* Point past end to continue parsing.
 	       */

--- a/Tests/base/GSMime/encoded-word-stack.m
+++ b/Tests/base/GSMime/encoded-word-stack.m
@@ -1,0 +1,70 @@
+#if	defined(GNUSTEP_BASE_LIBRARY)
+#import <Foundation/Foundation.h>
+#import <GNUstepBase/GSMime.h>
+#import "GNUstepBase/GNUstep.h"
+#import "Testing.h"
+
+#if	defined(__unix__) || defined(__APPLE__)
+#include <pthread.h>
+#include <string.h>
+#include <stdlib.h>
+
+static volatile int	decoded = 0;
+
+static void *
+worker(void *arg)
+{
+  ENTER_POOL
+  GSMimeParser	*p = [GSMimeParser mimeParser];
+  NSMutableData	*m = [NSMutableData data];
+  const char	*pre = "Subject: =?utf-8?B?";
+  const char	*post = "?=\r\n\r\n";
+  NSUInteger	n = 400000;
+  char		*a = malloc(n);
+
+  (void)arg;
+  memset(a, 'A', n);
+  [m appendBytes: pre length: strlen(pre)];
+  [m appendBytes: a length: n];
+  [m appendBytes: post length: strlen(post)];
+  free(a);
+
+  [p parse: m];
+  [p parse: nil];
+  if ([p mimeDocument] != nil)
+    {
+      decoded = 1;
+    }
+  LEAVE_POOL
+  return NULL;
+}
+#endif
+
+int main()
+{
+  START_SET("GSMime encoded-word stack safety")
+#if	defined(__unix__) || defined(__APPLE__)
+  pthread_attr_t	attr;
+  pthread_t		t;
+
+  /* A long RFC2047 encoded word used to be decoded into a stack VLA sized
+   * from the (untrusted) word length, overflowing the stack.  Decode it on
+   * a small stack so the regression crashes rather than merely runs. */
+  pthread_attr_init(&attr);
+  pthread_attr_setstacksize(&attr, 256 * 1024);
+  pthread_create(&t, &attr, worker, NULL);
+  pthread_join(t, NULL);
+  PASS(decoded == 1,
+    "a long encoded word is decoded without overflowing the stack")
+#else
+  SKIP("test needs pthreads with a configurable stack size")
+#endif
+  END_SET("GSMime encoded-word stack safety")
+  return 0;
+}
+#else
+int main(void)
+{
+  return 0;
+}
+#endif


### PR DESCRIPTION
A long RFC2047 encoded word in a MIME header overflows the stack.

`-[GSMimeParser _decodeHeader]` decodes the data part of an encoded word (`=?charset?enc?data?=`) into a stack VLA:

```objc
if (tmp > src)
  {
    unsigned char buf[tmp - src + 1];   // tmp-src is the encoded-word length
    ...
    ptr = decodeWord(buf, src, tmp, encoding);
```

`tmp - src` is the length of the encoded data, which comes straight from the header being parsed, so an attacker controls the size of the VLA. A header carrying a long encoded word overflows the stack.

AddressSanitizer confirms it — a ~400KB `=?utf-8?B?AAAA…?=` decoded on a 256KB thread stack crashes (`SEGV` in `decodeWord`/`decodebase64` ← `_decodeHeader` ← `parseHeaders:remaining:` ← `parse:`).

This allocates the buffer on the heap instead, matching the bounded-stack approach used elsewhere for untrusted lengths.

### Test

`Tests/base/GSMime/encoded-word-stack.m` decodes a long encoded word on a thread with a small (256KB) stack, so the regression overflows the stack and aborts before the fix and passes after (Unix only; it skips elsewhere).
