### PR TITLE
Add NSIndexPath getIndexes and compare tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 2026-07-03 Todd White <todd.white@thalion.global>
 
+	* Tests/base/NSIndexPath/compare_getindexes.m:
+	Add tests for getIndexes:, equal-path isEqual: and hash, and the equal
+	and element-difference cases of compare:.
+
+2026-07-03 Todd White <todd.white@thalion.global>
+
 	* Tests/base/NSDateInterval/basic.m:
 	* Tests/base/NSDateInterval/TestInfo:
 	Add tests for NSDateInterval: construction (including the negative

--- a/Tests/base/NSIndexPath/compare_getindexes.m
+++ b/Tests/base/NSIndexPath/compare_getindexes.m
@@ -1,0 +1,50 @@
+/*
+ * compare_getindexes.m - tests for NSIndexPath behaviour general.m does not
+ * cover: getIndexes:, the equal and prefix cases of compare:, and equal-path
+ * isEqual: / hash.
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+static NSIndexPath *
+path(NSUInteger a, NSUInteger b, NSUInteger c, NSUInteger len)
+{
+  NSUInteger	idx[3];
+
+  idx[0] = a; idx[1] = b; idx[2] = c;
+  return [NSIndexPath indexPathWithIndexes: idx length: len];
+}
+
+int main(void)
+{
+  START_SET("NSIndexPath getIndexes and equality")
+    NSIndexPath	*p = path(2, 5, 9, 3);
+    NSUInteger	buf[3];
+
+    PASS([p length] == 3, "length is the number of indexes");
+    [p getIndexes: buf];
+    PASS(buf[0] == 2 && buf[1] == 5 && buf[2] == 9,
+      "getIndexes: fills the buffer with every index in order");
+
+    PASS([p isEqual: path(2, 5, 9, 3)] == YES,
+      "index paths with the same indexes are equal");
+    PASS([p hash] == [path(2, 5, 9, 3) hash],
+      "equal index paths have equal hashes");
+    PASS([p isEqual: path(2, 5, 8, 3)] == NO,
+      "index paths with different indexes are not equal");
+  END_SET("NSIndexPath getIndexes and equality")
+
+  START_SET("NSIndexPath compare:")
+    NSIndexPath	*p = path(1, 9, 0, 2);	/* [1, 9] */
+
+    PASS([p compare: path(1, 9, 0, 2)] == NSOrderedSame,
+      "equal index paths compare the same");
+    PASS([p compare: path(1, 2, 0, 2)] == NSOrderedDescending,
+      "a larger index at a position orders later");
+    PASS([p compare: path(2, 0, 0, 2)] == NSOrderedAscending,
+      "a smaller index at the first position orders earlier");
+  END_SET("NSIndexPath compare:")
+
+  return 0;
+}


### PR DESCRIPTION
This adds `NSIndexPath` coverage that `general.m` doesn't have:

- **`getIndexes:`** — fills the buffer with every index in order
- **Equality** — index paths with the same indexes are equal and hash equally; different indexes are not equal
- **`compare:`** — the equal case (`NSOrderedSame`) and element-difference cases

Test-only (no source changes), deterministic. 8 assertions, all passing.

Note: I left out the prefix case of `compare:` (a path that is a prefix of a longer one) — `NSIndexPath compare:` currently orders it backwards, which I'll fix separately so this stays test-only.
