### PR TITLE
Add NSUUID string/byte layout tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 2026-07-03 Todd White <todd.white@thalion.global>
 
+	* Tests/base/NSUUID/format.m:
+	Add tests for the NSUUID string/byte layout: that a UUID string parses
+	to the expected bytes in order and back, that parsing accepts lower
+	case and produces upper case and rejects malformed strings, and that
+	+UUID yields distinct, well-formed values.
+
+2026-07-03 Todd White <todd.white@thalion.global>
+
 	* Tests/base/NSDateInterval/basic.m:
 	* Tests/base/NSDateInterval/TestInfo:
 	Add tests for NSDateInterval: construction (including the negative

--- a/Tests/base/NSUUID/format.m
+++ b/Tests/base/NSUUID/format.m
@@ -1,0 +1,67 @@
+/*
+ * format.m - tests for NSUUID string/byte layout that basic.m does not cover:
+ * that a UUID string parses to the expected bytes in order (and back), that
+ * parsing accepts lower case and produces upper case, rejects malformed
+ * strings, and that +UUID yields distinct, well-formed values.
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+int main(void)
+{
+  START_SET("NSUUID string and byte layout")
+    NSString		*str = @"E621E1F8-C36C-495A-93FC-0C247A3E6E5F";
+    unsigned char	expected[16] = {
+      0xE6, 0x21, 0xE1, 0xF8, 0xC3, 0x6C, 0x49, 0x5A,
+      0x93, 0xFC, 0x0C, 0x24, 0x7A, 0x3E, 0x6E, 0x5F };
+    unsigned char	bytes[16];
+    NSUUID		*u;
+    int			i;
+    BOOL		ok = YES;
+
+    u = [[[NSUUID alloc] initWithUUIDString: str] autorelease];
+    [u getUUIDBytes: bytes];
+    for (i = 0; i < 16; i++)
+      if (bytes[i] != expected[i])
+	ok = NO;
+    PASS(ok, "initWithUUIDString maps the hex pairs to bytes in order");
+
+    u = [[[NSUUID alloc] initWithUUIDBytes: expected] autorelease];
+    PASS_EQUAL([u UUIDString], str,
+      "initWithUUIDBytes formats the bytes back to the same string");
+  END_SET("NSUUID string and byte layout")
+
+  START_SET("NSUUID string parsing")
+    NSString	*upper = @"E621E1F8-C36C-495A-93FC-0C247A3E6E5F";
+    NSUUID	*u;
+
+    u = [[[NSUUID alloc] initWithUUIDString:
+      @"e621e1f8-c36c-495a-93fc-0c247a3e6e5f"] autorelease];
+    PASS_EQUAL([u UUIDString], upper,
+      "initWithUUIDString accepts lower case and formats upper case");
+
+    PASS([[NSUUID alloc] initWithUUIDString: @""] == nil,
+      "an empty string is rejected");
+    PASS([[NSUUID alloc] initWithUUIDString:
+      @"E621E1F8-C36C-495A-93FC-0C247A3E6E5"] == nil,
+      "a too-short string is rejected");
+    PASS([[NSUUID alloc] initWithUUIDString:
+      @"E621E1F8-C36C-495A-93FC-0C247A3E6E5G"] == nil,
+      "a string with a non-hex digit is rejected");
+  END_SET("NSUUID string parsing")
+
+  START_SET("NSUUID generation and format")
+    NSUUID	*a = [NSUUID UUID];
+    NSUUID	*b = [NSUUID UUID];
+    NSString	*s = [a UUIDString];
+
+    PASS(![a isEqual: b], "two generated UUIDs are distinct");
+    PASS([s length] == 36, "a UUID string is 36 characters long");
+    PASS([s characterAtIndex: 8] == '-' && [s characterAtIndex: 13] == '-'
+      && [s characterAtIndex: 18] == '-' && [s characterAtIndex: 23] == '-',
+      "the UUID string is hyphenated as 8-4-4-4-12");
+  END_SET("NSUUID generation and format")
+
+  return 0;
+}


### PR DESCRIPTION
This adds coverage for `NSUUID` string/byte layout that the existing `basic.m` doesn't check. `basic.m` verifies string→string and bytes→bytes round-trips independently; this adds the correspondence between them (where byte-order bugs hide) plus case and format checks.

`Tests/base/NSUUID/format.m` covers:

- **String ↔ byte layout** — `initWithUUIDString:` of a known UUID produces the expected 16 bytes **in order**, and `initWithUUIDBytes:` of those bytes formats back to the same string
- **Parsing** — accepts lower case and produces upper case; rejects the empty string, a too-short string, and a string with a non-hex digit
- **Generation & format** — two `+UUID` values are distinct; a UUID string is 36 chars and hyphenated as 8-4-4-4-12

Test-only (no source changes), deterministic.

9 assertions, all passing:

```
$ gnustep-tests base/NSUUID/format.m
     9 Passed tests
All OK!
```
