### PR TITLE
NSMutableOrderedSet: fix intersect enumeration crash

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 2026-07-03 Todd White <todd.white@thalion.global>
 
+	* Source/NSOrderedSet.m (-[NSMutableOrderedSet intersectOrderedSet:],
+	-[NSMutableOrderedSet intersectSet:]): Enumerate a snapshot of the
+	receiver's contents rather than removing objects while enumerating the
+	receiver itself.
+	* Tests/base/NSOrderedSet/intersect.m: New test.
+
+2026-07-03 Todd White <todd.white@thalion.global>
+
 	* Tests/base/NSDateInterval/basic.m:
 	* Tests/base/NSDateInterval/TestInfo:
 	Add tests for NSDateInterval: construction (including the negative

--- a/Source/NSOrderedSet.m
+++ b/Source/NSOrderedSet.m
@@ -1695,7 +1695,7 @@ static SEL	remSel;
 {
   if (other != self)
     {
-      id keys = [self objectEnumerator];
+      id keys = [[self array] objectEnumerator];
       id key;
 
       while ((key = [keys nextObject]))
@@ -1710,7 +1710,7 @@ static SEL	remSel;
 
 - (void) intersectSet: (NSSet *)other
 {
-  id keys = [self objectEnumerator];
+  id keys = [[self array] objectEnumerator];
   id key;
 
   while ((key = [keys nextObject]))

--- a/Tests/base/NSOrderedSet/intersect.m
+++ b/Tests/base/NSOrderedSet/intersect.m
@@ -1,0 +1,30 @@
+/*
+ * intersect.m - regression test for -[NSMutableOrderedSet intersectOrderedSet:]
+ * and -[NSMutableOrderedSet intersectSet:], which enumerated the receiver while
+ * removing objects from it, tripping an internal bounds assertion.
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+#define OS(...)  [NSOrderedSet orderedSetWithObjects: __VA_ARGS__, nil]
+#define MOS(...) [NSMutableOrderedSet orderedSetWithObjects: __VA_ARGS__, nil]
+
+int main(void)
+{
+  START_SET("NSMutableOrderedSet intersect")
+    NSMutableOrderedSet	*m;
+
+    m = MOS(@"a", @"b", @"c", @"d");
+    [m intersectOrderedSet: OS(@"b", @"c", @"x")];
+    PASS([m isEqualToOrderedSet: OS(@"b", @"c")],
+      "intersectOrderedSet: keeps only the shared objects, in order");
+
+    m = MOS(@"a", @"b", @"c", @"d");
+    [m intersectSet: [NSSet setWithObjects: @"b", @"c", @"x", nil]];
+    PASS([m isEqualToOrderedSet: OS(@"b", @"c")],
+      "intersectSet: keeps only the shared objects, in order");
+  END_SET("NSMutableOrderedSet intersect")
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

`-[NSMutableOrderedSet intersectOrderedSet:]` and `-[NSMutableOrderedSet intersectSet:]` enumerate the receiver and remove objects from it inside the loop:

```objc
id keys = [self objectEnumerator];
id key;
while ((key = [keys nextObject]))
  {
    if ([other containsObject: key] == NO)
      [self removeObject: key];
  }
```

Mutating the ordered set while enumerating it desynchronises the enumerator from the underlying storage and trips an internal `GSIArray` bounds assertion (`NSInvalidArgumentException`) once a removed element shifts the indexes.

## Fix

Enumerate a snapshot of the receiver's contents (`[self array]`) so the removals don't disturb the enumeration.

## Test

`Tests/base/NSOrderedSet/intersect.m` exercises both methods (dropping the objects not in the other collection). It fails before this change (the assertion aborts the set) and passes after.
