### PR TITLE
NSScanner: implement scanHexDouble: and scanHexFloat:

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2026-07-05 Todd White <todd.white@thalion.global>
+
+	* Source/NSScanner.m (-[NSScanner scanHexDouble:],
+	-[NSScanner scanHexFloat:]): Implement scanning of a C hexadecimal
+	floating point value; both were unimplemented stubs returning NO.
+	* Tests/base/NSScanner/scanHexFloat.m:
+	New test.
+
 2026-07-03 Todd White <todd.white@thalion.global>
 
 	* Source/NSCalendar.m (-[NSDateComponents copyWithZone:]):

--- a/Source/NSScanner.m
+++ b/Source/NSScanner.m
@@ -1448,11 +1448,134 @@ typedef GSString	*ivars;
 
 - (BOOL) scanHexDouble: (double *)result
 {
-  return NO;    // FIXME
+  unsigned int	saveScanLocation = _scanLocation;
+  double	mantissa = 0.0;
+  int		fractionalDigits = 0;
+  int		exponent = 0;
+  BOOL		negative = NO;
+  BOOL		negativeExponent = NO;
+  BOOL		seenDot = NO;
+  BOOL		seenDigit = NO;
+
+  /* Skip whitespace */
+  if (!skipToNextField())
+    {
+      _scanLocation = saveScanLocation;
+      return NO;
+    }
+
+  /* Optional sign */
+  if (_scanLocation < myLength())
+    {
+      unichar	c = mySevenBit(_scanLocation);
+
+      if (c == '+')
+	_scanLocation++;
+      else if (c == '-')
+	{
+	  negative = YES;
+	  _scanLocation++;
+	}
+    }
+
+  /* A hexadecimal floating point value requires a 0x or 0X prefix. */
+  if (_scanLocation + 1 >= myLength()
+    || mySevenBit(_scanLocation) != '0'
+    || (mySevenBit(_scanLocation + 1) != 'x'
+      && mySevenBit(_scanLocation + 1) != 'X'))
+    {
+      _scanLocation = saveScanLocation;
+      return NO;
+    }
+  _scanLocation += 2;
+
+  /* Hexadecimal mantissa with an optional binary point. */
+  while (_scanLocation < myLength())
+    {
+      unichar	c = mySevenBit(_scanLocation);
+      int	digit;
+
+      if (c == '.')
+	{
+	  if (seenDot)
+	    break;
+	  seenDot = YES;
+	  _scanLocation++;
+	  continue;
+	}
+      if (c >= '0' && c <= '9')
+	digit = c - '0';
+      else if (c >= 'a' && c <= 'f')
+	digit = c - 'a' + 10;
+      else if (c >= 'A' && c <= 'F')
+	digit = c - 'A' + 10;
+      else
+	break;
+      mantissa = mantissa * 16.0 + digit;
+      if (seenDot)
+	fractionalDigits++;
+      seenDigit = YES;
+      _scanLocation++;
+    }
+  if (!seenDigit)
+    {
+      _scanLocation = saveScanLocation;
+      return NO;
+    }
+
+  /* Optional binary exponent: 'p' or 'P', an optional sign, then digits. */
+  if (_scanLocation < myLength()
+    && (mySevenBit(_scanLocation) == 'p' || mySevenBit(_scanLocation) == 'P'))
+    {
+      unsigned int	exponentLocation = _scanLocation;
+      BOOL		seenExponentDigit = NO;
+
+      _scanLocation++;
+      if (_scanLocation < myLength())
+	{
+	  unichar	c = mySevenBit(_scanLocation);
+
+	  if (c == '+')
+	    _scanLocation++;
+	  else if (c == '-')
+	    {
+	      negativeExponent = YES;
+	      _scanLocation++;
+	    }
+	}
+      while (_scanLocation < myLength()
+	&& mySevenBit(_scanLocation) >= '0' && mySevenBit(_scanLocation) <= '9')
+	{
+	  exponent = exponent * 10 + (mySevenBit(_scanLocation) - '0');
+	  seenExponentDigit = YES;
+	  _scanLocation++;
+	}
+      if (!seenExponentDigit)
+	_scanLocation = exponentLocation;
+      else if (negativeExponent)
+	exponent = -exponent;
+    }
+
+  if (result != 0)
+    {
+      double	value = ldexp(mantissa, exponent - 4 * fractionalDigits);
+
+      *result = negative ? -value : value;
+    }
+  return YES;
 }
+
 - (BOOL) scanHexFloat: (float *)result
 {
-  return NO;    // FIXME
+  double	d;
+
+  if ([self scanHexDouble: &d])
+    {
+      if (result != 0)
+	*result = (float)d;
+      return YES;
+    }
+  return NO;
 }
 - (BOOL) scanInteger: (NSInteger *)value
 {

--- a/Tests/base/NSScanner/scanHexFloat.m
+++ b/Tests/base/NSScanner/scanHexFloat.m
@@ -1,0 +1,68 @@
+/*
+ * scanHexFloat.m - tests for -[NSScanner scanHexDouble:] and -scanHexFloat:,
+ * which parse a C hexadecimal floating point value of the form 0xh.hhhp±d.
+ * The scanned values are exact powers of two, so they are compared exactly.
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+int main(void)
+{
+  START_SET("scanHexDouble")
+    NSScanner	*sc;
+    double	d;
+
+    sc = [NSScanner scannerWithString: @"0x1.8p1"];
+    PASS([sc scanHexDouble: &d] && d == 3.0 && [sc isAtEnd],
+      "0x1.8p1 scans as 3.0");
+    sc = [NSScanner scannerWithString: @"0x1p4"];
+    PASS([sc scanHexDouble: &d] && d == 16.0, "0x1p4 scans as 16");
+    sc = [NSScanner scannerWithString: @"0xA"];
+    PASS([sc scanHexDouble: &d] && d == 10.0, "0xA without an exponent scans as 10");
+    sc = [NSScanner scannerWithString: @"0x1p-2"];
+    PASS([sc scanHexDouble: &d] && d == 0.25, "0x1p-2 scans as 0.25");
+    sc = [NSScanner scannerWithString: @"-0x1.8p1"];
+    PASS([sc scanHexDouble: &d] && d == -3.0, "a leading minus is honoured");
+    sc = [NSScanner scannerWithString: @"0xf.8p0"];
+    PASS([sc scanHexDouble: &d] && d == 15.5, "0xf.8p0 scans as 15.5");
+    sc = [NSScanner scannerWithString: @"0X1P4"];
+    PASS([sc scanHexDouble: &d] && d == 16.0, "the 0X prefix and P exponent are case insensitive");
+  END_SET("scanHexDouble")
+
+  START_SET("scanHexDouble rejects input that is not a hex float")
+    NSScanner	*sc;
+    double	d = 99.0;
+
+    sc = [NSScanner scannerWithString: @"1.5"];
+    PASS(![sc scanHexDouble: &d] && [sc scanLocation] == 0,
+      "a value without the 0x prefix is not scanned");
+    sc = [NSScanner scannerWithString: @"0x"];
+    PASS(![sc scanHexDouble: &d] && [sc scanLocation] == 0,
+      "0x with no digits is not scanned");
+    sc = [NSScanner scannerWithString: @"hello"];
+    PASS(![sc scanHexDouble: &d], "non-numeric input is not scanned");
+  END_SET("scanHexDouble rejects input that is not a hex float")
+
+  START_SET("scanHexDouble skips whitespace and stops at the end of the value")
+    NSScanner	*sc = [NSScanner scannerWithString: @"  0x2p3 rest"];
+    double	d;
+
+    PASS([sc scanHexDouble: &d] && d == 16.0, "leading whitespace is skipped");
+    PASS([sc scanLocation] == 7, "scanning stops after the hex float");
+  END_SET("scanHexDouble skips whitespace and stops at the end of the value")
+
+  START_SET("scanHexFloat")
+    NSScanner	*sc;
+    float	f;
+
+    sc = [NSScanner scannerWithString: @"0x1.8p1"];
+    PASS([sc scanHexFloat: &f] && f == 3.0f, "0x1.8p1 scans as 3.0");
+    sc = [NSScanner scannerWithString: @"0x1p-1"];
+    PASS([sc scanHexFloat: &f] && f == 0.5f, "0x1p-1 scans as 0.5");
+    sc = [NSScanner scannerWithString: @"1.5"];
+    PASS(![sc scanHexFloat: &f], "a value without the 0x prefix is not scanned");
+  END_SET("scanHexFloat")
+
+  return 0;
+}


### PR DESCRIPTION
`-[NSScanner scanHexDouble:]` and `-[NSScanner scanHexFloat:]` were unimplemented stubs that always returned `NO` (`// FIXME`). This implements them.

`scanHexDouble:` scans a C hexadecimal floating point value of the form `0xh.hhhp±d`: after the usual whitespace skipping it reads an optional sign, a required `0x`/`0X` prefix, hexadecimal mantissa digits with an optional binary point, and an optional binary exponent (`p`/`P`, optional sign, decimal digits). The value is assembled with `ldexp`, so it is exact for the (power-of-two) values these strings denote and independent of the C locale — matching the manual, locale-independent style of the other `scan…` methods rather than calling `strtod`. Input without the `0x` prefix, or `0x` with no digits, is rejected and leaves the scan location unchanged. `scanHexFloat:` narrows the double result.

I cross-checked the parser against `strtod`'s hex-float handling over a range of inputs (fractional, negative, negative exponent, uppercase, no-exponent, π) — value and consumed length agree in every case.

Includes `Tests/base/NSScanner/scanHexFloat.m` (values, rejection cases, whitespace skipping, scan-location advance). The full `NSScanner` suite passes.
