### PR TITLE
NSMutableOrderedSet: fix moveObjectsAtIndexes:toIndex:

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 2026-07-03 Todd White <todd.white@thalion.global>
 
+	* Source/NSOrderedSet.m (-[NSMutableOrderedSet
+	moveObjectsAtIndexes:toIndex:]): Build the moved objects in index order,
+	remove them highest index first so the earlier indexes stay valid, and
+	reinsert them at an increasing target index.
+	* Tests/base/NSOrderedSet/moveObjects.m: New test.
+
+2026-07-03 Todd White <todd.white@thalion.global>
+
 	* Tests/base/NSDateInterval/basic.m:
 	* Tests/base/NSDateInterval/TestInfo:
 	Add tests for NSDateInterval: construction (including the negative

--- a/Source/NSOrderedSet.m
+++ b/Source/NSOrderedSet.m
@@ -1551,25 +1551,23 @@ static SEL	remSel;
          inIndexRange: NULL];
 
   // Build the temporary array....
-  while (i-- > 0)
+  for (i = 0; i < count; i++)
     {
-      NSUInteger index = indexArray[i];
-      id obj = [self objectAtIndex: index];
-      [tmpArray addObject: obj];
+      [tmpArray addObject: [self objectAtIndex: indexArray[i]]];
     }
 
   // Remove the originals...
-  for (i = 0; i < count; i++)
+  i = count;
+  while (i-- > 0)
     {
-      NSUInteger index = indexArray[i];
-      [self removeObjectAtIndex: index];
+      [self removeObjectAtIndex: indexArray[i]];
     }
 
   // Move the objects
   e = [tmpArray objectEnumerator];
   while ((o = [e nextObject]) != nil)
     {
-      [self insertObject: o atIndex: index];
+      [self insertObject: o atIndex: index++];
     }
 }
 

--- a/Tests/base/NSOrderedSet/moveObjects.m
+++ b/Tests/base/NSOrderedSet/moveObjects.m
@@ -1,0 +1,39 @@
+/*
+ * moveObjects.m - regression test for -[NSMutableOrderedSet
+ * moveObjectsAtIndexes:toIndex:], which removed the moved objects in ascending
+ * index order (so each removal shifted the later indexes) and reinserted them
+ * reversed, dropping and reordering objects.
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+#define OS(...)  [NSOrderedSet orderedSetWithObjects: __VA_ARGS__, nil]
+#define MOS(...) [NSMutableOrderedSet orderedSetWithObjects: __VA_ARGS__, nil]
+
+int main(void)
+{
+  START_SET("NSMutableOrderedSet moveObjectsAtIndexes:toIndex:")
+    NSMutableOrderedSet	*m;
+
+    m = MOS(@"a", @"b", @"c", @"d");
+    [m moveObjectsAtIndexes: [NSIndexSet indexSetWithIndexesInRange:
+      NSMakeRange(1, 2)] toIndex: 0];
+    PASS([m count] == 4, "no object is lost when moving a range");
+    PASS([m isEqualToOrderedSet: OS(@"b", @"c", @"a", @"d")],
+      "moving a range to the front places the objects there in order");
+
+    m = MOS(@"a", @"b", @"c", @"d", @"e");
+    [m moveObjectsAtIndexes: [NSIndexSet indexSetWithIndexesInRange:
+      NSMakeRange(0, 2)] toIndex: 3];
+    PASS([m isEqualToOrderedSet: OS(@"c", @"d", @"e", @"a", @"b")],
+      "the target index is relative to the set after the objects are removed");
+
+    m = MOS(@"a", @"b", @"c", @"d");
+    [m moveObjectsAtIndexes: [NSIndexSet indexSetWithIndex: 0] toIndex: 2];
+    PASS([m isEqualToOrderedSet: OS(@"b", @"c", @"a", @"d")],
+      "moving a single object");
+  END_SET("NSMutableOrderedSet moveObjectsAtIndexes:toIndex:")
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

`-[NSMutableOrderedSet moveObjectsAtIndexes:toIndex:]` removed the moved objects in **ascending** index order:

```objc
for (i = 0; i < count; i++)
  [self removeObjectAtIndex: indexArray[i]];
```

Each removal shifts the remaining indexes down, so after removing the first index the later `indexArray[i]` values point at the wrong objects. It also built the temporary array in reverse. Moving a range therefore dropped and reordered objects — e.g. moving `{1,2}` of `[a, b, c, d]` to index 0 produced `(b, a, c)` (an object lost) instead of `(b, c, a, d)`.

## Fix

Build the temporary array in index order, remove the originals **highest index first** so the earlier indexes stay valid, and reinsert them at an increasing target index.

## Test

`Tests/base/NSOrderedSet/moveObjects.m` checks moving a range to the front, moving with a post-removal target index, and moving a single object. It fails before this change and passes after.
