### PR TITLE
NSInvocation: support structures containing bitfields

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,20 @@
 	* Headers/Foundation/NSKeyedArchiver.h: Add the _allowedClasses
 	instance variable.
 	* Tests/base/NSKeyedArchiver/secure_coding.m: New test.
+	* Source/cifframe.m (cifframe_type): Handle the _C_BFLD type encoding.
+	Passing or returning a structure that contains a bitfield through an
+	NSInvocation aborted with "Unknown type in sig".  Coalesce each run of
+	bitfields into the storage units of their underlying type so the
+	enclosing structure gets the correct libffi layout.
+	* Source/NSMethodSignature.m (next_arg): Take the size of a structure
+	that contains bitfields from the runtime.  Bitfields share a storage
+	unit and report a byte size of zero individually, so summing the member
+	sizes gave such a structure a size of zero and its return value was lost.
+	Work out a bitfield's alignment from its underlying type rather than
+	from objc_alignof_type, whose gnu runtime implementation aborts on a
+	bitfield encoding.
+	* Tests/base/NSInvocation/bitfield.m: New test.
+
 2026-07-05 Todd White <todd.white@thalion.global>
 
 	* Source/NSScanner.m (-[NSScanner scanDecimal:]): Implement; it

--- a/Source/NSMethodSignature.m
+++ b/Source/NSMethodSignature.m
@@ -266,6 +266,7 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
 	  unsigned int def_align = objc_alignof_type(typePtr-1);
 	  unsigned int acc_align = def_align;
 	  const char	*ptr = typePtr;
+	  BOOL		hasBitField = NO;
 
 	  /*
 	   *	Skip "<name>=" stuff.
@@ -287,6 +288,9 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
 	      acc_size = ROUND(acc_size, local.align);
 	      acc_size += local.size;
 	      acc_align = MAX(local.align, def_align);
+#if	defined(_C_BFLD)
+	      if (*local.type == _C_BFLD) hasBitField = YES;
+#endif
 	    }
 	  /*
 	   *	Continue accumulating structure size
@@ -302,6 +306,9 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
 	      acc_size = ROUND(acc_size, local.align);
 	      acc_size += local.size;
 	      acc_align = MAX(local.align, acc_align);
+#if	defined(_C_BFLD)
+	      if (*local.type == _C_BFLD) hasBitField = YES;
+#endif
 	    }
 	  /*
 	   * Size must be a multiple of alignment
@@ -312,6 +319,13 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
 	    }
 	  info->size = acc_size;
 	  info->align = acc_align;
+	  /* Bit-fields share a storage unit, so their individual byte sizes
+	   * cannot be summed; take the whole structure's size from the runtime.
+	   */
+	  if (hasBitField)
+	    {
+	      info->size = objc_sizeof_type(info->type);
+	    }
 	  typePtr++;	/* Skip end-of-struct	*/
 	}
 	break;
@@ -360,12 +374,33 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
 #endif
 #if     defined(_C_BFLD)
       case _C_BFLD:
-        /* Rely on the runtime to either provide the info or bomb out.
-         * Nowadays we ought to be able to expect modern enough runtimes.
+        /* The gnu runtime encodes a bit-field as b<pos><type><width> and its
+         * objc_alignof_type() aborts on that encoding, so work the alignment
+         * out directly from the field's underlying type.  A bit-field shares
+         * a storage unit with its neighbours and so contributes no separate
+         * byte size of its own; the enclosing structure takes its size from
+         * the runtime once (see the _C_BFLD handling under _C_STRUCT_B).
          */
         typePtr--;
-        info->size = objc_sizeof_type(typePtr);
-        info->align = objc_alignof_type(typePtr);
+        {
+          const char	*p = typePtr + 1;
+
+          while (isdigit(*p)) p++;	/* skip the starting bit position */
+          switch (*p)
+            {
+              case _C_CHR: case _C_UCHR:
+                info->align = __alignof__(char); break;
+              case _C_SHT: case _C_USHT:
+                info->align = __alignof__(short); break;
+              case _C_LNG: case _C_ULNG:
+                info->align = __alignof__(long); break;
+              case _C_LNG_LNG: case _C_ULNG_LNG:
+                info->align = __alignof__(long long); break;
+              default:
+                info->align = __alignof__(int); break;
+            }
+        }
+        info->size = 0;
         typePtr = objc_skip_typespec(typePtr);
         break;
 #endif

--- a/Source/cifframe.m
+++ b/Source/cifframe.m
@@ -548,6 +548,85 @@ cifframe_type(const char *typePtr, const char **advance, NSPointerArray **extra)
     case _C_BOOL: ftype = &ffi_type_uchar;
       break;
 #endif
+    case _C_BFLD:
+      {
+	/* A bitfield is encoded as b<offset><type><width> (the older form is
+	 * just b<width>).  Consecutive bitfields share a storage unit of the
+	 * underlying type, so coalesce this whole run of them into the
+	 * storage they occupy: one element of the underlying type per unit,
+	 * which gives the enclosing structure the correct size and alignment.
+	 */
+	int		maxbit = 0;
+	char		utype = _C_INT;
+	char		tt[2];
+	ffi_type	*bft;
+	unsigned	tsize;
+	unsigned	units;
+
+	typePtr = type;			/* Back up to the leading 'b'. */
+	while (*typePtr == _C_BFLD)
+	  {
+	    int		off = 0;
+	    int		width = 0;
+
+	    typePtr++;			/* Skip 'b'. */
+	    while (isdigit((unsigned char)*typePtr))
+	      off = off * 10 + (*typePtr++ - '0');
+	    if (*typePtr != '\0' && !isdigit((unsigned char)*typePtr)
+	      && *typePtr != _C_STRUCT_E && *typePtr != _C_UNION_E
+	      && *typePtr != _C_ARY_E && *typePtr != _C_BFLD)
+	      {
+		utype = *typePtr++;	/* Underlying type. */
+		while (isdigit((unsigned char)*typePtr))
+		  width = width * 10 + (*typePtr++ - '0');
+	      }
+	    else
+	      {
+		width = off;		/* Older b<width> form. */
+		off = 0;
+	      }
+	    if (off + width > maxbit)
+	      maxbit = off + width;
+	  }
+
+	tt[0] = utype;
+	tt[1] = '\0';
+	bft = cifframe_type(tt, NULL, extra);
+	tsize = (bft->size > 0) ? (unsigned)bft->size : 1;
+	units = (maxbit + 8 * tsize - 1) / (8 * tsize);
+	if (units < 1)
+	  units = 1;
+
+	if (units == 1)
+	  {
+	    ftype = bft;
+	  }
+	else
+	  {
+	    unsigned	size = sizeof(ffi_type);
+	    unsigned	align = __alignof(double);
+	    unsigned	k;
+
+	    if (size % align != 0)
+	      size += (align - (size % align));
+	    ftype = malloc(size + (units + 1) * sizeof(ffi_type*));
+	    ftype->size = 0;
+	    ftype->alignment = 0;
+	    ftype->type = FFI_TYPE_STRUCT;
+	    ftype->elements = (void*)ftype + size;
+	    for (k = 0; k < units; k++)
+	      ftype->elements[k] = bft;
+	    ftype->elements[units] = NULL;
+	    if (nil == *extra)
+	      {
+		*extra = [NSPointerArray pointerArrayWithOptions:
+		  NSPointerFunctionsOpaquePersonality
+		  | NSPointerFunctionsMallocMemory];
+	      }
+	    [*extra addPointer: ftype];
+	  }
+      }
+      break;
     default:
       ftype = &ffi_type_void;
       NSCAssert(0, @"Unknown type in sig");

--- a/Tests/base/NSInvocation/bitfield.m
+++ b/Tests/base/NSInvocation/bitfield.m
@@ -1,0 +1,124 @@
+/* Passing and returning a structure that contains bitfields through an
+ * NSInvocation.  This exercises cifframe_type's handling of the _C_BFLD ('b')
+ * type encoding, which used to abort with "Unknown type in sig", and the
+ * NSMethodSignature sizing of such a structure.  Checking the round-tripped
+ * values confirms the structure is laid out correctly for the call, not
+ * merely that the abort is gone.
+ */
+
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+typedef struct {
+  unsigned int	a: 3;
+  unsigned int	b: 5;
+  unsigned int	c: 7;
+} BitStruct;
+
+/* A run of single-bit fields, as found in the NSView "rflags" structure. */
+typedef struct {
+  unsigned int	f0: 1, f1: 1, f2: 1, f3: 1, f4: 1,
+		f5: 1, f6: 1, f7: 1, f8: 1, f9: 1;
+} FlagStruct;
+
+/* Wide enough that the two fields occupy separate storage units. */
+typedef struct {
+  unsigned int	a: 20;
+  unsigned int	b: 20;
+} WideStruct;
+
+@interface BitTarget : NSObject
+- (BitStruct) transform: (BitStruct)input;
+- (FlagStruct) flip: (FlagStruct)input;
+- (WideStruct) swap: (WideStruct)input;
+@end
+
+@implementation BitTarget
+- (BitStruct) transform: (BitStruct)input
+{
+  BitStruct	output;
+
+  output.a = input.c & 7;
+  output.b = input.b;
+  output.c = input.a;
+  return output;
+}
+- (FlagStruct) flip: (FlagStruct)input
+{
+  input.f0 = !input.f0;
+  return input;
+}
+- (WideStruct) swap: (WideStruct)input
+{
+  WideStruct	output;
+
+  output.a = input.b;
+  output.b = input.a;
+  return output;
+}
+@end
+
+int main(void)
+{
+  START_SET("bitfield structure through NSInvocation")
+    BitTarget		*t = [[[BitTarget alloc] init] autorelease];
+    BitStruct		input = { 5, 20, 100 };
+    BitStruct		output;
+    FlagStruct		fin;
+    FlagStruct		fout;
+    WideStruct		win;
+    WideStruct		wout;
+    NSMethodSignature	*sig;
+    NSInvocation	*inv;
+
+    sig = [t methodSignatureForSelector: @selector(transform:)];
+    PASS(sig != nil, "a signature containing a bitfield struct is created");
+    PASS([sig methodReturnLength] == sizeof(BitStruct),
+      "the return length of a bitfield struct is correct");
+
+    inv = [NSInvocation invocationWithMethodSignature: sig];
+    PASS(inv != nil,
+      "an invocation for a bitfield struct is built without aborting");
+
+    [inv setSelector: @selector(transform:)];
+    [inv setTarget: t];
+    [inv setArgument: &input atIndex: 2];
+    [inv invoke];
+
+    memset(&output, 0, sizeof(output));
+    [inv getReturnValue: &output];
+    PASS(output.a == (input.c & 7) && output.b == input.b && output.c == input.a,
+      "a bitfield structure round-trips through the invocation");
+
+    memset(&fin, 0, sizeof(fin));
+    fin.f3 = 1;
+    fin.f9 = 1;
+    sig = [t methodSignatureForSelector: @selector(flip:)];
+    inv = [NSInvocation invocationWithMethodSignature: sig];
+    [inv setSelector: @selector(flip:)];
+    [inv setTarget: t];
+    [inv setArgument: &fin atIndex: 2];
+    [inv invoke];
+
+    memset(&fout, 0, sizeof(fout));
+    [inv getReturnValue: &fout];
+    PASS(fout.f0 == 1 && fout.f1 == 0 && fout.f3 == 1 && fout.f9 == 1,
+      "a run of single-bit fields round-trips through the invocation");
+
+    win.a = 0xABCDE;
+    win.b = 0x12345;
+    sig = [t methodSignatureForSelector: @selector(swap:)];
+    inv = [NSInvocation invocationWithMethodSignature: sig];
+    [inv setSelector: @selector(swap:)];
+    [inv setTarget: t];
+    [inv setArgument: &win atIndex: 2];
+    [inv invoke];
+
+    memset(&wout, 0, sizeof(wout));
+    [inv getReturnValue: &wout];
+    PASS(wout.a == 0x12345 && wout.b == 0xABCDE,
+      "a bitfield struct spanning two storage units round-trips");
+  END_SET("bitfield structure through NSInvocation")
+
+  return 0;
+}


### PR DESCRIPTION
Fixes #290.

Passing or returning a structure by value through an `NSInvocation` aborts in
`cifframe_type` with `Unknown type in sig` when the structure contains a
bitfield (the `_C_BFLD`, `b<offset><type><width>` encoding) — the `rflags`
case from the issue.

Fixing the abort exposed a second problem: `NSMethodSignature` sizes such a
structure as zero.  A bitfield reports a byte size of zero on its own (it
shares a storage unit with its neighbours), so summing the member sizes in
`next_arg` gives the whole structure a size of zero; `getReturnValue:` then
copies nothing and the returned structure comes back all-zero.

Both are addressed here:

* `cifframe_type` handles `_C_BFLD` by coalescing each run of consecutive
  bitfields into the storage units of their underlying type (one ffi element
  per unit), so the enclosing structure gets the correct libffi layout.
* `next_arg` takes the size of a bitfield-containing structure from the
  runtime (`objc_sizeof_type`) instead of summing the members.

### Test

`Tests/base/NSInvocation/bitfield.m` passes and returns three bitfield
structures through an invocation and checks the round-tripped field values: a
3/5/7-bit struct, a run of single-bit fields as in NSView's `rflags`, and a
struct wide enough to occupy two storage units (exercising the multi-unit
path).

Verified on the current tree:

* Before: the test aborts with the assertion from this issue.
* After: the values round-trip correctly, and the NSInvocation (75),
  NSMethodSignature (46) and NSValue (47) suites all pass.
