### PR TITLE
NSKeyedUnarchiver: range-check the CF$UID object reference before indexing _objMap

### DIFF
--- a/Source/NSKeyedUnarchiver.m
+++ b/Source/NSKeyedUnarchiver.m
@@ -164,6 +164,17 @@ static NSMapTable	*globalClassMap = 0;
    * If the referenced object is already in _objMap
    * we simply return it (the object at index 0 maps to nil)
    */
+  /* The index comes from an (untrusted) CF$UID in the archive, and GSIArray
+   * is not bounds checked in release builds, so reject an out-of-range
+   * reference (as -[_objects objectAtIndex:] does below) rather than reading
+   * past the end of the map.
+   */
+  if (index >= GSIArrayCount(_objMap))
+    {
+      [NSException raise: NSRangeException
+		  format: @"[%@ -%@] archive object index out of range",
+	NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
+    }
   obj = GSIArrayItemAtIndex(_objMap, index).obj;
   if (obj != nil)
     {

--- a/Tests/base/NSKeyedArchiver/uidbounds.m
+++ b/Tests/base/NSKeyedArchiver/uidbounds.m
@@ -1,0 +1,71 @@
+/*
+ * uidbounds.m - regression test for -[NSKeyedUnarchiver _decodeObject:].
+ *
+ * The object-reference index decoded from a CF$UID in a keyed archive was used
+ * to index the _objMap GSIArray (which is not bounds checked in release builds)
+ * before the bounds-checked -[_objects objectAtIndex:].  An archive whose root
+ * CF$UID is out of range therefore read past the end of the map - a heap buffer
+ * overflow when unarchiving an untrusted archive with assertions compiled out.
+ * The index is now range checked, so an out-of-range reference is rejected
+ * rather than used to over-read the map.
+ *
+ *   - a normal object still round-trips through the keyed archiver.
+ *   - an archive whose root CF$UID is past the object table is rejected.
+ */
+
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+
+/* Build a keyed archive, then point its root CF$UID one past the object
+ * table (the CF$UID dictionaries the binary plist parser produces are
+ * immutable, so replace the whole reference rather than editing it in place).
+ */
+static NSData *
+tamperedArchive(void)
+{
+  NSData		*archive;
+  NSMutableDictionary	*plist;
+  NSMutableDictionary	*top;
+  NSArray		*objects;
+  NSDictionary		*badRef;
+
+  archive = [NSKeyedArchiver archivedDataWithRootObject: @"hello world"];
+  plist = [NSPropertyListSerialization
+    propertyListWithData: archive
+		 options: NSPropertyListMutableContainersAndLeaves
+		  format: NULL
+		   error: NULL];
+  objects = [plist objectForKey: @"$objects"];
+  top = [[[plist objectForKey: @"$top"] mutableCopy] autorelease];
+  badRef = [NSDictionary dictionaryWithObject:
+    [NSNumber numberWithUnsignedInteger: [objects count] + 1]
+    forKey: @"CF$UID"];
+  [top setObject: badRef forKey: @"root"];
+  [plist setObject: top forKey: @"$top"];
+  return [NSPropertyListSerialization
+    dataWithPropertyList: plist
+		  format: NSPropertyListBinaryFormat_v1_0
+		 options: 0
+		   error: NULL];
+}
+
+int
+main(int argc, char *argv[])
+{
+  START_SET("NSKeyedUnarchiver CF$UID bounds")
+  ENTER_POOL
+  id	obj;
+
+  obj = [NSKeyedUnarchiver unarchiveObjectWithData:
+    [NSKeyedArchiver archivedDataWithRootObject: @"hello world"]];
+  PASS_EQUAL(obj, @"hello world", "a normal keyed archive unarchives")
+
+  PASS_EXCEPTION([NSKeyedUnarchiver unarchiveObjectWithData: tamperedArchive()],
+    NSRangeException,
+    "an out-of-range CF$UID in an archive is rejected, not used to over-read")
+
+  LEAVE_POOL
+  END_SET("NSKeyedUnarchiver CF$UID bounds")
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

`-[NSKeyedUnarchiver _decodeObject:]` uses the object-reference index decoded from a `CF$UID` in the archive to index the `_objMap` `GSIArray` **before** the bounds-checked `-[_objects objectAtIndex:]` that follows:

```objc
obj = GSIArrayItemAtIndex(_objMap, index).obj;   /* index is an untrusted CF$UID */
if (obj != nil) { ... return obj; }
...
obj = [_objects objectAtIndex: index];           /* this one is range-checked */
```

`GSIArrayItemAtIndex` is not bounds checked in release builds — its only check is an assertion that `NS_BLOCK_ASSERTIONS` compiles out. So an archive whose root `CF$UID` is out of range reads past the end of `_objMap`: a heap buffer overflow when unarchiving an untrusted archive. The intended rejection (`objectAtIndex:` raising `NSRangeException`) is simply reached too late.

The fix range-checks `index` against `GSIArrayCount(_objMap)` up front and rejects an out-of-range reference with `NSRangeException`, matching the rejection `objectAtIndex:` already performs.

## Validation (Ubuntu 24.04, clang 18, libobjc2)

- **Positive + negative control** (in-tree `gnustep-tests`, assertions on): patched, **2/2 pass** — a normal object still round-trips through the keyed archiver, and an archive whose root `CF$UID` is one past the object table is rejected with `NSRangeException`. Against the unpatched lib the rejection case **fails** (`GSIArrayItemAtIndex`'s assertion raises `NSInternalInconsistencyException` instead).
- **Memory safety** (ASan, built with `NS_BLOCK_ASSERTIONS` so the `GSIArray` assertion is compiled out): the unpatched `-_decodeObject:` reads past `_objMap` — `AddressSanitizer: heap-buffer-overflow, READ of size 8` just past the map allocation. The patched build rejects the reference before the read.

A new regression test is added at `Tests/base/NSKeyedArchiver/uidbounds.m`.
