### PR TITLE
NSIndexPath: fix compare: ordering of a path and its prefix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 2026-07-03 Todd White <todd.white@thalion.global>
 
+	* Source/NSIndexPath.m (-[NSIndexPath compare:]): Order a shorter path
+	that is a prefix of the other before the longer path, not after.
+	* Tests/base/NSIndexPath/compare_prefix.m: New test.
+
+2026-07-03 Todd White <todd.white@thalion.global>
+
 	* Tests/base/NSDateInterval/basic.m:
 	* Tests/base/NSDateInterval/TestInfo:
 	Add tests for NSDateInterval: construction (including the negative

--- a/Source/NSIndexPath.m
+++ b/Source/NSIndexPath.m
@@ -112,11 +112,11 @@ static	NSIndexPath	*dummy = nil;
 	{
 	  if (pos >= _length)
 	    {
-	      return NSOrderedDescending;
+	      return NSOrderedAscending;
 	    }
 	  else if (pos >= olength)
 	    {
-	      return NSOrderedAscending;
+	      return NSOrderedDescending;
 	    }
 	  if (oindexes[pos] < _indexes[pos])
 	    {

--- a/Tests/base/NSIndexPath/compare_prefix.m
+++ b/Tests/base/NSIndexPath/compare_prefix.m
@@ -1,0 +1,34 @@
+/*
+ * compare_prefix.m - regression test for -[NSIndexPath compare:] ordering a
+ * path and its own prefix.  The length branches were inverted, so a prefix
+ * (shorter) path compared as ordered after the longer path instead of before.
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+static NSIndexPath *
+path2(NSUInteger a, NSUInteger b, NSUInteger len)
+{
+  NSUInteger	idx[2];
+
+  idx[0] = a; idx[1] = b;
+  return [NSIndexPath indexPathWithIndexes: idx length: len];
+}
+
+int main(void)
+{
+  START_SET("NSIndexPath compare: prefix ordering")
+    NSIndexPath	*shorter = path2(1, 0, 1);	/* [1]    */
+    NSIndexPath	*longer  = path2(1, 9, 2);	/* [1, 9] */
+
+    PASS([shorter compare: longer] == NSOrderedAscending,
+      "a prefix index path sorts before the longer path");
+    PASS([longer compare: shorter] == NSOrderedDescending,
+      "the longer path sorts after its prefix");
+    PASS([longer compare: path2(1, 9, 2)] == NSOrderedSame,
+      "equal-length equal paths still compare the same");
+  END_SET("NSIndexPath compare: prefix ordering")
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

When one index path is a prefix of the other, `-[NSIndexPath compare:]` returns the wrong order. The length branches are inverted:

```objc
if (pos >= _length)
  return NSOrderedDescending;   // receiver ran out first (it is the prefix)
else if (pos >= olength)
  return NSOrderedAscending;    // other ran out first
```

The receiver running out of indexes means it is the shorter, prefix path and should sort **before** the longer one, but it returns `NSOrderedDescending`. So `[1] compare: [1, 9]` returns `NSOrderedDescending` instead of `NSOrderedAscending` (and the reverse is likewise wrong). `general.m` didn't catch this because its comparisons always differ at position 0.

## Fix

Swap the two results so a prefix (shorter) path is ordered first.

## Test

`Tests/base/NSIndexPath/compare_prefix.m` compares a path against its own prefix both ways (plus an equal control). It fails before this change and passes after.
