### PR TITLE
NSDecimalCompare: ignore trailing zeros in the mantissa

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2026-07-03 Todd White <todd.white@thalion.global>
+
+	* Source/NSDecimal.m (GSDecimalCompare):
+	Treat trailing zeros in a mantissa as insignificant, so that two equal
+	values of different mantissa length (as produced by NSDecimalNormalize)
+	compare as NSOrderedSame rather than by length.
+	* Tests/base/NSDecimalNumber/compare_trailing_zeros.m: New test.
+
 2026-07-01 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Source/NSProxy.m:

--- a/Source/NSDecimal.m
+++ b/Source/NSDecimal.m
@@ -242,21 +242,25 @@ GSDecimalCompare(const GSDecimal *leftOperand, const GSDecimal *rightOperand)
 	}
     }
 
-  // Same digits, check length
+  // Same leading digits: the longer mantissa is larger in magnitude unless
+  // its extra (least significant) digits are all zeros, so that trailing
+  // zeros do not affect the comparison.
   if (leftOperand->length > rightOperand->length)
     {
-      if (rightOperand->isNegative)
-	return NSOrderedAscending;
-      else
-	return NSOrderedDescending;
+      for (i = l; i < leftOperand->length; i++)
+	if (leftOperand->cMantissa[i] != 0)
+	  return rightOperand->isNegative
+	    ? NSOrderedAscending : NSOrderedDescending;
+      return NSOrderedSame;
     }
 
   if (leftOperand->length < rightOperand->length)
     {
-      if (rightOperand->isNegative)
-	return NSOrderedDescending;
-      else
-	return NSOrderedAscending;
+      for (i = l; i < rightOperand->length; i++)
+	if (rightOperand->cMantissa[i] != 0)
+	  return rightOperand->isNegative
+	    ? NSOrderedDescending : NSOrderedAscending;
+      return NSOrderedSame;
     }
 
   return NSOrderedSame;

--- a/Tests/base/NSDecimalNumber/compare_trailing_zeros.m
+++ b/Tests/base/NSDecimalNumber/compare_trailing_zeros.m
@@ -1,0 +1,71 @@
+/*
+ * compare_trailing_zeros.m - regression test for NSDecimalCompare treating a
+ * mantissa that carries trailing zeros as a different value from the same
+ * number without them.
+ *
+ * NSDecimalNormalize aligns the exponents of two decimals, appending trailing
+ * zeros to the mantissa of the operand with the larger exponent (1.5 becomes
+ * 1.50 when normalized against 2.05).  GSDecimalCompare broke the tie between
+ * two values with equal leading digits purely on mantissa length, so the
+ * normalized 1.50 compared as greater than 1.5 although they are equal.  A
+ * trailing zero is not significant, so the two must compare NSOrderedSame.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Foundation/NSDecimal.h>
+#import "ObjectTesting.h"
+
+static NSDecimal
+dfs(const char *s)
+{
+  NSDecimal d;
+
+  NSDecimalFromString(&d, [NSString stringWithUTF8String: s], nil);
+  return d;
+}
+
+/* Return "value" carrying trailing zeros, by normalizing it against a value
+ * with a smaller exponent (which pads "value" without changing it). */
+static NSDecimal
+padded(const char *value, const char *other)
+{
+  NSDecimal a = dfs(value);
+  NSDecimal b = dfs(other);
+
+  NSDecimalNormalize(&a, &b, NSRoundPlain);
+  return a;
+}
+
+int main(void)
+{
+  START_SET("NSDecimalCompare ignores trailing zeros")
+    NSDecimal	p, q, a, b;
+
+    /* 1.5 normalized against 2.05 becomes 1.50 (mantissa 150, exponent -2). */
+    p = padded("1.5", "2.05");
+    a = dfs("1.5");
+    PASS(NSDecimalCompare(&p, &a) == NSOrderedSame,
+      "1.50 (padded) compares equal to 1.5");
+    PASS(NSDecimalCompare(&a, &p) == NSOrderedSame,
+      "1.5 compares equal to 1.50 (padded)");
+
+    /* Same for negative values. */
+    q = padded("-1.5", "-2.05");
+    b = dfs("-1.5");
+    PASS(NSDecimalCompare(&q, &b) == NSOrderedSame,
+      "-1.50 (padded) compares equal to -1.5");
+
+    /* Positive controls: a genuine trailing digit still orders correctly. */
+    a = dfs("1.53"); b = dfs("1.5");
+    PASS(NSDecimalCompare(&a, &b) == NSOrderedDescending,
+      "1.53 is still greater than 1.5");
+    a = dfs("2"); b = dfs("1");
+    PASS(NSDecimalCompare(&a, &b) == NSOrderedDescending,
+      "2 is still greater than 1");
+    a = dfs("1.5"); b = dfs("1.5");
+    PASS(NSDecimalCompare(&a, &b) == NSOrderedSame,
+      "1.5 compares equal to itself");
+  END_SET("NSDecimalCompare ignores trailing zeros")
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

`NSDecimalCompare` can report two equal values as unequal when one carries trailing zeros in its mantissa.

`GSDecimalCompare` breaks the tie between two operands with the same sign, the same magnitude (`exponent + length`), and the same leading digits purely on **mantissa length** — without checking whether the longer operand's extra digits are trailing zeros. So the longer-but-equal value is treated as larger.

This is reachable from the public API. `NSDecimalNormalize` aligns two decimals' exponents by appending trailing zeros to the operand with the larger exponent (`1.5` becomes `1.50` when normalized against `2.05`). After that:

```
NSDecimalCompare(1.50, 1.5)   -> NSOrderedDescending   (should be NSOrderedSame)
NSDecimalCompare(1.5, 1.50)   -> NSOrderedAscending    (should be NSOrderedSame)
NSDecimalCompare(-1.50, -1.5) -> NSOrderedAscending    (should be NSOrderedSame)
```

The bug is masked whenever both operands are compacted (which is why comparisons of, say, `NSDecimalFromString(@"1.0")` and `@"1.00")` work — the parser compacts away the trailing zeros).

## Fix

When the leading digits match and the lengths differ, scan the extra (least significant) digits of the longer mantissa: the values differ only if one of those digits is non-zero; otherwise they are equal. A genuine trailing digit (e.g. `1.53` vs `1.5`) still orders correctly.

## Test

`Tests/base/NSDecimalNumber/compare_trailing_zeros.m` builds the trailing-zero operand via `NSDecimalNormalize` (the reachable trigger) and checks the equal comparisons, plus positive controls that real ordering is preserved. It fails before this change and passes after; the existing `mantissa_overflow` and `string` tests in the same directory are unaffected.

```
$ gnustep-tests base/NSDecimalNumber/compare_trailing_zeros.m
     6 Passed tests
All OK!
```
