### PR TITLE
GSFromUnicode: reserve four bytes before each UTF-32 output write

### DIFF
--- a/Source/Additions/Unicode.m
+++ b/Source/Additions/Unicode.m
@@ -2592,7 +2592,7 @@ GSFromUnicode(unsigned char **dst, unsigned int *size, const unichar *src,
 	      }
 
 	    /* Grow output buffer to make room if necessary */
-	    if (dpos >= bsize)
+	    while (dpos + 4 > bsize)
 	      {
 		GROW();
 	      }

--- a/Tests/base/NSString/utf32-from-bounds.m
+++ b/Tests/base/NSString/utf32-from-bounds.m
@@ -1,0 +1,25 @@
+#import "ObjectTesting.h"
+#import <Foundation/NSData.h>
+#import <Foundation/NSString.h>
+
+int main()
+{
+  START_SET("NSString -> UTF-32 output bounds")
+
+  /* Converting to UTF-32 writes four bytes per character but only checked
+   * that one byte of space remained.  Once the destination buffer has been
+   * grown to the character count (which happens for a long string) and that
+   * count is not a multiple of four, the four-byte write overran the buffer.
+   * A string of 20001 characters reproduces it; the conversion must complete
+   * and produce 4 bytes per character. */
+  NSUInteger	n = 20001;	/* > internal grow threshold, not a multiple of 4 */
+  NSString	*s = [@"" stringByPaddingToLength: n withString: @"A"
+                                    startingAtIndex: 0];
+  NSData	*d = [s dataUsingEncoding: NSUTF32LittleEndianStringEncoding];
+
+  PASS([d length] == n * 4,
+    "a long string converts to UTF-32 without overrunning the buffer")
+
+  END_SET("NSString -> UTF-32 output bounds")
+  return 0;
+}


### PR DESCRIPTION
`GSFromUnicode` overruns the destination buffer when converting a long string to UTF-32.

The UTF-32 output loop writes four bytes per character but only grew the buffer when no byte remained at all:

```objc
if (dpos >= bsize)        // only guarantees 1 free byte
  { GROW(); }
...
memcpy((ptr + dpos), &u, 4);   // writes 4 bytes
dpos += 4;
```

`dpos` advances in steps of four, and normally `bsize` stays a multiple of four (the initial buffer and the `+ BUFSIZ` growth are), so `dpos` never lands within three bytes of `bsize`. But when the string is long enough that `GROW()` sizes the buffer to `slen` (the character count) and `slen` is not a multiple of four, `bsize` is no longer four-aligned: `dpos` then reaches the largest multiple of four below `bsize`, passes the `dpos >= bsize` check, and the four-byte `memcpy` overruns the buffer by one to three bytes.

Reachable from `-[NSString dataUsingEncoding:]` with `NSUTF32StringEncoding` and a string longer than the initial buffer (e.g. 20001 characters). AddressSanitizer: `heap-buffer-overflow ... in GSFromUnicode` (Unicode.m:2607).

The fix grows the buffer while fewer than four bytes remain (`while (dpos + 4 > bsize)`), matching the UTF-8 output path.

### Test

`Tests/base/NSString/utf32-from-bounds.m` converts a 20001-character string to UTF-32 and checks the result is four bytes per character. The overrun is into an internally allocated buffer, so the test detects it under AddressSanitizer (it aborts before the fix); the length check also guards normal conversion.
