### PR TITLE
NSKeyedUnarchiver: enforce secure coding class restrictions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,19 @@
+2026-07-06 Todd White <todd.white@thalion.global>
+
+	* Source/NSKeyedUnarchiver.m: Enforce NSSecureCoding class
+	restrictions.  The secure decoding entry points
+	(unarchivedObjectOfClasses:fromData:error: and the array and
+	dictionary variants) now enable secure coding, decode against the
+	given allowed classes and return nil with an NSError on a
+	violation, instead of forwarding to the insecure path.
+	-_decodeObject: rejects a class-tagged object whose class is not
+	one of the allowed classes or does not support secure coding.
+	-decodeObjectOfClasses:forKey: restricts the allowed classes for
+	its subtree.
+	* Headers/Foundation/NSKeyedArchiver.h: Add the _allowedClasses
+	instance variable.
+	* Tests/base/NSKeyedArchiver/secure_coding.m: New test.
+
 2026-07-03 Todd White <todd.white@thalion.global>
 
 	* Source/NSCalendar.m (-[NSDateComponents copyWithZone:]):

--- a/Headers/Foundation/NSKeyedArchiver.h
+++ b/Headers/Foundation/NSKeyedArchiver.h
@@ -273,6 +273,7 @@ GS_EXPORT_CLASS
 #endif
   NSZone	*_zone;		/* Zone for allocating objs.	*/
   BOOL          _requiresSecureCoding;
+  NSSet		*_allowedClasses; /* Current secure-coding allowed set (not retained; owned by the caller for the duration of a decode). */
 #endif
 #if     GS_NONFRAGILE
 #else

--- a/Source/NSKeyedUnarchiver.m
+++ b/Source/NSKeyedUnarchiver.m
@@ -27,6 +27,8 @@
 #import "Foundation/NSAutoreleasePool.h"
 #import "Foundation/NSData.h"
 #import "Foundation/NSDictionary.h"
+#import "Foundation/NSError.h"
+#import "Foundation/FoundationErrors.h"
 #import "Foundation/NSException.h"
 #import "Foundation/NSMapTable.h"
 #import "Foundation/NSNull.h"
@@ -74,6 +76,7 @@ static NSMapTable	*globalClassMap = 0;
 
 @interface NSKeyedUnarchiver (Private)
 - (id) _decodeObject: (unsigned)index;
+- (void) _validateSecureClass: (Class)aClass named: (NSString*)aName;
 @end
 
 @implementation NSKeyedUnarchiver (Internal)
@@ -155,6 +158,31 @@ static NSMapTable	*globalClassMap = 0;
 @end
 
 @implementation NSKeyedUnarchiver (Private)
+- (void) _validateSecureClass: (Class)aClass named: (NSString*)aName
+{
+  NSEnumerator	*e;
+  Class		a;
+
+  if ([aClass conformsToProtocol: @protocol(NSSecureCoding)] == NO
+    || [aClass supportsSecureCoding] == NO)
+    {
+      [NSException raise: NSInvalidUnarchiveOperationException
+	format: @"secure coding requested, but class '%@' does not support"
+	@" secure coding", aName];
+    }
+  e = [_allowedClasses objectEnumerator];
+  while ((a = [e nextObject]) != nil)
+    {
+      if ([aClass isSubclassOfClass: a] == YES)
+	{
+	  return;	// A kind of an allowed class.
+	}
+    }
+  [NSException raise: NSInvalidUnarchiveOperationException
+    format: @"secure coding requested, but class '%@' is not one of the"
+    @" allowed classes", aName];
+}
+
 - (id) _decodeObject: (unsigned)index
 {
   id	o;
@@ -231,6 +259,11 @@ static NSMapTable	*globalClassMap = 0;
 		    }
 		}
 	    }
+	}
+
+      if (_requiresSecureCoding == YES)
+	{
+	  [self _validateSecureClass: c named: classname];
 	}
 
       savedCursor = _cursor;
@@ -385,6 +418,45 @@ static NSMapTable	*globalClassMap = 0;
   return o;
 }
 
+/* Decode the root object of an archive with secure coding enabled and the
+ * given set of allowed classes, converting any failure into a nil result and
+ * an NSError rather than letting the exception escape. */
++ (id) _unarchivedRootFromData: (NSData*)data
+                allowedClasses: (NSSet*)classes
+                         error: (NSError**)error
+{
+  NSKeyedUnarchiver	*u = nil;
+  id			o = nil;
+
+  if (error != NULL)
+    {
+      *error = nil;
+    }
+  NS_DURING
+    {
+      u = [[NSKeyedUnarchiver alloc] initForReadingWithData: data];
+      [u setRequiresSecureCoding: YES];
+      u->_allowedClasses = classes;
+      o = RETAIN([u decodeObjectForKey: @"root"]);
+      [u finishDecoding];
+      DESTROY(u);
+    }
+  NS_HANDLER
+    {
+      DESTROY(u);
+      DESTROY(o);
+      if (error != NULL)
+	{
+	  *error = [NSError errorWithDomain: NSCocoaErrorDomain
+	    code: NSCoderReadCorruptError
+	    userInfo: [NSDictionary dictionaryWithObject: [localException reason]
+	                                          forKey: NSLocalizedDescriptionKey]];
+	}
+    }
+  NS_ENDHANDLER
+  return AUTORELEASE(o);
+}
+
 + (id) unarchivedObjectOfClass: (Class)cls
                       fromData: (NSData*)data
                          error: (NSError**)error
@@ -398,8 +470,7 @@ static NSMapTable	*globalClassMap = 0;
                         fromData: (NSData*)data
                            error: (NSError**)error
 {
-  /* FIXME: implement proper secure coding support */
-  return [self unarchiveObjectWithData: data];
+  return [self _unarchivedRootFromData: data allowedClasses: classes error: error];
 }
 
 + (NSArray*) unarchivedArrayOfObjectsOfClass: (Class)cls
@@ -415,8 +486,13 @@ static NSMapTable	*globalClassMap = 0;
                                       fromData: (NSData*)data
                                          error: (NSError**)error
 {
-  /* FIXME: implement proper secure coding support */
-  return [self unarchiveObjectWithData: data];
+  NSMutableSet	*allowed = [NSMutableSet setWithObject: [NSArray class]];
+
+  if (classes != nil)
+    {
+      [allowed unionSet: classes];
+    }
+  return [self _unarchivedRootFromData: data allowedClasses: allowed error: error];
 }
 
 + (NSDictionary*) unarchivedDictionaryWithKeysOfClass: (Class)keyCls
@@ -435,8 +511,17 @@ static NSMapTable	*globalClassMap = 0;
                                                fromData: (NSData*)data
                                                   error: (NSError**)error
 {
-  /* FIXME: implement proper secure coding support */
-  return [self unarchiveObjectWithData: data];
+  NSMutableSet	*allowed = [NSMutableSet setWithObject: [NSDictionary class]];
+
+  if (keyClasses != nil)
+    {
+      [allowed unionSet: keyClasses];
+    }
+  if (valueClasses != nil)
+    {
+      [allowed unionSet: valueClasses];
+    }
+  return [self _unarchivedRootFromData: data allowedClasses: allowed error: error];
 }
 
 
@@ -737,7 +822,25 @@ static NSMapTable	*globalClassMap = 0;
 
 - (id) decodeObjectOfClasses: (NSSet *)classes forKey: (NSString *)key
 {
-  return [self decodeObjectForKey: key];
+  NSSet	*saved = _allowedClasses;
+  id	o;
+
+  /* Restrict the allowed classes for this key's subtree, restoring the
+   * enclosing set afterwards (the enforcement itself is in -_decodeObject:
+   * and only applies when secure coding is required). */
+  _allowedClasses = classes;
+  NS_DURING
+    {
+      o = [self decodeObjectForKey: key];
+    }
+  NS_HANDLER
+    {
+      _allowedClasses = saved;
+      [localException raise];
+    }
+  NS_ENDHANDLER
+  _allowedClasses = saved;
+  return o;
 }
 
 - (NSPoint) decodePoint

--- a/Tests/base/NSKeyedArchiver/secure_coding.m
+++ b/Tests/base/NSKeyedArchiver/secure_coding.m
@@ -1,0 +1,140 @@
+/*
+ * secure_coding.m - the NSKeyedUnarchiver secure-coding entry points
+ * (unarchivedObjectOfClasses:fromData:error: and friends) must enforce the
+ * allowed-class set and NSSecureCoding conformance, returning nil and an
+ * NSError on a violation rather than instantiating an arbitrary class.
+ *
+ * These use a purpose-built NSSecureCoding class: the standard Foundation
+ * classes do not yet adopt NSSecureCoding, so an archive of, say, an NSArray
+ * cannot yet be decoded securely.  The enforcement itself is what is tested
+ * here.
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+@interface SCWidget : NSObject <NSSecureCoding>
+{
+  NSString	*_name;
+}
+- (NSString*) name;
+- (void) setName: (NSString*)aName;
+@end
+
+@implementation SCWidget
++ (BOOL) supportsSecureCoding { return YES; }
+- (NSString*) name { return _name; }
+- (void) setName: (NSString*)aName { [_name autorelease]; _name = [aName copy]; }
+- (void) dealloc { [_name release]; [super dealloc]; }
+- (void) encodeWithCoder: (NSCoder*)aCoder
+{ [aCoder encodeObject: _name forKey: @"name"]; }
+- (id) initWithCoder: (NSCoder*)aCoder
+{
+  if ((self = [super init]) != nil)
+    {
+      _name = [[aCoder decodeObjectForKey: @"name"] copy];
+    }
+  return self;
+}
+@end
+
+/* A subclass, to confirm a subclass of an allowed class is accepted. */
+@interface SCWidgetSub : SCWidget
+@end
+@implementation SCWidgetSub
+@end
+
+/* Conforms to NSCoding but not NSSecureCoding. */
+@interface SCSneaky : NSObject <NSCoding>
+@end
+@implementation SCSneaky
+- (void) encodeWithCoder: (NSCoder*)aCoder { (void)aCoder; }
+- (id) initWithCoder: (NSCoder*)aCoder { (void)aCoder; return [super init]; }
+@end
+
+static NSData *
+archive(id obj)
+{
+  return [NSKeyedArchiver archivedDataWithRootObject: obj];
+}
+
+int main(void)
+{
+  START_SET("secure decoding enforces the allowed classes")
+    SCWidget	*w = [[SCWidget alloc] init];
+    NSData	*data;
+    NSError	*err;
+    id		obj;
+
+    [w setName: @"secret"];
+    data = archive(w);
+    [w release];
+
+    err = nil;
+    obj = [NSKeyedUnarchiver
+      unarchivedObjectOfClasses: [NSSet setWithObject: [SCWidget class]]
+                       fromData: data error: &err];
+    PASS(obj != nil && [obj isKindOfClass: [SCWidget class]] && err == nil,
+      "a class in the allowed set is decoded");
+
+    err = nil;
+    obj = [NSKeyedUnarchiver
+      unarchivedObjectOfClasses: [NSSet setWithObject: [NSString class]]
+                       fromData: data error: &err];
+    PASS(obj == nil && err != nil
+      && [[err domain] isEqualToString: NSCocoaErrorDomain]
+      && [err code] == NSCoderReadCorruptError,
+      "a class not in the allowed set is rejected with an error");
+
+    err = nil;
+    obj = [NSKeyedUnarchiver
+      unarchivedObjectOfClasses: [NSSet set]
+                       fromData: data error: &err];
+    PASS(obj == nil && err != nil,
+      "an empty allowed set rejects a custom class");
+  END_SET("secure decoding enforces the allowed classes")
+
+  START_SET("secure decoding requires NSSecureCoding conformance")
+    SCSneaky	*s = [[SCSneaky alloc] init];
+    NSData	*data = archive(s);
+    NSError	*err = nil;
+    id		obj;
+
+    [s release];
+    obj = [NSKeyedUnarchiver
+      unarchivedObjectOfClasses: [NSSet setWithObject: [SCSneaky class]]
+                       fromData: data error: &err];
+    PASS(obj == nil && err != nil,
+      "a class that does not support secure coding is rejected even when listed");
+  END_SET("secure decoding requires NSSecureCoding conformance")
+
+  START_SET("a subclass of an allowed class is accepted")
+    SCWidgetSub	*w = [[SCWidgetSub alloc] init];
+    NSData	*data;
+    NSError	*err = nil;
+    id		obj;
+
+    [w setName: @"sub"];
+    data = archive(w);
+    [w release];
+    obj = [NSKeyedUnarchiver
+      unarchivedObjectOfClasses: [NSSet setWithObject: [SCWidget class]]
+                       fromData: data error: &err];
+    PASS(obj != nil && [obj isKindOfClass: [SCWidgetSub class]] && err == nil,
+      "a subclass of an allowed class is decoded");
+  END_SET("a subclass of an allowed class is accepted")
+
+  START_SET("plist primitives are implicitly allowed")
+    NSData	*data = archive(@"hello");
+    NSError	*err = nil;
+    id		obj;
+
+    obj = [NSKeyedUnarchiver
+      unarchivedObjectOfClasses: [NSSet setWithObject: [NSNumber class]]
+                       fromData: data error: &err];
+    PASS_EQUAL(obj, @"hello",
+      "a plist primitive is decoded even when its class is not listed");
+  END_SET("plist primitives are implicitly allowed")
+
+  return 0;
+}


### PR DESCRIPTION
Implements the `NSKeyedUnarchiver` secure-coding enforcement discussed in #639.

The secure decoding entry points (`unarchivedObjectOfClasses:fromData:error:` and the array/dictionary variants) were stubs that forwarded to the insecure path, ignoring the allowed-class set entirely — a crafted archive could instantiate any class it named. They now:

- create a secure unarchiver with the given allowed classes,
- reject a `$class`-tagged object in `-_decodeObject:` when its class is not one of the allowed classes (`isKindOfClass:`, so subclasses pass) or does not support secure coding,
- return nil and an `NSError` (`NSCocoaErrorDomain` / `NSCoderReadCorruptError`) on a violation.

`-decodeObjectOfClasses:forKey:` restricts the allowed classes for its subtree (the propagation mechanism). Inline plist primitives skip the class check, so they stay implicitly allowed — matching Apple.

I checked the behaviour against Apple's Foundation on a macOS runner and matched it: a class in the set decodes; a class not in the set / an empty set / a class that doesn't support secure coding are rejected with an error; a subclass of an allowed class is accepted; plist primitives are implicitly allowed.

**Scope note:** this is the enforcement half. The standard Foundation classes don't yet adopt `NSSecureCoding` (only `NSUserActivity` implements `+supportsSecureCoding`), so an archive of, e.g., an `NSArray` can't be securely decoded until those classes conform. That's a separate design decision on how broadly to adopt it, raised on #639, so I kept it out of this PR. This change is complete on its own: it closes the "instantiate any class" hole and works for custom `NSSecureCoding` classes plus the implicitly-allowed primitives.

Includes `Tests/base/NSKeyedArchiver/secure_coding.m`.
