### PR TITLE
NSPointerArray: fix compact dropping objects before the first nil

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 2026-07-03 Todd White <todd.white@thalion.global>
 
+	* Source/NSPointerArray.m (-[NSConcretePointerArray compact]): Advance
+	the insertion point for every non-nil pointer and clear the trailing
+	slots, so that non-nil pointers before the first nil are not lost.
+	* Tests/base/NSPointerArray/compact.m: New test.
+
+2026-07-03 Todd White <todd.white@thalion.global>
+
 	* Tests/base/NSDateInterval/basic.m:
 	* Tests/base/NSDateInterval/TestInfo:
 	Add tests for NSDateInterval: construction (including the negative

--- a/Source/NSPointerArray.m
+++ b/Source/NSPointerArray.m
@@ -318,15 +318,22 @@ static Class	concreteClass = Nil;
     {
       id obj = pointerFunctionsRead(&_pf, &_contents[i]);
 
-      /* If this object is not nil, but at least one before it has been, then
-       * move it back to the correct location.
+      /* Move each non-nil pointer back over any preceding nil slots, and
+       * advance the insertion point for every non-nil pointer.
        */
-      if (nil != obj && i != insert)
+      if (nil != obj)
         {
-          pointerFunctionsAssign(&_pf, &_contents[insert++], obj);
+          if (i != insert)
+            {
+              pointerFunctionsAssign(&_pf, &_contents[insert], obj);
+            }
+          insert++;
         }
     }
-  _count = insert;
+  while (_count > insert)
+    {
+      _contents[--_count] = NULL;
+    }
   _version++;
 }
 

--- a/Tests/base/NSPointerArray/compact.m
+++ b/Tests/base/NSPointerArray/compact.m
@@ -1,0 +1,51 @@
+/*
+ * compact.m - regression test for -[NSPointerArray compact].  The insertion
+ * point was only advanced when a pointer was actually moved, so the non-nil
+ * pointers before the first nil were overwritten and lost (compacting
+ * [a, nil, b] produced [b]).
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+static id
+at(NSPointerArray *p, NSUInteger i)
+{
+  return (id)[p pointerAtIndex: i];
+}
+
+int main(void)
+{
+  START_SET("NSPointerArray compact")
+    NSPointerArray	*p;
+
+    p = [NSPointerArray strongObjectsPointerArray];
+    [p addPointer: (void *)@"a"];
+    [p addPointer: NULL];
+    [p addPointer: (void *)@"b"];
+    [p compact];
+    PASS([p count] == 2, "compact removes an interior NULL without losing objects");
+    PASS([at(p, 0) isEqual: @"a"] && [at(p, 1) isEqual: @"b"],
+      "compact keeps the non-NULL pointers in order");
+
+    p = [NSPointerArray strongObjectsPointerArray];
+    [p addPointer: NULL];
+    [p addPointer: (void *)@"a"];
+    [p addPointer: NULL];
+    [p addPointer: (void *)@"b"];
+    [p addPointer: NULL];
+    [p compact];
+    PASS([p count] == 2 && [at(p, 0) isEqual: @"a"] && [at(p, 1) isEqual: @"b"],
+      "compact removes leading, interior and trailing NULLs");
+
+    p = [NSPointerArray strongObjectsPointerArray];
+    [p addPointer: (void *)@"a"];
+    [p addPointer: (void *)@"b"];
+    [p addPointer: (void *)@"c"];
+    [p compact];
+    PASS([p count] == 3 && [at(p, 0) isEqual: @"a"] && [at(p, 2) isEqual: @"c"],
+      "compact leaves a NULL-free array unchanged");
+  END_SET("NSPointerArray compact")
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

`-[NSConcretePointerArray compact]` only advanced the insertion index when it actually moved a pointer:

```objc
if (nil != obj && i != insert)
  {
    pointerFunctionsAssign(&_pf, &_contents[insert++], obj);
  }
```

For every non-nil pointer that was already in the right place (`i == insert`), `insert` was **not** advanced. So once a nil was skipped, the following non-nil pointers were written back starting at index 0, overwriting the ones before the first nil. Compacting `[a, nil, b]` produced `[b]` — losing `a` — and even a nil-free array lost its first element. It also never cleared the now-stale trailing slots.

## Fix

Advance `insert` for every non-nil pointer (moving it back only when needed), and clear the trailing slots afterwards — the same move-then-clear pattern `removePointerAtIndex:` already uses.

## Test

`Tests/base/NSPointerArray/compact.m` compacts arrays with interior, leading and trailing nils, and a nil-free array. It fails before this change and passes after; it is also clean under AddressSanitizer with leak detection.
