### PR TITLE
NSCalendar: implement rangeOfUnit:inUnit:forDate:

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2026-07-06 Todd White <todd.white@thalion.global>
+
+	* Source/NSCalendar.m (_NSRangeOfUnitField,
+	-[NSCalendar rangeOfUnit:inUnit:forDate:]): Implement; it was a
+	stub that always returned {0, 0}.  Return the range of the smaller
+	unit within the larger unit for the date, or {NSNotFound,
+	NSNotFound} for a pair that is not a containment.
+	* Tests/base/NSCalendar/rangeOfUnit.m: New test.
+
 2026-07-03 Todd White <todd.white@thalion.global>
 
 	* Source/NSCalendar.m (-[NSDateComponents copyWithZone:]):

--- a/Source/NSCalendar.m
+++ b/Source/NSCalendar.m
@@ -69,6 +69,64 @@ static UCalendarDateFields _NSCalendarUnitToDateField(NSCalendarUnit unit)
     return UCAL_DAY_OF_WEEK_IN_MONTH;
   return (UCalendarDateFields)-1;
 }
+
+/* The ICU field whose range a smaller unit spans within a larger unit, or -1
+ * when the pair is not a supported containment.  The larger unit selects the
+ * field for the ambiguous day/week cases (a day is UCAL_DATE within a month
+ * but UCAL_DAY_OF_YEAR within a year). */
+static UCalendarDateFields
+_NSRangeOfUnitField(NSCalendarUnit smaller, NSCalendarUnit larger)
+{
+  switch (smaller)
+    {
+      case NSCalendarUnitSecond:
+        if (larger & (NSCalendarUnitMinute | NSCalendarUnitHour
+          | NSCalendarUnitDay | NSCalendarUnitWeekday
+          | NSCalendarUnitWeekOfMonth | NSCalendarUnitWeekOfYear
+          | NSCalendarUnitMonth | NSCalendarUnitYear | NSCalendarUnitEra))
+          return UCAL_SECOND;
+        break;
+      case NSCalendarUnitMinute:
+        if (larger & (NSCalendarUnitHour | NSCalendarUnitDay
+          | NSCalendarUnitWeekday | NSCalendarUnitWeekOfMonth
+          | NSCalendarUnitWeekOfYear | NSCalendarUnitMonth
+          | NSCalendarUnitYear | NSCalendarUnitEra))
+          return UCAL_MINUTE;
+        break;
+      case NSCalendarUnitHour:
+        if (larger & (NSCalendarUnitDay | NSCalendarUnitWeekday
+          | NSCalendarUnitWeekOfMonth | NSCalendarUnitWeekOfYear
+          | NSCalendarUnitMonth | NSCalendarUnitYear | NSCalendarUnitEra))
+          return UCAL_HOUR_OF_DAY;
+        break;
+      case NSCalendarUnitDay:
+        if (larger & NSCalendarUnitMonth)
+          return UCAL_DAY_OF_MONTH;
+        if (larger & NSCalendarUnitYear)
+          return UCAL_DAY_OF_YEAR;
+        break;
+      case NSCalendarUnitWeekday:
+        if (larger & (NSCalendarUnitWeekOfMonth | NSCalendarUnitWeekOfYear
+          | NSCalendarUnitMonth | NSCalendarUnitYear))
+          return UCAL_DAY_OF_WEEK;
+        break;
+      case NSCalendarUnitWeekOfMonth:
+        if (larger & NSCalendarUnitMonth)
+          return UCAL_WEEK_OF_MONTH;
+        break;
+      case NSCalendarUnitWeekOfYear:
+        if (larger & NSCalendarUnitYear)
+          return UCAL_WEEK_OF_YEAR;
+        break;
+      case NSCalendarUnitMonth:
+        if (larger & (NSCalendarUnitYear | NSCalendarUnitEra))
+          return UCAL_MONTH;
+        break;
+      default:
+        break;
+    }
+  return (UCalendarDateFields)-1;
+}
 #endif /* GS_USE_ICU */
 
 typedef struct {
@@ -871,7 +929,35 @@ do \
                  inUnit: (NSCalendarUnit) larger
                 forDate: (NSDate*) date
 {
-  return NSMakeRange (0, 0);
+  NSRange result = NSMakeRange (NSNotFound, NSNotFound);
+#if GS_USE_ICU == 1
+  UCalendarDateFields field = _NSRangeOfUnitField(smaller, larger);
+
+  if (field != (UCalendarDateFields)-1)
+    {
+      UErrorCode	err = U_ZERO_ERROR;
+      UDate		udate;
+
+      [self _resetCalendar];
+      udate = (UDate)floor([date timeIntervalSince1970] * 1000.0);
+      ucal_setMillis(my->cal, udate, &err);
+      result.location = (NSUInteger)
+        ucal_getLimit(my->cal, field, UCAL_ACTUAL_MINIMUM, &err);
+      result.length = (NSUInteger)
+        ucal_getLimit(my->cal, field, UCAL_ACTUAL_MAXIMUM, &err)
+        - result.location + 1;
+      // ICU's month is 0-based, while NSCalendar is 1-based
+      if (field == UCAL_MONTH)
+        {
+          result.location += 1;
+        }
+      if (U_FAILURE(err))
+        {
+          result = NSMakeRange (NSNotFound, NSNotFound);
+        }
+    }
+#endif
+  return result;
 }
 
 - (BOOL) rangeOfUnit: (NSCalendarUnit) unit

--- a/Tests/base/NSCalendar/rangeOfUnit.m
+++ b/Tests/base/NSCalendar/rangeOfUnit.m
@@ -1,0 +1,87 @@
+/*
+ * rangeOfUnit.m - -[NSCalendar rangeOfUnit:inUnit:forDate:] returns the range
+ * of the smaller unit within the larger unit for the given date (e.g. the
+ * number of days in the month), which was previously an unimplemented stub
+ * that always returned {0, 0}.
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+#if	defined(GS_USE_ICU)
+#define	NSCALENDAR_SUPPORTED	GS_USE_ICU
+#else
+#define	NSCALENDAR_SUPPORTED	1 /* Assume Apple support */
+#endif
+
+static NSCalendar	*gcal;
+
+static NSDate *
+mkdate(int y, int mo, int d)
+{
+  NSDateComponents	*c = [[NSDateComponents new] autorelease];
+
+  [c setYear: y];
+  [c setMonth: mo];
+  [c setDay: d];
+  return [gcal dateFromComponents: c];
+}
+
+#define	RNG(sm, lg, dt)	[gcal rangeOfUnit: (sm) inUnit: (lg) forDate: (dt)]
+
+int main(void)
+{
+  START_SET("NSCalendar rangeOfUnit:inUnit:forDate:")
+    NSRange	r;
+
+    if (NSCALENDAR_SUPPORTED == 0)
+      {
+        SKIP("NSCalendar not supported (no ICU)")
+      }
+
+    gcal = [[NSCalendar alloc]
+      initWithCalendarIdentifier: NSCalendarIdentifierGregorian];
+    [gcal setTimeZone: [NSTimeZone timeZoneWithName: @"UTC"]];
+    /* Fix the week definition so the week counts are deterministic. */
+    [gcal setFirstWeekday: 1];
+    [gcal setMinimumDaysInFirstWeek: 1];
+
+    r = RNG(NSCalendarUnitDay, NSCalendarUnitMonth, mkdate(2015, 2, 15));
+    PASS(r.location == 1 && r.length == 28, "February 2015 has 28 days");
+    r = RNG(NSCalendarUnitDay, NSCalendarUnitMonth, mkdate(2016, 2, 15));
+    PASS(r.location == 1 && r.length == 29, "February 2016 (leap) has 29 days");
+    r = RNG(NSCalendarUnitDay, NSCalendarUnitMonth, mkdate(2015, 1, 15));
+    PASS(r.location == 1 && r.length == 31, "January has 31 days");
+    r = RNG(NSCalendarUnitDay, NSCalendarUnitMonth, mkdate(2015, 4, 15));
+    PASS(r.location == 1 && r.length == 30, "April has 30 days");
+
+    r = RNG(NSCalendarUnitDay, NSCalendarUnitYear, mkdate(2015, 6, 1));
+    PASS(r.location == 1 && r.length == 365, "2015 has 365 days");
+    r = RNG(NSCalendarUnitDay, NSCalendarUnitYear, mkdate(2016, 6, 1));
+    PASS(r.location == 1 && r.length == 366, "2016 (leap) has 366 days");
+
+    r = RNG(NSCalendarUnitMonth, NSCalendarUnitYear, mkdate(2015, 6, 1));
+    PASS(r.location == 1 && r.length == 12, "a year has 12 months");
+
+    r = RNG(NSCalendarUnitHour, NSCalendarUnitDay, mkdate(2015, 6, 1));
+    PASS(r.location == 0 && r.length == 24, "a day has 24 hours");
+    r = RNG(NSCalendarUnitMinute, NSCalendarUnitHour, mkdate(2015, 6, 1));
+    PASS(r.location == 0 && r.length == 60, "an hour has 60 minutes");
+    r = RNG(NSCalendarUnitSecond, NSCalendarUnitMinute, mkdate(2015, 6, 1));
+    PASS(r.location == 0 && r.length == 60, "a minute has 60 seconds");
+
+    r = RNG(NSCalendarUnitWeekday, NSCalendarUnitWeekOfYear, mkdate(2015, 6, 1));
+    PASS(r.location == 1 && r.length == 7, "a week has 7 weekdays");
+    r = RNG(NSCalendarUnitWeekOfMonth, NSCalendarUnitMonth, mkdate(2015, 2, 15));
+    PASS(r.location == 1 && r.length == 4, "February 2015 spans 4 weeks");
+    r = RNG(NSCalendarUnitWeekOfYear, NSCalendarUnitYear, mkdate(2015, 6, 1));
+    PASS(r.location == 1 && r.length >= 52 && r.length <= 54,
+      "2015 spans a full year of week-of-year values");
+
+    /* A pair that is not a containment yields {NSNotFound, NSNotFound}. */
+    r = RNG(NSCalendarUnitMonth, NSCalendarUnitDay, mkdate(2015, 6, 1));
+    PASS(r.location == NSNotFound, "a month is not contained in a day");
+  END_SET("NSCalendar rangeOfUnit:inUnit:forDate:")
+
+  return 0;
+}


### PR DESCRIPTION
Fixes #1.

`-[NSCalendar rangeOfUnit:inUnit:forDate:]` was an unimplemented stub that always returned `{0, 0}`, so e.g. the number of days in a month came back as 0 — the 11-year-old report in #1.

It now maps the `(smaller, larger)` unit pair to the ICU field whose range the smaller unit spans within the larger (a day is `UCAL_DATE` within a month but `UCAL_DAY_OF_YEAR` within a year), sets the calendar to the date, and returns `ucal_getLimit`'s actual minimum and maximum (with the usual +1 for ICU's 0-based month). A pair that isn't a supported containment returns `{NSNotFound, NSNotFound}`, matching Apple.

I verified the values against Apple's Foundation on a macOS runner — day-in-month → {1, 28/29/30/31}, day-in-year → {1, 365/366}, month-in-year → {1, 12}, hour-in-day → {0, 24}, weekday-in-week → {1, 7}, etc.

Scope: this covers the common, well-defined unit pairs. Apple also returns values for some exotic date-spanning pairs (day-in-week, week-of-year within a month, day-in-era, …) with more involved semantics; those still return `{NSNotFound, NSNotFound}` here.

Includes `Tests/base/NSCalendar/rangeOfUnit.m` (skips when built without ICU).
