### PR TITLE
GSMime: avoid a stack VLA when scanning a long quoted header token

### DIFF
--- a/Source/Additions/GSMime.m
+++ b/Source/Additions/GSMime.m
@@ -2253,10 +2253,17 @@ NSDebugMLLog(@"GSMime", @"Header parsed - %@", info);
 	}
       else
 	{
-	  unichar	buf[length];
-	  unichar	*src = buf;
-	  unichar	*dst = buf;
+	  unichar	*src;
+	  unichar	*dst;
+	  NSString	*result;
 
+	  /* The quoted string length is attacker-controlled (it comes from an
+	   * untrusted header value), so use GS_BEGINITEMBUF rather than a stack
+	   * VLA to avoid a stack overflow on a very long quoted string.
+	   */
+	  GS_BEGINITEMBUF(buf, length, unichar)
+	  src = buf;
+	  dst = buf;
 	  [string getCharacters: buf range: NSMakeRange(start, length)];
 	  while (src < &buf[length])
 	    {
@@ -2270,7 +2277,9 @@ NSDebugMLLog(@"GSMime", @"Header parsed - %@", info);
 		}
 	      *dst++ = *src++;
 	    }
-	  return [NSStringClass stringWithCharacters: buf length: dst - buf];
+	  result = [NSStringClass stringWithCharacters: buf length: dst - buf];
+	  GS_ENDITEMBUF()
+	  return result;
 	}
     }
   else							// Token

--- a/Tests/base/GSMime/quoted-token-stack.m
+++ b/Tests/base/GSMime/quoted-token-stack.m
@@ -1,0 +1,62 @@
+#if	defined(GNUSTEP_BASE_LIBRARY)
+#import <Foundation/Foundation.h>
+#import <GNUstepBase/GSMime.h>
+#import "GNUstepBase/GNUstep.h"
+#import "Testing.h"
+
+#if	defined(__unix__) || defined(__APPLE__)
+#include <pthread.h>
+
+static volatile int	scanned = 0;
+
+static void *
+worker(void *arg)
+{
+  ENTER_POOL
+  GSMimeParser	*p = [GSMimeParser mimeParser];
+  NSUInteger	n = 400000;
+  NSString	*big = [@"" stringByPaddingToLength: n
+				 withString: @"A" startingAtIndex: 0];
+  NSString	*quoted = [NSString stringWithFormat: @"\"%@\"", big];
+  NSScanner	*sc = [NSScanner scannerWithString: quoted];
+  NSString	*token;
+
+  (void)arg;
+  token = [p scanToken: sc];
+  if ([token length] == n)
+    {
+      scanned = 1;
+    }
+  LEAVE_POOL
+  return NULL;
+}
+#endif
+
+int main()
+{
+  START_SET("GSMime quoted-token stack safety")
+#if	defined(__unix__) || defined(__APPLE__)
+  pthread_attr_t	attr;
+  pthread_t		t;
+
+  /* A long quoted header value used to be copied into a stack VLA sized from
+   * the (untrusted) value length, overflowing the stack.  Scan it on a small
+   * stack so the regression crashes rather than merely runs. */
+  pthread_attr_init(&attr);
+  pthread_attr_setstacksize(&attr, 256 * 1024);
+  pthread_create(&t, &attr, worker, NULL);
+  pthread_join(t, NULL);
+  PASS(scanned == 1,
+    "a long quoted token is scanned without overflowing the stack")
+#else
+  SKIP("test needs pthreads with a configurable stack size")
+#endif
+  END_SET("GSMime quoted-token stack safety")
+  return 0;
+}
+#else
+int main(void)
+{
+  return 0;
+}
+#endif


### PR DESCRIPTION
## Summary

`-[GSMimeParser scanToken:]` parses a header token. Its quoted-string branch copies the token into a **stack VLA sized from the quoted-string length**:

```objc
unichar buf[length];                 /* length = quoted-string content length */
...
[string getCharacters: buf range: NSMakeRange(start, length)];
```

A quoted header value is attacker-controlled, so a long quoted value overflows the stack. This is reachable from untrusted input through:

- **HTTP auth** — `+[GSHTTPAuthentication protectionSpaceForAuthentication:requestURL:]` (and `-authorizationForAuthentication:method:path:`) scan a malicious server's `WWW-Authenticate` value, e.g. `Digest realm="<very long>"`.
- **MIME header parameters** — any header with a long quoted parameter value (`Content-Type: …; name="<very long>"`, etc.) goes through `scanToken:` during a normal `-parse:`.

The fix uses `GS_BEGINITEMBUF` / `GS_ENDITEMBUF` (as in `-_decodeHeader`), keeping the common short token on the stack and moving only a large one to the heap.

## Validation (Ubuntu 24.04, clang 18, libobjc2)

- Reached through the public auth entry `+[GSHTTPAuthentication protectionSpaceForAuthentication:requestURL:]` with a 400KB quoted realm on a 256KB-stack thread: the unpatched build crashes (**AddressSanitizer: SEGV, stack overflow** on the worker thread); the patched build returns normally.
- Regression test (in-tree `gnustep-tests`, a 256KB-stack worker scanning a 400000-character quoted token): patched **1/1 pass**; against the unpatched lib the test binary **crashes (stack overflow) before completing**.

A new regression test is added at `Tests/base/GSMime/quoted-token-stack.m`.
