### PR TITLE
NSScanner: implement scanDecimal:

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-07-05 Todd White <todd.white@thalion.global>
+
+	* Source/NSScanner.m (-[NSScanner scanDecimal:]): Implement; it
+	was an unimplemented stub that raised an exception.
+	* Tests/base/NSScanner/scanDecimal.m:
+	New test.
+
 2026-07-03 Todd White <todd.white@thalion.global>
 
 	* Source/NSCalendar.m (-[NSDateComponents copyWithZone:]):

--- a/Source/NSScanner.m
+++ b/Source/NSScanner.m
@@ -825,12 +825,112 @@ typedef GSString	*ivars;
 }
 
 /**
- * Not implemented.
+ * After initial skipping (if any), this method scans a decimal value,
+ * placing it in <em>value</em> if that is not null.  The decimal separator
+ * from the locale is honoured, as is a trailing 'e' or 'E' exponent.
+ * <br/>
+ * Returns YES if anything is scanned, NO otherwise.
  */
 - (BOOL) scanDecimal: (NSDecimal*)value
 {
-  [self notImplemented:_cmd];			/* FIXME */
-  return NO;
+  unsigned int	saveScanLocation = _scanLocation;
+  unsigned int	start;
+  BOOL		seenDigit = NO;
+  int		exponent = 0;
+  BOOL		negativeExponent = NO;
+  NSDecimal	d;
+
+  /* Skip whitespace */
+  if (!skipToNextField())
+    {
+      _scanLocation = saveScanLocation;
+      return NO;
+    }
+  start = _scanLocation;
+
+  /* Optional sign */
+  if (_scanLocation < myLength())
+    {
+      unichar	c = mySevenBit(_scanLocation);
+
+      if (c == '+' || c == '-')
+	_scanLocation++;
+    }
+
+  /* Integer digits */
+  while (_scanLocation < myLength()
+    && mySevenBit(_scanLocation) >= '0' && mySevenBit(_scanLocation) <= '9')
+    {
+      seenDigit = YES;
+      _scanLocation++;
+    }
+
+  /* Optional decimal separator followed by fractional digits */
+  if (_scanLocation < myLength()
+    && (_decimal == mySevenBit(_scanLocation)
+      || (_decimal > 127 && _decimal == myCharacter(_scanLocation))))
+    {
+      _scanLocation++;
+      while (_scanLocation < myLength()
+	&& mySevenBit(_scanLocation) >= '0' && mySevenBit(_scanLocation) <= '9')
+	{
+	  seenDigit = YES;
+	  _scanLocation++;
+	}
+    }
+
+  if (!seenDigit)
+    {
+      _scanLocation = saveScanLocation;
+      return NO;
+    }
+
+  /* NSDecimalFromString honours the locale's decimal separator but does not
+   * handle an exponent, which is applied separately below. */
+  NSDecimalFromString(&d,
+    [_string substringWithRange: NSMakeRange(start, _scanLocation - start)],
+    _locale);
+
+  /* Optional exponent: 'e' or 'E', an optional sign, then decimal digits */
+  if (_scanLocation < myLength()
+    && (mySevenBit(_scanLocation) == 'e' || mySevenBit(_scanLocation) == 'E'))
+    {
+      unsigned int	exponentLocation = _scanLocation;
+      BOOL		seenExponentDigit = NO;
+
+      _scanLocation++;
+      if (_scanLocation < myLength())
+	{
+	  unichar	c = mySevenBit(_scanLocation);
+
+	  if (c == '+')
+	    _scanLocation++;
+	  else if (c == '-')
+	    {
+	      negativeExponent = YES;
+	      _scanLocation++;
+	    }
+	}
+      while (_scanLocation < myLength()
+	&& mySevenBit(_scanLocation) >= '0' && mySevenBit(_scanLocation) <= '9')
+	{
+	  exponent = exponent * 10 + (mySevenBit(_scanLocation) - '0');
+	  seenExponentDigit = YES;
+	  _scanLocation++;
+	}
+      if (!seenExponentDigit)
+	_scanLocation = exponentLocation;
+      else
+	{
+	  if (negativeExponent)
+	    exponent = -exponent;
+	  NSDecimalMultiplyByPowerOf10(&d, &d, (short)exponent, NSRoundPlain);
+	}
+    }
+
+  if (value != 0)
+    *value = d;
+  return YES;
 }
 
 /**

--- a/Tests/base/NSScanner/scanDecimal.m
+++ b/Tests/base/NSScanner/scanDecimal.m
@@ -1,0 +1,62 @@
+/*
+ * scanDecimal.m - tests for -[NSScanner scanDecimal:], which scans a decimal
+ * number into an NSDecimal, honouring the locale decimal separator and an
+ * optional e/E exponent.  Results are checked through NSDecimalString.
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+static NSString *
+scan(NSString *s)
+{
+  NSScanner	*sc = [NSScanner scannerWithString: s];
+  NSDecimal	d;
+
+  return [sc scanDecimal: &d] ? NSDecimalString(&d, nil) : nil;
+}
+
+int main(void)
+{
+  START_SET("scanDecimal values")
+    PASS_EQUAL(scan(@"3.14"), @"3.14", "a fractional value is scanned");
+    PASS_EQUAL(scan(@"-2.5"), @"-2.5", "a negative value keeps its sign");
+    PASS_EQUAL(scan(@"42"), @"42", "an integer value is scanned");
+    PASS_EQUAL(scan(@".5"), @"0.5", "a leading separator is accepted");
+    PASS_EQUAL(scan(@"+7"), @"7", "a leading plus is accepted");
+  END_SET("scanDecimal values")
+
+  START_SET("scanDecimal exponent")
+    PASS_EQUAL(scan(@"1.5e3"), @"1500", "a positive exponent scales the value");
+    PASS_EQUAL(scan(@"1e-2"), @"0.01", "a negative exponent scales the value");
+    PASS_EQUAL(scan(@"2E2"), @"200", "an uppercase E exponent is accepted");
+  END_SET("scanDecimal exponent")
+
+  START_SET("scanDecimal rejects and positions")
+    NSScanner	*sc;
+    NSDecimal	d;
+
+    sc = [NSScanner scannerWithString: @"abc"];
+    PASS(![sc scanDecimal: &d] && [sc scanLocation] == 0,
+      "non-numeric input is not scanned and the location is unchanged");
+
+    sc = [NSScanner scannerWithString: @"  12.5 rest"];
+    PASS([sc scanDecimal: &d] && [sc scanLocation] == 6,
+      "whitespace is skipped and scanning stops after the number");
+  END_SET("scanDecimal rejects and positions")
+
+  START_SET("scanDecimal honours the locale separator")
+    NSDictionary	*loc;
+    NSScanner		*sc;
+    NSDecimal		d;
+
+    loc = [NSDictionary dictionaryWithObject: @"," forKey: NSDecimalSeparator];
+    sc = [NSScanner scannerWithString: @"3,14"];
+    [sc setLocale: loc];
+    PASS([sc scanDecimal: &d]
+      && [NSDecimalString(&d, nil) isEqualToString: @"3.14"],
+      "a comma decimal separator from the locale is used");
+  END_SET("scanDecimal honours the locale separator")
+
+  return 0;
+}


### PR DESCRIPTION
`-[NSScanner scanDecimal:]` was an unimplemented stub that raised an exception (`[self notImplemented:_cmd]`). This implements it.

After the usual whitespace skipping it scans an optional sign, integer digits, an optional decimal separator with fractional digits, and an optional `e`/`E` exponent. The decimal separator is taken from the scanner's locale (the cached `_decimal` character, exactly as `scanDouble:` uses it). The mantissa is converted with `NSDecimalFromString` (which honours the locale separator), and any exponent is then applied with `NSDecimalMultiplyByPowerOf10`, keeping the result exact. Input that is not a number leaves the scan location unchanged.

Includes `Tests/base/NSScanner/scanDecimal.m` covering values, sign, a leading separator, `e`/`E` exponents, whitespace skipping and scan-location advance, rejection of non-numeric input, and a comma decimal separator supplied through the locale. The full `NSScanner` suite passes.
