### PR TITLE
NSDecimal: do not report a large negative sum or difference as underflow

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2026-07-05 Todd White <todd.white@thalion.global>
+
+	* Source/NSDecimal.m (NSDecimalAdd, NSDecimalSubtract): Do not turn
+	an overflow into an underflow when the result is negative.  A sum or
+	difference too large to represent is an overflow whatever its sign.
+	* Tests/base/NSDecimalNumber/add_subtract_overflow_sign.m:
+	New test.
+
 2026-07-03 Todd White <todd.white@thalion.global>
 
 	* Source/NSCalendar.m (-[NSDateComponents copyWithZone:]):

--- a/Source/NSDecimal.m
+++ b/Source/NSDecimal.m
@@ -515,10 +515,6 @@ NSDecimalAdd(NSDecimal *result, const NSDecimal *left, const NSDecimal *right,
 	  error1 = GSSimpleAdd(result, &n2, &n1, mode);
 	}
       result->isNegative = YES;
-      if (NSCalculationUnderflow == error1)
-	error1 = NSCalculationOverflow;
-      else if (NSCalculationOverflow == error1)
-	error1 = NSCalculationUnderflow;
     }
   else
     {
@@ -581,10 +577,6 @@ NSDecimalSubtract(NSDecimal *result, const NSDecimal *left,
 	  n1.isNegative = NO;
 	  error1 = NSDecimalAdd(result, &n1, right, mode);
 	  result->isNegative = YES;
-	  if (NSCalculationUnderflow == error1)
-	    error1 = NSCalculationOverflow;
-	  else if (NSCalculationOverflow == error1)
-	    error1 = NSCalculationUnderflow;
 	  return error1;
 	}
       else

--- a/Tests/base/NSDecimalNumber/add_subtract_overflow_sign.m
+++ b/Tests/base/NSDecimalNumber/add_subtract_overflow_sign.m
@@ -1,0 +1,54 @@
+/*
+ * add_subtract_overflow_sign.m - regression test for NSDecimalAdd and
+ * NSDecimalSubtract classifying an out-of-range result by its sign.  Two large
+ * negatives summed to an even larger magnitude were reported as
+ * NSCalculationUnderflow, while the positive counterpart was reported as
+ * NSCalculationOverflow; underflow is for values too close to zero, so a value
+ * that large must not be an underflow, and the error must not depend on sign.
+ *
+ * Whether the overflow is detected at all depends on the build (the GMP mantissa
+ * code does not flag it), so the test asserts that the two signs agree and that
+ * neither is reported as underflow, rather than a specific error code.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Foundation/NSDecimal.h>
+#import "ObjectTesting.h"
+
+static NSDecimal
+dfs(const char *s)
+{
+  NSDecimal d;
+
+  NSDecimalFromString(&d, [NSString stringWithUTF8String: s], nil);
+  return d;
+}
+
+int main(void)
+{
+  START_SET("NSDecimalAdd/Subtract overflow does not depend on sign")
+    NSDecimal		pos, neg, r;
+    NSCalculationError	ep, en;
+
+    /* 38 nines * 10^126: adding two of these carries the exponent to 127. */
+    pos = dfs("99999999999999999999999999999999999999e126");
+    neg = dfs("-99999999999999999999999999999999999999e126");
+
+    ep = NSDecimalAdd(&r, &pos, &pos, NSRoundPlain);
+    en = NSDecimalAdd(&r, &neg, &neg, NSRoundPlain);
+    PASS(en != NSCalculationUnderflow,
+      "a large negative sum is not reported as underflow");
+    PASS(ep == en,
+      "the sum error does not depend on the sign of the result");
+
+    /* (+big) - (-big) and (-big) - (+big) reach the same magnitude. */
+    ep = NSDecimalSubtract(&r, &pos, &neg, NSRoundPlain);
+    en = NSDecimalSubtract(&r, &neg, &pos, NSRoundPlain);
+    PASS(en != NSCalculationUnderflow,
+      "a large negative difference is not reported as underflow");
+    PASS(ep == en,
+      "the difference error does not depend on the sign of the result");
+  END_SET("NSDecimalAdd/Subtract overflow does not depend on sign")
+
+  return 0;
+}


### PR DESCRIPTION
Companion to the `NSDecimalMultiply` overflow fix. `NSDecimalAdd` and `NSDecimalSubtract` had the same sign-dependent misclassification: when the result is negative they turned an overflow into an underflow.

In the both-negative branch of `NSDecimalAdd` (and the mixed-sign branch of `NSDecimalSubtract`, which routes through it), the magnitude is computed with the operands made positive and the result negated, after which:

```c
if (NSCalculationUnderflow == error1)
  error1 = NSCalculationOverflow;
else if (NSCalculationOverflow == error1)
  error1 = NSCalculationUnderflow;
```

`GSSimpleAdd` only ever reports overflow (adding two positive magnitudes cannot underflow), so this only ever flips a real overflow into a spurious underflow. A sum or difference too large to represent is an overflow whatever its sign — underflow is for values too close to zero.

This path is reached in the non-GMP mantissa build, where `GSSimpleAdd` flags the carry-out as an overflow (the GMP path does not detect it). The fix removes both sign swaps.

The regression test (`Tests/base/NSDecimalNumber/add_subtract_overflow_sign.m`) asserts that the error does not depend on the sign of the result and that a large negative result is not reported as underflow — properties that hold in both the GMP and non-GMP builds. The full `NSDecimalNumber` suite passes in both configurations.
