### PR TITLE
GSToUnicode: don't over-read a partial UTF-16/UTF-32 unit

### DIFF
--- a/Source/Additions/Unicode.m
+++ b/Source/Additions/Unicode.m
@@ -1250,7 +1250,7 @@ GSToUnicode(unichar **dst, unsigned int *size, const unsigned char *src,
 	if ((GS_WORDS_BIGENDIAN && NSUTF16LittleEndianStringEncoding == enc)
 	  || (!GS_WORDS_BIGENDIAN && NSUTF16BigEndianStringEncoding == enc))
 	  {
-	    while (spos < slen)
+	    while (slen - spos >= sizeof(uint16_t))
               {
                 uint16_t	c = *(uint16_t*)(src + spos);
 
@@ -1261,7 +1261,7 @@ GSToUnicode(unichar **dst, unsigned int *size, const unsigned char *src,
 	  }
 	else
 	  {
-	    while (spos < slen)
+	    while (slen - spos >= sizeof(uint16_t))
               {
 	        ptr[dpos++] = *(uint16_t*)(src + spos);
 		spos += 2;
@@ -1280,7 +1280,7 @@ GSToUnicode(unichar **dst, unsigned int *size, const unsigned char *src,
 	    {
 	      swap = YES;
 	    }
-	  while (spos < slen)
+	  while (slen - spos >= sizeof(uint32_t))
 	    {
 	      uint32_t	c = *(uint32_t*)(src + spos);
 

--- a/Tests/base/NSString/utf16-utf32-bounds.m
+++ b/Tests/base/NSString/utf16-utf32-bounds.m
@@ -1,0 +1,61 @@
+#import "ObjectTesting.h"
+#import <Foundation/NSData.h>
+#import <Foundation/NSString.h>
+
+#if	defined(__unix__) || defined(__APPLE__)
+#include <sys/mman.h>
+#include <unistd.h>
+#include <string.h>
+
+/* Decode `n` bytes that sit at the very end of a page whose following page is
+ * unmapped, so an over-read past the data faults instead of silently reading
+ * adjacent memory. */
+static NSString *
+guarded(NSUInteger n, NSStringEncoding enc)
+{
+  long		pg = sysconf(_SC_PAGESIZE);
+  char		*base = mmap(NULL, 2 * pg, PROT_READ | PROT_WRITE,
+    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  char		*p;
+  NSString	*s;
+
+  if (base == MAP_FAILED) return nil;
+  p = base + pg - n;
+  memset(p, 'A', n);
+  mprotect(base + pg, pg, PROT_NONE);
+  s = [[NSString alloc] initWithData:
+    [NSData dataWithBytesNoCopy: p length: n freeWhenDone: NO] encoding: enc];
+  mprotect(base + pg, pg, PROT_READ | PROT_WRITE);
+  munmap(base, 2 * pg);
+  return [s autorelease];
+}
+#endif
+
+int main()
+{
+  START_SET("NSString UTF-16/UTF-32 data length bounds")
+
+  /* A well-formed UTF-16 buffer still decodes correctly. */
+  {
+    unsigned char	bytes[] = { 0x00, 'A', 0x00, 'B' };	/* "AB" BE */
+    NSString		*s = [[[NSString alloc] initWithData:
+      [NSData dataWithBytes: bytes length: 4]
+      encoding: NSUTF16BigEndianStringEncoding] autorelease];
+
+    PASS_EQUAL(s, @"AB", "a well-formed UTF-16 buffer decodes")
+  }
+
+#if	defined(__unix__) || defined(__APPLE__)
+  /* The UTF-16 and UTF-32 decoders read a whole 2- or 4-byte unit each
+   * iteration but only checked that a single byte remained, over-reading a
+   * buffer whose length is not a multiple of the unit size.  Reaching here
+   * (rather than faulting on the guard page) is the regression check. */
+  PASS(guarded(1, NSUTF16BigEndianStringEncoding) != nil,
+    "an odd-length UTF-16 buffer is decoded without over-reading")
+  PASS(guarded(3, NSUTF32BigEndianStringEncoding) != nil,
+    "a non-multiple-of-4 UTF-32 buffer is decoded without over-reading")
+#endif
+
+  END_SET("NSString UTF-16/UTF-32 data length bounds")
+  return 0;
+}


### PR DESCRIPTION
`GSToUnicode` over-reads the source when decoding a UTF-16 or UTF-32 buffer whose length is not a whole number of code units.

The decoding loops read a full unit each iteration but only checked that one byte remained:

```objc
// UTF-16
while (spos < slen)
  { ptr[dpos++] = *(uint16_t*)(src + spos); spos += 2; }   // reads 2 bytes
// UTF-32
while (spos < slen)
  { uint32_t c = *(uint32_t*)(src + spos); ... spos += 4; } // reads 4 bytes
```

So an odd-length UTF-16 buffer (or a UTF-32 buffer not a multiple of 4) reads 1–3 bytes past the end. This is reachable from the public `-[NSString initWithData:encoding:]` — e.g. decoding a truncated UTF-16 file or network buffer.

AddressSanitizer: `heap-buffer-overflow ... in GSToUnicode` (Unicode.m:1285 for UTF-32; the UTF-16 loops at :1255/:1266 have the same issue).

The fix requires a whole unit to remain (`slen - spos >= 2` / `>= 4`); any trailing partial bytes are ignored.

### Test

`Tests/base/NSString/utf16-utf32-bounds.m` decodes a short non-unit-aligned buffer placed at the end of a page backed by a `PROT_NONE` guard page, so the over-read faults deterministically (Unix only; skips elsewhere), plus a well-formed UTF-16 buffer as a positive control. Before the fix the test aborts on the guard page; after, it passes 3/3.
