### PR TITLE
NSCalendar: implement rangeOfUnit:startDate:interval:forDate:

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2026-07-06 Todd White <todd.white@thalion.global>
+
+	* Source/NSCalendar.m
+	(-[NSCalendar rangeOfUnit:startDate:interval:forDate:]): Implement;
+	it was a stub returning NO.  Return the start and duration of the
+	calendar unit that contains the date.
+	* Tests/base/NSCalendar/rangeOfUnitInterval.m: New test.
+
 2026-07-03 Todd White <todd.white@thalion.global>
 
 	* Source/NSCalendar.m (-[NSDateComponents copyWithZone:]):

--- a/Source/NSCalendar.m
+++ b/Source/NSCalendar.m
@@ -879,7 +879,114 @@ do \
             interval: (NSTimeInterval*)tip
              forDate: (NSDate*)date
 {
+#if GS_USE_ICU == 1
+  UErrorCode	err = U_ZERO_ERROR;
+  UDate		udate, start, end;
+  UCalendarDateFields	advance;
+  BOOL		isWeek = NO;
+  int32_t	era, year, month, day, hour, minute, second;
+
+  [self _resetCalendar];
+  udate = (UDate)floor([date timeIntervalSince1970] * 1000.0);
+  ucal_setMillis(my->cal, udate, &err);
+
+  era = ucal_get(my->cal, UCAL_ERA, &err);
+  year = ucal_get(my->cal, UCAL_YEAR, &err);
+  month = ucal_get(my->cal, UCAL_MONTH, &err);
+  day = ucal_get(my->cal, UCAL_DAY_OF_MONTH, &err);
+  hour = ucal_get(my->cal, UCAL_HOUR_OF_DAY, &err);
+  minute = ucal_get(my->cal, UCAL_MINUTE, &err);
+  second = ucal_get(my->cal, UCAL_SECOND, &err);
+  if (U_FAILURE(err))
+    {
+      return NO;
+    }
+
+  /* Rebuild the date from the requested unit downwards; the smaller fields
+   * default to their minimum, giving the start of the unit. */
+  ucal_clear(my->cal);
+  ucal_set(my->cal, UCAL_ERA, era);
+  ucal_set(my->cal, UCAL_YEAR, year);
+  switch (unit)
+    {
+      case NSCalendarUnitYear:
+        advance = UCAL_YEAR;
+        break;
+      case NSCalendarUnitMonth:
+        ucal_set(my->cal, UCAL_MONTH, month);
+        advance = UCAL_MONTH;
+        break;
+      case NSCalendarUnitWeekOfYear:
+      case NSCalendarUnitWeekOfMonth:
+        isWeek = YES;
+        /* fall through to set the day, then roll back to the first weekday */
+      case NSCalendarUnitDay:
+      case NSCalendarUnitWeekday:
+      case NSCalendarUnitWeekdayOrdinal:
+        ucal_set(my->cal, UCAL_MONTH, month);
+        ucal_set(my->cal, UCAL_DAY_OF_MONTH, day);
+        advance = UCAL_DAY_OF_MONTH;
+        break;
+      case NSCalendarUnitHour:
+        ucal_set(my->cal, UCAL_MONTH, month);
+        ucal_set(my->cal, UCAL_DAY_OF_MONTH, day);
+        ucal_set(my->cal, UCAL_HOUR_OF_DAY, hour);
+        advance = UCAL_HOUR_OF_DAY;
+        break;
+      case NSCalendarUnitMinute:
+        ucal_set(my->cal, UCAL_MONTH, month);
+        ucal_set(my->cal, UCAL_DAY_OF_MONTH, day);
+        ucal_set(my->cal, UCAL_HOUR_OF_DAY, hour);
+        ucal_set(my->cal, UCAL_MINUTE, minute);
+        advance = UCAL_MINUTE;
+        break;
+      case NSCalendarUnitSecond:
+        ucal_set(my->cal, UCAL_MONTH, month);
+        ucal_set(my->cal, UCAL_DAY_OF_MONTH, day);
+        ucal_set(my->cal, UCAL_HOUR_OF_DAY, hour);
+        ucal_set(my->cal, UCAL_MINUTE, minute);
+        ucal_set(my->cal, UCAL_SECOND, second);
+        advance = UCAL_SECOND;
+        break;
+      default:
+        return NO;	// Era and any composite units are not handled.
+    }
+
+  if (isWeek == YES)
+    {
+      int32_t	dow = ucal_get(my->cal, UCAL_DAY_OF_WEEK, &err);
+      int32_t	back = (dow - (int32_t)my->firstWeekday + 7) % 7;
+
+      ucal_add(my->cal, UCAL_DAY_OF_MONTH, -back, &err);
+    }
+
+  start = ucal_getMillis(my->cal, &err);
+  if (isWeek == YES)
+    {
+      ucal_add(my->cal, UCAL_DAY_OF_MONTH, 7, &err);
+    }
+  else
+    {
+      ucal_add(my->cal, advance, 1, &err);
+    }
+  end = ucal_getMillis(my->cal, &err);
+  if (U_FAILURE(err))
+    {
+      return NO;
+    }
+
+  if (datep != NULL)
+    {
+      *datep = [NSDate dateWithTimeIntervalSince1970: start / 1000.0];
+    }
+  if (tip != NULL)
+    {
+      *tip = (end - start) / 1000.0;
+    }
+  return YES;
+#else
   return NO;
+#endif
 }
 
 - (BOOL) isEqual: (id) obj

--- a/Tests/base/NSCalendar/rangeOfUnitInterval.m
+++ b/Tests/base/NSCalendar/rangeOfUnitInterval.m
@@ -1,0 +1,87 @@
+/*
+ * rangeOfUnitInterval.m - -[NSCalendar rangeOfUnit:startDate:interval:forDate:]
+ * returns the start and duration of the calendar unit that contains the date,
+ * which was previously an unimplemented stub that always returned NO.
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+#if	defined(GS_USE_ICU)
+#define	NSCALENDAR_SUPPORTED	GS_USE_ICU
+#else
+#define	NSCALENDAR_SUPPORTED	1 /* Assume Apple support */
+#endif
+
+static NSCalendar	*gcal;
+
+static NSDate *
+mkdate(int y, int mo, int d, int h, int mi, int s)
+{
+  NSDateComponents	*c = [[NSDateComponents new] autorelease];
+
+  [c setYear: y];
+  [c setMonth: mo];
+  [c setDay: d];
+  [c setHour: h];
+  [c setMinute: mi];
+  [c setSecond: s];
+  return [gcal dateFromComponents: c];
+}
+
+static BOOL
+chk(NSCalendarUnit unit, NSDate *date, NSDate *expStart, NSTimeInterval expLen)
+{
+  NSDate		*start = nil;
+  NSTimeInterval	len = 0;
+
+  return [gcal rangeOfUnit: unit startDate: &start interval: &len forDate: date]
+    && [start isEqualToDate: expStart]
+    && len == expLen;
+}
+
+int main(void)
+{
+  START_SET("NSCalendar rangeOfUnit:startDate:interval:forDate:")
+    NSDate	*d;
+
+    if (NSCALENDAR_SUPPORTED == 0)
+      {
+        SKIP("NSCalendar not supported (no ICU)")
+      }
+
+    gcal = [[NSCalendar alloc]
+      initWithCalendarIdentifier: NSCalendarIdentifierGregorian];
+    [gcal setTimeZone: [NSTimeZone timeZoneWithName: @"UTC"]];
+    [gcal setFirstWeekday: 1];
+    [gcal setMinimumDaysInFirstWeek: 1];
+
+    d = mkdate(2015, 2, 18, 12, 30, 45);	// a Wednesday
+
+    PASS(chk(NSCalendarUnitYear, d, mkdate(2015, 1, 1, 0, 0, 0), 31536000.0),
+      "the year containing the date starts on 1 January");
+    PASS(chk(NSCalendarUnitMonth, d, mkdate(2015, 2, 1, 0, 0, 0), 2419200.0),
+      "the month containing the date is 28 days");
+    PASS(chk(NSCalendarUnitDay, d, mkdate(2015, 2, 18, 0, 0, 0), 86400.0),
+      "the day containing the date starts at midnight");
+    PASS(chk(NSCalendarUnitHour, d, mkdate(2015, 2, 18, 12, 0, 0), 3600.0),
+      "the hour containing the date");
+    PASS(chk(NSCalendarUnitMinute, d, mkdate(2015, 2, 18, 12, 30, 0), 60.0),
+      "the minute containing the date");
+    PASS(chk(NSCalendarUnitSecond, d, mkdate(2015, 2, 18, 12, 30, 45), 1.0),
+      "the second containing the date");
+    PASS(chk(NSCalendarUnitWeekOfYear, d, mkdate(2015, 2, 15, 0, 0, 0), 604800.0),
+      "the week containing the date starts on the first weekday and is 7 days");
+
+    {
+      NSDate		*s = nil;
+      NSTimeInterval	l = 0;
+
+      PASS([gcal rangeOfUnit: NSCalendarUnitEra
+                   startDate: &s interval: &l forDate: d] == NO,
+        "an unhandled unit returns NO");
+    }
+  END_SET("NSCalendar rangeOfUnit:startDate:interval:forDate:")
+
+  return 0;
+}


### PR DESCRIPTION
Companion to #687. `-[NSCalendar rangeOfUnit:startDate:interval:forDate:]` was an unimplemented stub that always returned `NO`; this implements it.

It rebuilds the date from the requested unit downwards (so the smaller fields fall to their minimum — the start of the unit), then advances one unit to measure the duration. For a week unit the start rolls back to the calendar's first weekday and the interval is seven days. The era unit is not handled and returns `NO`.

Verified against Apple's Foundation on a macOS runner: e.g. the month of 2015-02-18 → start 2015-02-01, 28 days; the day → start of that day, 86400 s; the week (Wed) → start on the preceding Sunday, 604800 s; hour/minute/second likewise.

Includes `Tests/base/NSCalendar/rangeOfUnitInterval.m` (skips when built without ICU).
