### PR TITLE
NSHTTPCookie: stop the Set-Cookie comma scan running off the buffer end

### DIFF
--- a/Source/NSHTTPCookie.m
+++ b/Source/NSHTTPCookie.m
@@ -942,7 +942,7 @@ GSCookieStrings(NSString *string)
 
 		  /* skip past token characters.
 		   */
-		  while (c > 32 && c < 128 && strchr(bad, c) == 0)
+		  while (pos < end && c > 32 && c < 128 && strchr(bad, c) == 0)
 		    {
 		      pos++;
 		      if (pos < end)

--- a/Tests/base/NSHTTPCookie/comma-loop.m
+++ b/Tests/base/NSHTTPCookie/comma-loop.m
@@ -1,0 +1,49 @@
+#if	defined(GNUSTEP_BASE_LIBRARY)
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+
+#if	defined(__unix__) || defined(__APPLE__)
+#include <unistd.h>
+
+int main()
+{
+  START_SET("NSHTTPCookie Set-Cookie comma scan terminates")
+  ENTER_POOL
+  NSURL		*url = [NSURL URLWithString: @"http://example.com/"];
+  NSDictionary	*headers = [NSDictionary dictionaryWithObject: @"a=b, cd"
+						       forKey: @"Set-Cookie"];
+  NSArray	*cookies;
+  NSHTTPCookie	*cookie;
+
+  /* The comma-lookahead in GSCookieStrings used to run off the end of the
+   * buffer (looping ~2^32 times) for a Set-Cookie that ends in token
+   * characters after a comma with no '='.  A watchdog alarm bounds the test
+   * in case the scan fails to terminate; the value assertions catch the
+   * mis-parse the run-away scan produced. */
+  alarm(30);
+  cookies = [NSHTTPCookie cookiesWithResponseHeaderFields: headers forURL: url];
+  alarm(0);
+
+  PASS([cookies count] == 1,
+    "a comma not followed by a name=value pair is not a cookie separator")
+  cookie = [cookies count] ? [cookies objectAtIndex: 0] : nil;
+  PASS_EQUAL([cookie name], @"a", "the single cookie is parsed correctly")
+  LEAVE_POOL
+  END_SET("NSHTTPCookie Set-Cookie comma scan terminates")
+  return 0;
+}
+#else
+int main()
+{
+  START_SET("NSHTTPCookie Set-Cookie comma scan terminates")
+  SKIP("test needs alarm() as a watchdog")
+  END_SET("NSHTTPCookie Set-Cookie comma scan terminates")
+  return 0;
+}
+#endif
+#else
+int main(void)
+{
+  return 0;
+}
+#endif


### PR DESCRIPTION
## Summary

`GSCookieStrings` splits a `Set-Cookie` header value into individual cookie strings on commas. Because a comma can legitimately appear inside a value (e.g. in an `Expires` date), it looks ahead past each comma for a `' token ='` shape that would indicate a *new* cookie. The loop that skips the token characters tests only the character value, not the buffer position:

```c
int c = ptr[pos];
while (c > 32 && c < 128 && strchr(bad, c) == 0)
  {
    pos++;
    if (pos < end) { c = ptr[pos]; }   /* c is NOT updated once pos >= end */
  }
```

Once `pos` reaches `end`, the guarded read stops updating `c`, but `c` is still a token character, so the loop condition never becomes false and `pos` keeps incrementing until it wraps — roughly 2³² iterations — for a `Set-Cookie` value that ends in token characters after a comma with no `=` (e.g. `a=b, cd`). The `if (pos < end)` guard prevents an out-of-bounds read, so this is a CPU/run-away-loop hang, reachable from an untrusted server response header via `+[NSHTTPCookie cookiesWithResponseHeaderFields:forURL:]`.

The fix adds `pos < end` to the loop condition.

## Validation (Ubuntu 24.04, clang 18, libobjc2)

- Reproduced directly: `+[NSHTTPCookie cookiesWithResponseHeaderFields:forURL:]` with `Set-Cookie: a=b, cd` returns immediately when patched and spins (no return within 25s) when unpatched.
- Regression test (in-tree `gnustep-tests`, with a watchdog `alarm`): patched **2/2 pass** — the malformed value is parsed as a single cookie (`a`) without the run-away scan; against the unpatched lib the test aborts when the watchdog fires.

A new regression test is added at `Tests/base/NSHTTPCookie/comma-loop.m`.
