### PR TITLE
NSDecimal: classify a too-large product as overflow, not underflow

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2026-07-05 Todd White <todd.white@thalion.global>
+
+	* Source/NSDecimal.m (NSDecimalMultiply): Report a product too large
+	to represent as NSCalculationOverflow regardless of its sign, rather
+	than NSCalculationUnderflow when the result is negative.
+	* Tests/base/NSDecimalNumber/multiply_overflow_sign.m:
+	New test.
+
 2026-07-03 Todd White <todd.white@thalion.global>
 
 	* Source/NSCalendar.m (-[NSDateComponents copyWithZone:]):

--- a/Source/NSDecimal.m
+++ b/Source/NSDecimal.m
@@ -680,10 +680,7 @@ NSDecimalMultiply(NSDecimal *result, const NSDecimal *l, const NSDecimal *r,
   if (exp > 127)
     {
       result->validNumber = NO;
-      if (neg)
-	return NSCalculationUnderflow;
-      else
-	return NSCalculationOverflow;
+      return NSCalculationOverflow;
     }
 
   NSDecimalCopy(&n1, l);
@@ -707,10 +704,7 @@ NSDecimalMultiply(NSDecimal *result, const NSDecimal *l, const NSDecimal *r,
   if (result->exponent + exp > 127)
     {
       result->validNumber = NO;
-      if (neg)
-	return NSCalculationUnderflow;
-      else
-	return NSCalculationOverflow;
+      return NSCalculationOverflow;
     }
   else if (result->exponent + exp < -128)
     {

--- a/Tests/base/NSDecimalNumber/multiply_overflow_sign.m
+++ b/Tests/base/NSDecimalNumber/multiply_overflow_sign.m
@@ -1,0 +1,52 @@
+/*
+ * multiply_overflow_sign.m - regression test for NSDecimalMultiply reporting a
+ * too-large product as NSCalculationUnderflow when the result is negative.
+ *
+ * A product whose exponent exceeds the representable range is too large to
+ * represent, which is an overflow.  NSDecimalMultiply classified that case by
+ * the sign of the result and returned NSCalculationUnderflow for a negative
+ * product, although its magnitude is far too large (underflow is for values too
+ * close to zero).  The sibling NSDecimalMultiplyByPowerOf10 already reports
+ * NSCalculationOverflow for such a value regardless of sign.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Foundation/NSDecimal.h>
+#import "ObjectTesting.h"
+
+static NSDecimal
+dfs(const char *s)
+{
+  NSDecimal d;
+
+  NSDecimalFromString(&d, [NSString stringWithUTF8String: s], nil);
+  return d;
+}
+
+int main(void)
+{
+  START_SET("NSDecimalMultiply overflow does not depend on sign")
+    NSDecimal		a, pos, neg, r;
+    NSCalculationError	e;
+
+    /* Exponents sum to 200, beyond the representable range, so the product is
+     * too large whichever sign it carries. */
+    a = dfs("5e100");
+    pos = dfs("5e100");
+    neg = dfs("-5e100");
+
+    e = NSDecimalMultiply(&r, &a, &pos, NSRoundPlain);
+    PASS(e == NSCalculationOverflow,
+      "a large positive product reports overflow");
+    e = NSDecimalMultiply(&r, &a, &neg, NSRoundPlain);
+    PASS(e == NSCalculationOverflow,
+      "a large negative product reports overflow, not underflow");
+
+    /* NSDecimalMultiplyByPowerOf10 classifies the same magnitude the same way. */
+    e = NSDecimalMultiplyByPowerOf10(&r, &neg, 100, NSRoundPlain);
+    PASS(e == NSCalculationOverflow,
+      "NSDecimalMultiplyByPowerOf10 agrees for a large negative value");
+  END_SET("NSDecimalMultiply overflow does not depend on sign")
+
+  return 0;
+}


### PR DESCRIPTION
`NSDecimalMultiply` reported a product whose exponent exceeds the representable range as `NSCalculationUnderflow` when the result was negative:

```c
if (exp > 127)
  {
    result->validNumber = NO;
    if (neg)
      return NSCalculationUnderflow;
    else
      return NSCalculationOverflow;
  }
```

A value that large is an overflow whatever its sign — underflow is for values too close to zero. `NSDecimalMultiplyByPowerOf10` already reports `NSCalculationOverflow` for such a value regardless of sign, so the two disagreed. For example `5e100 * -5e100` (exponent sum 200) returned `NSCalculationUnderflow` while `5e100 * 5e100` returned `NSCalculationOverflow`.

The fix drops the sign test at both overflow points in `NSDecimalMultiply`, so a too-large product is always reported as overflow.

Includes a regression test (`Tests/base/NSDecimalNumber/multiply_overflow_sign.m`) covering both signs and the agreement with `NSDecimalMultiplyByPowerOf10`; the full `NSDecimalNumber` suite passes.
