### PR TITLE
NSCache: do not discard content when no count limit is set

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 2026-07-03 Todd White <todd.white@thalion.global>
 
+	* Source/NSCache.m (-_evictObjectsToMakeSpaceForObjectWithCost:):
+	Only apply the count limit when one has been set.  A count limit of 0
+	means "no limit", but the eviction test triggered on count >= 0 for
+	every insert, so an otherwise unbounded cache discarded the content of
+	the discardable objects it held.  Guard the count check with
+	_countLimit > 0, matching the existing _costLimit > 0 guard.
+	* Tests/base/NSCache/nolimit.m: New test.
 	* Tests/base/NSDateInterval/basic.m:
 	* Tests/base/NSDateInterval/TestInfo:
 	Add tests for NSDateInterval: construction (including the negative

--- a/Source/NSCache.m
+++ b/Source/NSCache.m
@@ -234,7 +234,8 @@
     }
 
   // Only evict if we need the space.
-  if (count > 0 && (spaceNeeded > 0 || count >= _countLimit))
+  if (count > 0
+    && (spaceNeeded > 0 || (_countLimit > 0 && count >= _countLimit)))
     {
       NSMutableArray *evictedKeys = nil;
       // Round up slightly.

--- a/Tests/base/NSCache/nolimit.m
+++ b/Tests/base/NSCache/nolimit.m
@@ -1,0 +1,49 @@
+#import "ObjectTesting.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSCache.h>
+
+/* NSDiscardableContent object that records whether the cache asked it to
+ * discard its content.
+ */
+@interface DiscardableObject : NSObject <NSDiscardableContent>
+{
+  @public
+  BOOL	discarded;
+}
+@end
+
+@implementation DiscardableObject
+- (BOOL) beginContentAccess { return YES; }
+- (void) endContentAccess {}
+- (void) discardContentIfPossible { discarded = YES; }
+- (BOOL) isContentDiscarded { return discarded; }
+@end
+
+int main()
+{
+  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
+  NSCache		*cache = [[NSCache new] autorelease];
+  DiscardableObject	*a = [[DiscardableObject new] autorelease];
+  DiscardableObject	*b = [[DiscardableObject new] autorelease];
+  DiscardableObject	*c = [[DiscardableObject new] autorelease];
+
+  /* A cache with neither a count limit nor a cost limit is unbounded
+   * (both limits default to 0, which means "no limit"), so it must never
+   * discard the content of the objects it holds, even discardable ones.
+   */
+  [cache setObject: a forKey: @"a"];
+  [cache setObject: b forKey: @"b"];
+  [cache setObject: c forKey: @"c"];
+
+  PASS(NO == [a isContentDiscarded],
+    "an unbounded cache does not discard content on insert");
+  PASS(NO == [b isContentDiscarded],
+    "an unbounded cache leaves later objects' content intact");
+  PASS_EQUAL(a, [cache objectForKey: @"a"],
+    "the first object is still cached in an unbounded cache");
+  PASS_EQUAL(c, [cache objectForKey: @"c"],
+    "the last object is still cached in an unbounded cache");
+
+  [arp release]; arp = nil;
+  return 0;
+}


### PR DESCRIPTION
`-_evictObjectsToMakeSpaceForObjectWithCost:` ran its eviction pass whenever `count >= _countLimit`. A count limit of 0 means "no limit" (and is the default), so `count >= 0` was true on *every* insert and the cache called `discardContentIfPossible` on the discardable objects it held even though it was unbounded.

The parallel cost check is already guarded with `_costLimit > 0`; this guards the count check the same way.

```objc
-  if (count > 0 && (spaceNeeded > 0 || count >= _countLimit))
+  if (count > 0
+    && (spaceNeeded > 0 || (_countLimit > 0 && count >= _countLimit)))
```

The new test `Tests/base/NSCache/nolimit.m` fails before and passes after. The existing `cache.m` count- and cost-based eviction tests (which set explicit limits) are unaffected.
