### PR TITLE
Create NSProgress userInfo dictionary if needed

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-07-06 Frederik Seiffert <frederik@algoriddim.com>
+
+	* Source/NSProgress.m:
+	Create the userInfo dictionary if needed.
+
 2026-07-03 Todd White <todd.white@thalion.global>
 
 	* Source/NSCalendar.m (-[NSDateComponents copyWithZone:]):

--- a/Source/NSProgress.m
+++ b/Source/NSProgress.m
@@ -256,7 +256,17 @@ GSProgressIsIndeterminate(int64_t total, int64_t completed)
        * created (implicit) child. You can see the hand-off at the end of this
        * method. */
       internal->_pendingUnitCountForChild = 0;
-      internal->_userInfo = [userInfo mutableCopy];
+
+      /* Always create a userInfo dict for -setUserInfoObject:forKey: */
+      if (userInfo == nil)
+	{
+	  internal->_userInfo = [[NSMutableDictionary alloc] init];
+	}
+      else
+	{
+	  internal->_userInfo = [userInfo mutableCopy];
+	}
+
       internal->_cancelled = NO;
       internal->_cancellable = YES;
       internal->_finished = NO;


### PR DESCRIPTION
Fixes `-setUserInfoObject:forKey:` not working if progress was initialized with nil object, and matches macOS behavior where calling `-userInfo` always returns an object.