### PR TITLE
NSDateComponents: -copy must return a new instance

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 2026-07-03 Todd White <todd.white@thalion.global>
 
+	* Source/NSCalendar.m (-[NSDateComponents copyWithZone:]):
+	Always return a new instance.  NSDateComponents is mutable, but
+	copyWithZone: short-circuited through NSShouldRetainWithZone and
+	returned the receiver, so -copy handed back the same object and
+	mutating the "copy" changed the original.
+	* Tests/base/NSDateComponents/copy.m:
+	* Tests/base/NSDateComponents/TestInfo:
+	New test.
 	* Tests/base/NSDateInterval/basic.m:
 	* Tests/base/NSDateInterval/TestInfo:
 	Add tests for NSDateInterval: construction (including the negative

--- a/Source/NSCalendar.m
+++ b/Source/NSCalendar.m
@@ -1379,22 +1379,15 @@ typedef struct {
 
 - (id) copyWithZone: (NSZone*)zone
 {
-  if (NSShouldRetainWithZone(self, zone))
-    {
-      return RETAIN(self);
-    }
-  else
-    {
-      NSDateComponents  *c = [[NSDateComponents allocWithZone: zone] init];
+  NSDateComponents  *c = [[NSDateComponents allocWithZone: zone] init];
 
-      memcpy(c->_NSDateComponentsInternal, _NSDateComponentsInternal,
-        sizeof(DateComp));
-      /* We gave objects to the copy, so we need to retain them too.
-       */
-      RETAIN(my->cal);
-      RETAIN(my->tz);
-      return c;
-    }
+  memcpy(c->_NSDateComponentsInternal, _NSDateComponentsInternal,
+    sizeof(DateComp));
+  /* We gave objects to the copy, so we need to retain them too.
+   */
+  RETAIN(my->cal);
+  RETAIN(my->tz);
+  return c;
 }
 
 @end

--- a/Tests/base/NSDateComponents/copy.m
+++ b/Tests/base/NSDateComponents/copy.m
@@ -1,0 +1,35 @@
+#import "ObjectTesting.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSCalendar.h>
+
+int main()
+{
+  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
+
+  START_SET("copy is an independent object")
+    NSDateComponents	*dc = [[NSDateComponents new] autorelease];
+    NSDateComponents	*c;
+
+    [dc setYear: 1999];
+    [dc setMonth: 12];
+    [dc setDay: 31];
+    [dc setLeapMonth: YES];
+
+    c = [[dc copy] autorelease];
+
+    /* NSDateComponents is mutable, so a copy must be a separate object. */
+    PASS(c != dc, "copy returns a distinct object");
+    PASS(1999 == [c year], "copy preserves year");
+    PASS(12 == [c month], "copy preserves month");
+    PASS(31 == [c day], "copy preserves day");
+    PASS(YES == [c leapMonth], "copy preserves leapMonth");
+
+    /* Mutating the copy must not reach back into the original. */
+    [c setYear: 2020];
+    PASS(2020 == [c year], "the copy is independently mutable");
+    PASS(1999 == [dc year], "mutating the copy leaves the original unchanged");
+  END_SET("copy is an independent object")
+
+  [arp release]; arp = nil;
+  return 0;
+}


### PR DESCRIPTION
`-[NSDateComponents copyWithZone:]` short-circuited through `NSShouldRetainWithZone` and returned the receiver — the pattern used by immutable classes:

```objc
if (NSShouldRetainWithZone(self, zone))
  {
    return RETAIN(self);
  }
```

But NSDateComponents is mutable (it has only setters, and there is no immutable/mutable pair), so `-copy` (which passes a NULL zone) handed back the *same* object. Mutating the "copy" then changed the original:

```objc
NSDateComponents *a = [NSDateComponents new];
[a setYear: 1999];
NSDateComponents *b = [a copy];
[b setYear: 2020];
// a.year is now 2020, and b == a
```

This drops the short-circuit so a fresh instance is always allocated (the struct is `memcpy`-ed and the calendar/timeZone retained, as the existing else-branch already did).

The new test `Tests/base/NSDateComponents/copy.m` fails before and passes after.
