### PR TITLE
Add NSValueTransformer registry tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 2026-07-03 Todd White <todd.white@thalion.global>
 
+	* Tests/base/NSValueTransformer/registry.m:
+	Add tests for the NSValueTransformer name registry
+	(setValueTransformer:forName:, valueTransformerForName:,
+	valueTransformerNames), the allowsReverseTransformation metadata, and
+	that reverseTransformedValue: on a non-reversible transformer raises.
+
+2026-07-03 Todd White <todd.white@thalion.global>
+
 	* Tests/base/NSDateInterval/basic.m:
 	* Tests/base/NSDateInterval/TestInfo:
 	Add tests for NSDateInterval: construction (including the negative

--- a/Tests/base/NSValueTransformer/registry.m
+++ b/Tests/base/NSValueTransformer/registry.m
@@ -1,0 +1,45 @@
+/*
+ * registry.m - tests for NSValueTransformer behaviour basic.m does not cover:
+ * the name registry (setValueTransformer:forName:, valueTransformerForName:,
+ * valueTransformerNames), the allowsReverseTransformation metadata, and that
+ * reverseTransformedValue: on a non-reversible transformer raises.
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+int main(void)
+{
+  START_SET("NSValueTransformer registry")
+    NSValueTransformer	*neg = [NSValueTransformer valueTransformerForName:
+      NSNegateBooleanTransformerName];
+
+    PASS([NSValueTransformer valueTransformerForName: @"NoSuchTransformer"] == nil,
+      "valueTransformerForName: of an unknown name is nil");
+
+    [NSValueTransformer setValueTransformer: neg forName: @"MyNegate"];
+    PASS([NSValueTransformer valueTransformerForName: @"MyNegate"] == neg,
+      "a registered transformer is returned by valueTransformerForName:");
+    PASS([[NSValueTransformer valueTransformerNames]
+      containsObject: @"MyNegate"] == YES,
+      "valueTransformerNames lists a registered name");
+  END_SET("NSValueTransformer registry")
+
+  START_SET("NSValueTransformer reverse metadata")
+    NSValueTransformer	*neg = [NSValueTransformer valueTransformerForName:
+      NSNegateBooleanTransformerName];
+    NSValueTransformer	*isNil = [NSValueTransformer valueTransformerForName:
+      NSIsNilTransformerName];
+
+    PASS([[neg class] allowsReverseTransformation] == YES,
+      "NSNegateBoolean allows reverse transformation");
+    PASS([[isNil class] allowsReverseTransformation] == NO,
+      "NSIsNil does not allow reverse transformation");
+
+    PASS_EXCEPTION(({ [isNil reverseTransformedValue: @""]; }),
+      NSGenericException,
+      "reverseTransformedValue: on a non-reversible transformer raises");
+  END_SET("NSValueTransformer reverse metadata")
+
+  return 0;
+}


### PR DESCRIPTION
This adds `NSValueTransformer` coverage that `basic.m` (which tests the built-in transforms) doesn't have:

- **Name registry** — `valueTransformerForName:` of an unknown name is nil; `setValueTransformer:forName:` registers a transformer that `valueTransformerForName:` then returns and `valueTransformerNames` lists
- **Reverse metadata** — `allowsReverseTransformation` is `YES` for `NSNegateBoolean` and `NO` for `NSIsNil`
- **Reverse of a non-reversible transformer** — `-reverseTransformedValue:` raises `NSGenericException`

Test-only (no source changes), deterministic. 6 assertions, all passing.
