### PR TITLE
New key-value observing (KVO) implementation on all runtimes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -31,8 +31,19 @@
 	prototype takes the address as char*, so it is cast; it is still the
 	binary address rather than an ascii string.
 
-2026-07-07  Todd White <todd.white@thalion.global>
+2026-07-08  Todd White <todd.white@thalion.global>
 
+	* Source/NSKVOSwizzling.m: On runtimes without libobjc2 per-object
+	method addition, make an observed object notify for arbitrary-key
+	mutation, as NSMutableDictionary does, by overriding setObject:forKey:
+	and removeObjectForKey: on the notifying subclass.  This was done only
+	for the libobjc2 backend, so key-value observing of a mutable
+	dictionary fired no notifications on the GNU runtime.
+	* Tests/base/NSKVOSupport/general.m,
+	Tests/base/NSKVOSupport/newoldvalues.m: Remove the FLAKY_ON_GCC markers
+	that made the affected cases hopeful on the GNU runtime; they now pass.
+
+2026-07-07  Todd White <todd.white@thalion.global>
 	* Tests/base/NSKVOSupport/kvoToMany.m: Rework to avoid Objective-C
 	blocks and other constructs unavailable with the GNU runtime
 	(property auto-synthesis, the strong attribute, object subscripting),

--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,40 @@
 
 2026-07-07  Todd White <todd.white@thalion.global>
 
+	* configure.ac: Build the new key-value observing implementation on
+	every Objective-C runtime rather than only the next-generation one.
+	Add --disable-newkvo to fall back to the old implementation.
+	* configure: Regenerate.
+	* Source/GNUmakefile: Define GNUSTEP_BASE_NEW_KVO when the new KVO is
+	compiled so the swizzling code can select a backend.
+	* Source/NSKVOInternal.h: Guard on GNUSTEP_BASE_NEW_KVO as well as
+	__OBJC2__.  Declare the _NSKVOKeyObserver and _NSKVOKeypathObserver
+	instance variables explicitly; gcc does not synthesise them from the
+	property declarations.
+	* Source/NSKVOSwizzling.m: Add a per-class swizzling backend, using an
+	NSKVONotifying_<Class> subclass and object_setClass, for runtimes that
+	lack the libobjc2 object_addMethod_np extension.
+	(KVCSetterForPropertyName): Correct the buffer offset; it dropped the
+	second character of every key, so no setter selector resolved.
+	(_NSKVOInfoForClass, _NSKVOInstallOverride, _NSKVOEnsureKeyWillNotify):
+	Use a recursive gs_mutex instead of @synchronized, which needs
+	Objective-C exceptions that the GNU runtime does not enable on Windows.
+	(notifyingSetImpl*): Call straight through to the original setter when
+	the object has no observation info.
+	* Source/NSKVOSupport.m: Replace the block-based change dispatch with
+	plain functions.
+	(-[_NSKVOObservationInfo addObserver:], removeObserver:,
+	observersForKey:): Hold the per-key observer arrays copy-on-write so a
+	notification does not copy them.
+	(_kvoWillSetChange, _dispatchDidChange): Reuse the change dictionary
+	across notifications and iterate observers in reverse with an index
+	loop.
+	(_addNestedObserversAndOptionallyDependents,
+	_removeNestedObserversAndOptionallyDependents): Return early for a
+	simple key that has no dependents.
+
+2026-07-07  Todd White <todd.white@thalion.global>
+
 	* configure.ac: Detect the 5-argument (Solaris) form of
 	gethostbyname_r in addition to the 6-argument (glibc) form, and
 	record the argument count in GS_GETHOSTBYNAME_R_ARGS.

--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,14 @@
 
 2026-07-07  Todd White <todd.white@thalion.global>
 
+	* Tests/base/NSKVOSupport/kvoToMany.m: Rework to avoid Objective-C
+	blocks and other constructs unavailable with the GNU runtime
+	(property auto-synthesis, the strong attribute, object subscripting),
+	and drop the objc-2 build guard, so the to-many key-value observing
+	tests build and run on the GNU runtime as well.
+
+2026-07-07  Todd White <todd.white@thalion.global>
+
 	* configure.ac: Build the new key-value observing implementation on
 	every Objective-C runtime rather than only the next-generation one.
 	Add --disable-newkvo to fall back to the old implementation.

--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,7 @@
 	that made the affected cases hopeful on the GNU runtime; they now pass.
 
 2026-07-07  Todd White <todd.white@thalion.global>
+
 	* Tests/base/NSKVOSupport/kvoToMany.m: Rework to avoid Objective-C
 	blocks and other constructs unavailable with the GNU runtime
 	(property auto-synthesis, the strong attribute, object subscripting),

--- a/Source/GNUmakefile
+++ b/Source/GNUmakefile
@@ -358,13 +358,13 @@ NSZone.m \
 externs.m \
 objc-load.m 
 
-# We have two implementations for Key Value Observing.
-# One highly-optimised one that depends on libobjc2
-# and the original implementation.
+# We have two implementations for Key Value Observing: the newer one
+# (NSKVOSupport.m/NSKVOSwizzling.m) and the original (NSKeyValueObserving.m).
 ifeq ($(GNUSTEP_BASE_HAVE_NEWKVO), 1)
   BASE_MFILES += \
   NSKVOSupport.m \
   NSKVOSwizzling.m
+  ADDITIONAL_OBJCFLAGS += -DGNUSTEP_BASE_NEW_KVO=1
 else
   BASE_MFILES += \
   NSKeyValueObserving.m

--- a/Source/NSKVOInternal.h
+++ b/Source/NSKVOInternal.h
@@ -54,7 +54,7 @@
 
 #import "GSPrivate.h"
 
-#if defined(__OBJC2__)
+#if defined(__OBJC2__) || defined(GNUSTEP_BASE_NEW_KVO)
 
 #import "GSPThread.h"
 
@@ -70,6 +70,19 @@
 @class _NSKVOKeypathObserver;
 
 @interface _NSKVOKeyObserver : NSObject
+{
+  _NSKVOKeypathObserver *_keypathObserver;
+  _NSKVOKeyObserver     *_restOfKeypathObserver;
+  NSArray               *_dependentObservers;
+  id                     _object;
+  NSString              *_key;
+  NSString              *_restOfKeypath;
+  NSArray               *_affectedObservers;
+  BOOL                   _root;
+  /* Accessed with __atomic_* builtins for portability: GCC does not allow
+   * the _Atomic type qualifier on an Objective-C instance variable. */
+  BOOL                   _isRemoved;
+}
 - (instancetype)initWithObject:(id)object
                keypathObserver:(_NSKVOKeypathObserver *)keypathObserver
                            key:(NSString *)key
@@ -87,6 +100,15 @@
 @end
 
 @interface _NSKVOKeypathObserver : NSObject
+{
+  id                         _object;
+  id                         _observer;
+  NSString                  *_keypath;
+  NSKeyValueObservingOptions _options;
+  void                      *_context;
+  NSMutableDictionary       *_pendingChange;
+  int                        _changeDepth;
+}
 - (instancetype)initWithObject:(id)object
                       observer:(id)observer
                        keyPath:(NSString *)keypath
@@ -103,11 +125,10 @@
 
 @interface _NSKVOObservationInfo : NSObject
 {
-  NSMutableDictionary<NSString *, NSMutableArray<_NSKVOKeyObserver *> *>
-                           *_keyObserverMap;
+  NSMutableDictionary      *_keyObserverMap;
   NSInteger                 _dependencyDepth;
-  NSMutableSet<id>         *_existingDependentKeys;
-  NSMutableSet<id>         *_dependencyAncestorKeys;
+  NSMutableSet             *_existingDependentKeys;
+  NSMutableSet             *_dependencyAncestorKeys;
   gs_mutex_t                _lock;
 }
 - (instancetype)init;

--- a/Source/NSKVOSupport.m
+++ b/Source/NSKVOSupport.m
@@ -46,15 +46,13 @@
 
 #import "common.h"
 #import "NSKVOInternal.h"
-#import <objc/objc-arc.h>
-#import <stdatomic.h>
 
 #import <Foundation/Foundation.h>
 
-typedef void (^DispatchChangeBlock)(_NSKVOKeyObserver *);
+typedef void (*DispatchChangeFunction)(_NSKVOKeyObserver *, void *context);
 
 static NSString *
-_NSKVCSplitKeypath(NSString *keyPath, NSString *__autoreleasing *pRemainder)
+_NSKVCSplitKeypath(NSString *keyPath, NSString **pRemainder)
 {
   NSRange result = [keyPath rangeOfString:@"."];
   if (keyPath.length > 0 && result.location != NSNotFound)
@@ -67,14 +65,18 @@ _NSKVCSplitKeypath(NSString *keyPath, NSString *__autoreleasing *pRemainder)
 }
 
 #pragma region Key Observer
-@interface
-_NSKVOKeyObserver ()
-{
-  _Atomic(BOOL) _isRemoved;
-}
-@end
-
 @implementation _NSKVOKeyObserver
+/* GCC does not perform clang's default (automatic) property synthesis, so the
+ * accessors are synthesized explicitly. */
+@synthesize keypathObserver = _keypathObserver;
+@synthesize restOfKeypathObserver = _restOfKeypathObserver;
+@synthesize dependentObservers = _dependentObservers;
+@synthesize object = _object;
+@synthesize key = _key;
+@synthesize restOfKeypath = _restOfKeypath;
+@synthesize affectedObservers = _affectedObservers;
+@synthesize root = _root;
+
 - (instancetype)initWithObject: (id)object
                keypathObserver: (_NSKVOKeypathObserver *)keypathObserver
                            key: (NSString *)key
@@ -105,25 +107,25 @@ _NSKVOKeyObserver ()
 
 - (BOOL)isRemoved
 {
-  return _isRemoved;
+  return __atomic_load_n(&_isRemoved, __ATOMIC_SEQ_CST);
 }
 
 - (void)setIsRemoved: (BOOL)removed
 {
-  _isRemoved = removed;
+  __atomic_store_n(&_isRemoved, removed, __ATOMIC_SEQ_CST);
 }
 @end
 #pragma endregion
 
 #pragma region Keypath Observer
-@interface
-_NSKVOKeypathObserver ()
-{
-  _Atomic(int) _changeDepth;
-}
-@end
-
 @implementation _NSKVOKeypathObserver
+@synthesize object = _object;
+@synthesize observer = _observer;
+@synthesize keypath = _keypath;
+@synthesize options = _options;
+@synthesize context = _context;
+@synthesize pendingChange = _pendingChange;
+
 - (instancetype) initWithObject: (id)object
                        observer: (id)observer
                         keyPath: (NSString *)keypath
@@ -148,19 +150,14 @@ _NSKVOKeypathObserver ()
   [super dealloc];
 }
 
-- (id) observer
-{
-  return _observer;
-}
-
 - (BOOL) pushWillChange
 {
-  return atomic_fetch_add(&_changeDepth, 1) == 0;
+  return __atomic_fetch_add(&_changeDepth, 1, __ATOMIC_SEQ_CST) == 0;
 }
 
 - (BOOL) popDidChange
 {
-  return atomic_fetch_sub(&_changeDepth, 1) == 1;
+  return __atomic_fetch_sub(&_changeDepth, 1, __ATOMIC_SEQ_CST) == 1;
 }
 @end
 #pragma endregion
@@ -288,35 +285,51 @@ _NSKVOKeypathObserver ()
   GS_MUTEX_UNLOCK(_lock);
 }
 
+/* The per-key observer arrays are stored copy-on-write: they are never
+ * mutated in place once stored, so -observersForKey: can hand out a snapshot
+ * without copying, and a snapshot being enumerated stays valid even if an
+ * observer callback adds or removes observers. */
 - (void) addObserver: (_NSKVOKeyObserver *)observer
 {
-  NSString       *key = observer.key;
-  NSMutableArray *observersForKey = nil;
+  NSString	*key = observer.key;
+  NSArray	*observersForKey;
 
   GS_MUTEX_LOCK(_lock);
   observersForKey = [_keyObserverMap objectForKey:key];
-  if (!observersForKey)
+  if (observersForKey)
     {
-      observersForKey = [NSMutableArray array];
-      [_keyObserverMap setObject:observersForKey forKey:key];
+      observersForKey = [observersForKey arrayByAddingObject:observer];
     }
-  [observersForKey addObject:observer];
+  else
+    {
+      observersForKey = [NSArray arrayWithObject:observer];
+    }
+  [_keyObserverMap setObject:observersForKey forKey:key];
   GS_MUTEX_UNLOCK(_lock);
 }
 
 - (void) removeObserver: (_NSKVOKeyObserver *)observer
 {
-  NSString      	*key;
-  NSMutableArray	*observersForKey;
+  NSString	*key;
+  NSArray	*observersForKey;
 
   GS_MUTEX_LOCK(_lock);
   key = observer.key;
   observersForKey = [_keyObserverMap objectForKey:key];
-  [observersForKey removeObject:observer];
-  observer.isRemoved = true;
-  if (observersForKey.count == 0)
+  [observer setIsRemoved: YES];
+  if (observersForKey != nil)
     {
-      [_keyObserverMap removeObjectForKey:key];
+      NSMutableArray *updated = [[observersForKey mutableCopy] autorelease];
+
+      [updated removeObject:observer];
+      if ([updated count] == 0)
+        {
+          [_keyObserverMap removeObjectForKey:key];
+        }
+      else
+        {
+          [_keyObserverMap setObject:updated forKey:key];
+        }
     }
   GS_MUTEX_UNLOCK(_lock);
 }
@@ -326,7 +339,7 @@ _NSKVOKeypathObserver ()
   NSArray	*result;
 
   GS_MUTEX_LOCK(_lock);
-  result = [[[_keyObserverMap objectForKey:key] copy] autorelease];
+  result = [[[_keyObserverMap objectForKey:key] retain] autorelease];
   GS_MUTEX_UNLOCK(_lock);
   return result;
 }
@@ -368,16 +381,28 @@ static void
 _addNestedObserversAndOptionallyDependents(_NSKVOKeyObserver *keyObserver,
                                            bool               dependents)
 {
-  id                     object = keyObserver.object;
-  NSString              *key = keyObserver.key;
-  _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
-  _NSKVOObservationInfo *observationInfo
-    = (__bridge _NSKVOObservationInfo *) [object observationInfo]
-        ?: _createObservationInfoForObject(object);
+  id                     object;
+  NSString              *key;
+  _NSKVOKeypathObserver *keypathObserver;
+
+  /* Fast path: a simple (non-keypath) observer with no dependents to
+   * reconstruct and no affected observers has no nested work here. */
+  if (!dependents && keyObserver.restOfKeypath == nil
+      && keyObserver.affectedObservers == nil)
+    {
+      return;
+    }
+
+  object = keyObserver.object;
+  key = keyObserver.key;
+  keypathObserver = keyObserver.keypathObserver;
 
   // Aggregate all keys whose values will affect us.
   if (dependents)
     {
+      _NSKVOObservationInfo *observationInfo
+        = (_NSKVOObservationInfo *) [object observationInfo]
+            ?: _createObservationInfoForObject(object);
       // Make sure to retrieve the underlying class of the observee.
       // This is just [object class] for an NSObject derived class.
       // When observing an object through a proxy, we instead use KVC
@@ -486,7 +511,7 @@ _addKeyObserver(_NSKVOKeyObserver *keyObserver)
 
   _NSKVOEnsureKeyWillNotify(object, keyObserver.key);
   observationInfo
-    = (__bridge _NSKVOObservationInfo *) [object observationInfo]
+    = (_NSKVOObservationInfo *) [object observationInfo]
       ?: _createObservationInfoForObject(object);
   [observationInfo addObserver:keyObserver];
 }
@@ -528,6 +553,15 @@ static void
 _removeNestedObserversAndOptionallyDependents(_NSKVOKeyObserver *keyObserver,
   bool dependents)
 {
+  /* Fast path: a simple (non-keypath) observer with no dependents and no
+   * affected observers has no nested work here. */
+  if (!dependents && keyObserver.restOfKeypathObserver == nil
+      && keyObserver.dependentObservers == nil
+      && keyObserver.affectedObservers == nil)
+    {
+      return;
+    }
+
   if (keyObserver.restOfKeypathObserver)
     {
       // Destroy the subpath observer recursively.
@@ -636,7 +670,7 @@ NSObject (NSKeyValueObserving)
 + (void) setKeys: (NSArray *) triggerKeys 
 triggerChangeNotificationsForDependentKey: (NSString *) dependentKey
 {
-  NSMutableDictionary<NSString *, NSSet *> *affectingKeys;
+  NSMutableDictionary *affectingKeys;
   NSSet *triggerKeySet;
 
   affectingKeys = objc_getAssociatedObject(self, KVO_MAP);
@@ -653,7 +687,7 @@ triggerChangeNotificationsForDependentKey: (NSString *) dependentKey
 
 - (void) observeValueForKeyPath: (NSString *)keyPath
                        ofObject: (id)object
-                         change: (NSDictionary<NSString *, id> *)change
+                         change: (NSDictionary *)change
                         context: (void *)context
 {
   [NSException raise: NSInternalInconsistencyException
@@ -667,14 +701,14 @@ static void *s_kvoObservationInfoAssociationKey; // has no value; pointer used
 
 - (void *) observationInfo
 {
-  return (__bridge void *)
+  return (void *)
     objc_getAssociatedObject(self, &s_kvoObservationInfoAssociationKey);
 }
 
 - (void) setObservationInfo: (void *)observationInfo
 {
   objc_setAssociatedObject(self, &s_kvoObservationInfoAssociationKey,
-    (__bridge id) observationInfo,
+    (id) observationInfo,
     OBJC_ASSOCIATION_RETAIN);
 }
 
@@ -699,7 +733,8 @@ static void *s_kvoObservationInfoAssociationKey; // has no value; pointer used
       free(selectorName);
       if ([self respondsToSelector:sel])
         {
-          return ((BOOL(*)(id, SEL)) objc_msgSend)(self, sel);
+          IMP imp = [self methodForSelector:sel];
+          return ((BOOL(*)(id, SEL)) imp)(self, sel);
         }
     }
   return YES;
@@ -818,7 +853,7 @@ static void *s_kvoObservationInfoAssociationKey; // has no value; pointer used
   if ((options & NSKeyValueObservingOptionInitial))
     {
       NSMutableDictionary *change = [NSMutableDictionary
-        dictionaryWithObjectsAndKeys:@(NSKeyValueChangeSetting),
+        dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger: NSKeyValueChangeSetting],
                                      NSKeyValueChangeKindKey, nil];
 
       if ((options & NSKeyValueObservingOptionNew))
@@ -841,7 +876,7 @@ static void *s_kvoObservationInfoAssociationKey; // has no value; pointer used
   _NSKVOObservationInfo *observationInfo;
 
   _removeKeypathObserver(self, keyPath, observer, context);
-  observationInfo = (__bridge _NSKVOObservationInfo *) [self observationInfo];
+  observationInfo = (_NSKVOObservationInfo *) [self observationInfo];
   if ([observationInfo isEmpty])
     {
       // TODO: was nullptr prior
@@ -878,7 +913,7 @@ _valueForPendingChangeAtIndexes(id notifyingObject, NSString *key,
                                 NSDictionary      *pendingChange)
 {
   id          value = nil;
-  NSIndexSet *indexes = pendingChange[NSKeyValueChangeIndexesKey];
+  NSIndexSet *indexes = [pendingChange objectForKey: NSKeyValueChangeIndexesKey];
   if (indexes)
     {
       NSArray  *collection = [notifyingObject valueForKey:key];
@@ -902,11 +937,11 @@ _valueForPendingChangeAtIndexes(id notifyingObject, NSString *key,
 // void TFunc(_NSKVOKeyObserver* keyObserver);
 inline static void
 _dispatchWillChange(id notifyingObject, NSString *key,
-                    DispatchChangeBlock block)
+                    DispatchChangeFunction fn, void *changeContext)
 {
   _NSKVOObservationInfo *observationInfo
-    = (__bridge _NSKVOObservationInfo *) [notifyingObject observationInfo];
-  NSArray<_NSKVOKeyObserver *> *observers = [observationInfo observersForKey:key];
+    = (_NSKVOObservationInfo *) [notifyingObject observationInfo];
+  NSArray *observers = [observationInfo observersForKey:key];
   for (_NSKVOKeyObserver *keyObserver in observers)
     {
       _NSKVOKeypathObserver *keypathObserver;
@@ -922,16 +957,16 @@ _dispatchWillChange(id notifyingObject, NSString *key,
         {
           NSKeyValueObservingOptions options;
 
-          // Call into the lambda function, which will do the actual set-up for
+          // Call into the change function, which does the actual set-up for
           // pendingChanges
-          block(keyObserver);
+          fn(keyObserver, changeContext);
 
           options = keypathObserver.options;
           if (options & NSKeyValueObservingOptionPrior)
             {
               NSMutableDictionary *change = keypathObserver.pendingChange;
 
-              [change setObject:@(YES)
+              [change setObject:[NSNumber numberWithBool: YES]
                          forKey:NSKeyValueChangeNotificationIsPriorKey];
               [keypathObserver.observer
                 observeValueForKeyPath:keypathObserver.keypath
@@ -949,14 +984,19 @@ _dispatchWillChange(id notifyingObject, NSString *key,
 }
 
 static void
-_dispatchDidChange(id notifyingObject, NSString *key, DispatchChangeBlock block)
+_dispatchDidChange(id notifyingObject, NSString *key,
+                   DispatchChangeFunction fn, void *changeContext)
 {
   _NSKVOObservationInfo *observationInfo
-    = (__bridge _NSKVOObservationInfo *) [notifyingObject observationInfo];
-  NSArray<_NSKVOKeyObserver *> *observers =
+    = (_NSKVOObservationInfo *) [notifyingObject observationInfo];
+  NSArray *observers =
     [observationInfo observersForKey:key];
-  for (_NSKVOKeyObserver *keyObserver in [observers reverseObjectEnumerator])
+  NSUInteger index = [observers count];
+  /* Notify in reverse order (a plain index loop avoids allocating an
+   * NSReverseEnumerator on every change). */
+  while (index-- > 0)
     {
+      _NSKVOKeyObserver     *keyObserver = [observers objectAtIndex: index];
       _NSKVOKeypathObserver *keypathObserver;
 
       if (keyObserver.isRemoved)
@@ -977,9 +1017,9 @@ _dispatchDidChange(id notifyingObject, NSString *key, DispatchChangeBlock block)
           NSMutableDictionary 	*change;
           void                	*context;
 
-          // Call into lambda, which will do set-up for finalizing changes
-          // dictionary
-          block(keyObserver);
+          // Call into the change function, which does set-up for finalizing
+          // the changes dictionary
+          fn(keyObserver, changeContext);
 
           observer = keypathObserver.observer;
           keypath = keypathObserver.keypath;
@@ -990,8 +1030,43 @@ _dispatchDidChange(id notifyingObject, NSString *key, DispatchChangeBlock block)
                                   ofObject:rootObject
                                     change:change
                                    context:context];
-          keypathObserver.pendingChange = nil;
+          /* pendingChange is retained for reuse by the next notification
+           * (cleared/repopulated in the change function), not freed here. */
         }
+    }
+}
+
+static void
+_kvoWillSetChange(_NSKVOKeyObserver *keyObserver, void *context)
+{
+  _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
+  NSKeyValueObservingOptions options = keypathObserver.options;
+  NSMutableDictionary *change = keypathObserver.pendingChange;
+
+  /* Reuse the change dictionary across notifications rather than allocating
+   * (and rehashing) a fresh one every time the setter fires. */
+  if (change == nil)
+    {
+      change = [[NSMutableDictionary alloc] initWithCapacity: 3];
+      keypathObserver.pendingChange = change;
+      [change release];
+    }
+  else
+    {
+      [change removeAllObjects];
+    }
+
+  [change setObject:[NSNumber numberWithUnsignedInteger: NSKeyValueChangeSetting]
+             forKey:NSKeyValueChangeKindKey];
+
+  if (options & NSKeyValueObservingOptionOld)
+    {
+      // For to-many mutations, we can't get the old values at indexes
+      // that have not yet been inserted.
+      id        rootObject = keypathObserver.object;
+      NSString *keypath = keypathObserver.keypath;
+      id oldValue = [rootObject valueForKeyPath:keypath] ?: [NSNull null];
+      [change setObject: oldValue forKey: NSKeyValueChangeOldKey];
     }
 }
 
@@ -999,25 +1074,25 @@ _dispatchDidChange(id notifyingObject, NSString *key, DispatchChangeBlock block)
 {
   if ([self observationInfo])
     {
-      _dispatchWillChange(self, key, ^(_NSKVOKeyObserver *keyObserver) {
-        NSMutableDictionary *change =
-          [NSMutableDictionary dictionaryWithObject:@(NSKeyValueChangeSetting)
-                                             forKey:NSKeyValueChangeKindKey];
-        _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
-        NSKeyValueObservingOptions options = keypathObserver.options;
+      _dispatchWillChange(self, key, _kvoWillSetChange, NULL);
+    }
+}
 
-        if (options & NSKeyValueObservingOptionOld)
-          {
-            // For to-many mutations, we can't get the old values at indexes
-            // that have not yet been inserted.
-            id        rootObject = keypathObserver.object;
-            NSString *keypath = keypathObserver.keypath;
-            id oldValue = [rootObject valueForKeyPath:keypath] ?: [NSNull null];
-            change[NSKeyValueChangeOldKey] = oldValue;
-          }
+static void
+_kvoDidSetChange(_NSKVOKeyObserver *keyObserver, void *context)
+{
+  _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
+  NSKeyValueObservingOptions options = keypathObserver.options;
+  NSMutableDictionary       *change = keypathObserver.pendingChange;
+  if ((options & NSKeyValueObservingOptionNew) &&
+      [[change objectForKey: NSKeyValueChangeKindKey] integerValue]
+        != NSKeyValueChangeRemoval)
+    {
+      NSString *keypath = keypathObserver.keypath;
+      id        rootObject = keypathObserver.object;
+      id newValue = [rootObject valueForKeyPath:keypath] ?: [NSNull null];
 
-        keypathObserver.pendingChange = change;
-      });
+      [change setObject: newValue forKey: NSKeyValueChangeNewKey];
     }
 }
 
@@ -1025,68 +1100,100 @@ _dispatchDidChange(id notifyingObject, NSString *key, DispatchChangeBlock block)
 {
   if ([self observationInfo])
     {
-      _dispatchDidChange(self, key, ^(_NSKVOKeyObserver *keyObserver) {
-        _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
-        NSKeyValueObservingOptions options = keypathObserver.options;
-        NSMutableDictionary       *change = keypathObserver.pendingChange;
-        if ((options & NSKeyValueObservingOptionNew) &&
-            [change[NSKeyValueChangeKindKey] integerValue]
-              != NSKeyValueChangeRemoval)
-          {
-            NSString *keypath = keypathObserver.keypath;
-            id        rootObject = keypathObserver.object;
-            id newValue = [rootObject valueForKeyPath:keypath] ?: [NSNull null];
-
-            change[NSKeyValueChangeNewKey] = newValue;
-          }
-      });
+      _dispatchDidChange(self, key, _kvoDidSetChange, NULL);
     }
+}
+
+struct _kvoIndexedWillContext
+{
+  NSKeyValueChange	*kind;
+  NSIndexSet		*indexes;
+  id			 object;
+  NSString		*key;
+};
+static void
+_kvoWillIndexedChange(_NSKVOKeyObserver *keyObserver, void *context)
+{
+  struct _kvoIndexedWillContext *ctx
+    = (struct _kvoIndexedWillContext *) context;
+  NSMutableDictionary   *change = [NSMutableDictionary
+    dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger: *ctx->kind],
+                                 NSKeyValueChangeKindKey,
+                                 ctx->indexes, NSKeyValueChangeIndexesKey,
+                                 nil];
+  _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
+  NSKeyValueObservingOptions options = keypathObserver.options;
+  id                         rootObject = keypathObserver.object;
+
+  // The reference platform does not support to-many mutations on nested
+  // keypaths. We have to treat them as to-one mutations to support
+  // aggregate functions.
+  if (*ctx->kind != NSKeyValueChangeSetting
+      && keyObserver.restOfKeypathObserver)
+    {
+      // This only needs to be done in willChange because didChange
+      // derives from the existing changeset.
+      [change setObject: [NSNumber numberWithUnsignedInteger:
+                           (*ctx->kind = NSKeyValueChangeSetting)]
+                 forKey: NSKeyValueChangeKindKey];
+
+      // Make change Old/New values the entire collection rather than a
+      // to-many change with objectsAtIndexes:
+      [change removeObjectForKey:NSKeyValueChangeIndexesKey];
+    }
+
+  if ((options & NSKeyValueObservingOptionOld)
+      && *ctx->kind != NSKeyValueChangeInsertion)
+    {
+      // For to-many mutations, we can't get the old values at indexes
+      // that have not yet been inserted.
+      NSString *keypath = keypathObserver.keypath;
+      [change setObject: _valueForPendingChangeAtIndexes(ctx->object, ctx->key,
+                           keypath, rootObject, keyObserver, change)
+                 forKey: NSKeyValueChangeOldKey];
+    }
+
+  keypathObserver.pendingChange = change;
 }
 
 - (void) willChange: (NSKeyValueChange)changeKind
     valuesAtIndexes: (NSIndexSet *)indexes
              forKey: (NSString *)key
 {
-  __block NSKeyValueChange kind = changeKind;
+  NSKeyValueChange kind = changeKind;
   if ([self observationInfo])
     {
-      _dispatchWillChange(self, key, ^(_NSKVOKeyObserver *keyObserver) {
-        NSMutableDictionary   *change = [NSMutableDictionary
-          dictionaryWithObjectsAndKeys:@(kind), NSKeyValueChangeKindKey,
-                                       indexes, NSKeyValueChangeIndexesKey,
-                                       nil];
-        _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
-        NSKeyValueObservingOptions options = keypathObserver.options;
-        id                         rootObject = keypathObserver.object;
+      struct _kvoIndexedWillContext ctx = { &kind, indexes, self, key };
+      _dispatchWillChange(self, key, _kvoWillIndexedChange, &ctx);
+    }
+}
 
-        // The reference platform does not support to-many mutations on nested
-        // keypaths. We have to treat them as to-one mutations to support
-        // aggregate functions.
-        if (kind != NSKeyValueChangeSetting
-            && keyObserver.restOfKeypathObserver)
-          {
-            // This only needs to be done in willChange because didChange
-            // derives from the existing changeset.
-            change[NSKeyValueChangeKindKey] = @(kind = NSKeyValueChangeSetting);
+struct _kvoIndexedDidContext
+{
+  id		 object;
+  NSString	*key;
+};
+static void
+_kvoDidIndexedChange(_NSKVOKeyObserver *keyObserver, void *context)
+{
+  struct _kvoIndexedDidContext *ctx
+    = (struct _kvoIndexedDidContext *) context;
+  _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
+  NSKeyValueObservingOptions options = keypathObserver.options;
+  NSMutableDictionary       *change = keypathObserver.pendingChange;
+  if ((options & NSKeyValueObservingOptionNew) &&
+      [[change objectForKey: NSKeyValueChangeKindKey] integerValue]
+        != NSKeyValueChangeRemoval)
+    {
+      // For to-many mutations, we can't get the new values at indexes
+      // that have been deleted.
+      id        rootObject = keypathObserver.object;
+      NSString *keypath = keypathObserver.keypath;
+      id        newValue
+        = _valueForPendingChangeAtIndexes(ctx->object, ctx->key, keypath,
+                                          rootObject, keyObserver, change);
 
-            // Make change Old/New values the entire collection rather than a
-            // to-many change with objectsAtIndexes:
-            [change removeObjectForKey:NSKeyValueChangeIndexesKey];
-          }
-
-        if ((options & NSKeyValueObservingOptionOld)
-            && kind != NSKeyValueChangeInsertion)
-          {
-            // For to-many mutations, we can't get the old values at indexes
-            // that have not yet been inserted.
-            NSString *keypath = keypathObserver.keypath;
-            change[NSKeyValueChangeOldKey]
-              = _valueForPendingChangeAtIndexes(self, key, keypath, rootObject,
-                                                keyObserver, change);
-          }
-
-        keypathObserver.pendingChange = change;
-      });
+      [change setObject: newValue forKey: NSKeyValueChangeNewKey];
     }
 }
 
@@ -1096,25 +1203,8 @@ _dispatchDidChange(id notifyingObject, NSString *key, DispatchChangeBlock block)
 {
   if ([self observationInfo])
     {
-      _dispatchDidChange(self, key, ^(_NSKVOKeyObserver *keyObserver) {
-        _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
-        NSKeyValueObservingOptions options = keypathObserver.options;
-        NSMutableDictionary       *change = keypathObserver.pendingChange;
-        if ((options & NSKeyValueObservingOptionNew) &&
-            [change[NSKeyValueChangeKindKey] integerValue]
-              != NSKeyValueChangeRemoval)
-          {
-            // For to-many mutations, we can't get the new values at indexes
-            // that have been deleted.
-            id        rootObject = keypathObserver.object;
-            NSString *keypath = keypathObserver.keypath;
-            id        newValue
-              = _valueForPendingChangeAtIndexes(self, key, keypath, rootObject,
-                                                keyObserver, change);
-
-            change[NSKeyValueChangeNewKey] = newValue;
-          }
-      });
+      struct _kvoIndexedDidContext ctx = { self, key };
+      _dispatchDidChange(self, key, _kvoDidIndexedChange, &ctx);
     }
 }
 
@@ -1123,63 +1213,120 @@ _dispatchDidChange(id notifyingObject, NSString *key, DispatchChangeBlock block)
 static const NSString *_NSKeyValueChangeOldSetValue
   = @"_NSKeyValueChangeOldSetValue";
 
+struct _kvoSetWillContext
+{
+  NSKeyValueChange		changeKind;
+  NSKeyValueSetMutationKind	mutationKind;
+  NSSet				*objects;
+};
+static void
+_kvoWillSetMutation(_NSKVOKeyObserver *keyObserver, void *context)
+{
+  struct _kvoSetWillContext *ctx = (struct _kvoSetWillContext *) context;
+  NSMutableDictionary *change =
+    [NSMutableDictionary dictionaryWithObject:[NSNumber numberWithUnsignedInteger: ctx->changeKind]
+                                       forKey:NSKeyValueChangeKindKey];
+  _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
+  NSKeyValueObservingOptions options = keypathObserver.options;
+  id                         rootObject = keypathObserver.object;
+  NSString                  *keypath = keypathObserver.keypath;
+
+  NSSet *oldValues = [rootObject valueForKeyPath:keypath];
+  if ((options & NSKeyValueObservingOptionOld)
+      && ctx->changeKind != NSKeyValueChangeInsertion)
+    {
+      NSMutableSet *removed = [NSMutableSet set];
+
+      // The old value should only contain values which are removed from
+      // the original collection.
+      switch (ctx->mutationKind)
+        {
+        case NSKeyValueMinusSetMutation:
+          // The only objects which were removed are those both in
+          // oldValues and objects.
+          for (id obj in oldValues)
+            {
+              if ([ctx->objects containsObject:obj])
+                [removed addObject:obj];
+            }
+          break;
+        case NSKeyValueIntersectSetMutation:
+        case NSKeyValueSetSetMutation:
+        default:
+          // The only objects which were removed are those in oldValues
+          // and NOT in objects.
+          for (id obj in oldValues)
+            {
+              if (![ctx->objects member:obj])
+                [removed addObject:obj];
+            }
+          break;
+        }
+      [change setObject: removed forKey: NSKeyValueChangeOldKey];
+    }
+
+  if (options & NSKeyValueObservingOptionNew)
+    {
+      // Save old value in change dictionary for
+      // didChangeValueForKey:withSetMutation:usingObjects: to use for
+      // determining added objects Only needed if observer wants New
+      // value.  A nil value would previously have been a no-op via the
+      // dictionary subscript, so guard it here.
+      NSSet *oldCopy = [[oldValues copy] autorelease];
+
+      if (oldCopy != nil)
+        {
+          [change setObject: oldCopy forKey: _NSKeyValueChangeOldSetValue];
+        }
+    }
+
+  keypathObserver.pendingChange = change;
+}
+
 - (void)willChangeValueForKey: (NSString *)key
               withSetMutation: (NSKeyValueSetMutationKind)mutationKind
                  usingObjects: (NSSet *)objects
 {
   if ([self observationInfo])
     {
-      NSKeyValueChange changeKind = _changeFromSetMutationKind(mutationKind);
-      _dispatchWillChange(self, key, ^(_NSKVOKeyObserver *keyObserver) {
-        NSMutableDictionary *change =
-          [NSMutableDictionary dictionaryWithObject:@(changeKind)
-                                             forKey:NSKeyValueChangeKindKey];
-        _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
-        NSKeyValueObservingOptions options = keypathObserver.options;
-        id                         rootObject = keypathObserver.object;
-        NSString                  *keypath = keypathObserver.keypath;
+      struct _kvoSetWillContext ctx
+        = { _changeFromSetMutationKind(mutationKind), mutationKind, objects };
+      _dispatchWillChange(self, key, _kvoWillSetMutation, &ctx);
+    }
+}
 
-        NSSet *oldValues = [rootObject valueForKeyPath:keypath];
-        if ((options & NSKeyValueObservingOptionOld)
-            && changeKind != NSKeyValueChangeInsertion)
-          {
-            // The old value should only contain values which are removed from
-            // the original dictionary
-            switch (mutationKind)
-              {
-              case NSKeyValueMinusSetMutation:
-                // The only objects which were removed are those both in
-                // oldValues and objects
-                change[NSKeyValueChangeOldKey] =
-                  [oldValues objectsPassingTest:^(id obj, BOOL *stop) {
-                    return [objects containsObject:obj];
-                  }];
-                break;
-              case NSKeyValueIntersectSetMutation:
-              case NSKeyValueSetSetMutation:
-              default:
-                // The only objects which were removed are those in oldValues
-                // and NOT in objects
-                change[NSKeyValueChangeOldKey] =
-                  [oldValues objectsPassingTest:^BOOL(id obj, BOOL *stop) {
-                    return [objects member:obj] ? NO : YES;
-                  }];
-                break;
-              }
-          }
+struct _kvoSetDidContext
+{
+  NSKeyValueSetMutationKind	mutationKind;
+  NSSet				*objects;
+};
+static void
+_kvoDidSetMutation(_NSKVOKeyObserver *keyObserver, void *context)
+{
+  struct _kvoSetDidContext *ctx = (struct _kvoSetDidContext *) context;
+  _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
+  NSKeyValueChange changeKind = _changeFromSetMutationKind(ctx->mutationKind);
+  NSKeyValueObservingOptions options = keypathObserver.options;
 
-        if (options & NSKeyValueObservingOptionNew)
-          {
-            // Save old value in change dictionary for
-            // didChangeValueForKey:withSetMutation:usingObjects: to use for
-            // determining added objects Only needed if observer wants New
-            // value
-            change[_NSKeyValueChangeOldSetValue] =
-              [[oldValues copy] autorelease];
-          }
+  if ((options & NSKeyValueObservingOptionNew)
+      && changeKind != NSKeyValueChangeRemoval)
+    {
+      // New values only exist for inserting or replacing, not removing
+      NSMutableDictionary *change = keypathObserver.pendingChange;
+      NSSet *oldValues = [change objectForKey: _NSKeyValueChangeOldSetValue];
+      NSMutableSet *added = [NSMutableSet set];
 
-        keypathObserver.pendingChange = change;
-      });
+      // The new value should only contain values which are added to the
+      // original set The only objects added are those in objects but
+      // NOT in oldValues
+      for (id obj in ctx->objects)
+        {
+          if (![oldValues member:obj])
+            [added addObject:obj];
+        }
+
+      [change setObject: added forKey: NSKeyValueChangeNewKey];
+      [change removeObjectForKey:_NSKeyValueChangeOldSetValue];
     }
 }
 
@@ -1189,29 +1336,8 @@ static const NSString *_NSKeyValueChangeOldSetValue
 {
   if ([self observationInfo])
     {
-      _dispatchDidChange(self, key, ^(_NSKVOKeyObserver *keyObserver) {
-        _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
-        NSKeyValueChange changeKind = _changeFromSetMutationKind(mutationKind);
-        NSKeyValueObservingOptions options = keypathObserver.options;
-
-        if ((options & NSKeyValueObservingOptionNew)
-            && changeKind != NSKeyValueChangeRemoval)
-          {
-            // New values only exist for inserting or replacing, not removing
-            NSMutableDictionary *change = keypathObserver.pendingChange;
-            NSSet *oldValues = change[_NSKeyValueChangeOldSetValue];
-            // The new value should only contain values which are added to the
-            // original set The only objects added are those in objects but
-            // NOT in oldValues
-            NSSet *newValue =
-              [objects objectsPassingTest:^BOOL(id obj, BOOL *stop) {
-                return [oldValues member:obj] ? NO : YES;
-              }];
-
-            change[NSKeyValueChangeNewKey] = newValue;
-            [change removeObjectForKey:_NSKeyValueChangeOldSetValue];
-          }
-      });
+      struct _kvoSetDidContext ctx = { mutationKind, objects };
+      _dispatchDidChange(self, key, _kvoDidSetMutation, &ctx);
     }
 }
 @end
@@ -1228,37 +1354,54 @@ NSObject (NSKeyValueObservingPrivate)
   return [self class];
 }
 
+struct _kvoNotifyContext
+{
+  id	oldValue;
+  id	newValue;
+};
+static void
+_kvoWillNotifyChange(_NSKVOKeyObserver *keyObserver, void *context)
+{
+  struct _kvoNotifyContext *ctx = (struct _kvoNotifyContext *) context;
+  NSMutableDictionary *change =
+    [NSMutableDictionary dictionaryWithObject:[NSNumber numberWithUnsignedInteger: NSKeyValueChangeSetting]
+                                       forKey:NSKeyValueChangeKindKey];
+  _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
+  NSKeyValueObservingOptions options = keypathObserver.options;
+
+  if (options & NSKeyValueObservingOptionOld)
+    {
+      [change setObject: (ctx->oldValue ? ctx->oldValue : [NSNull null])
+                 forKey: NSKeyValueChangeOldKey];
+    }
+
+  keypathObserver.pendingChange = change;
+}
+static void
+_kvoDidNotifyChange(_NSKVOKeyObserver *keyObserver, void *context)
+{
+  struct _kvoNotifyContext *ctx = (struct _kvoNotifyContext *) context;
+  _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
+  NSKeyValueObservingOptions options = keypathObserver.options;
+  NSMutableDictionary       *change = keypathObserver.pendingChange;
+  if ((options & NSKeyValueObservingOptionNew) &&
+      [[change objectForKey: NSKeyValueChangeKindKey] integerValue]
+        != NSKeyValueChangeRemoval)
+    {
+      [change setObject: (ctx->newValue ? ctx->newValue : [NSNull null])
+                 forKey: NSKeyValueChangeNewKey];
+    }
+}
+
 - (void)_notifyObserversOfChangeForKey: (NSString *)key
                               oldValue: (id)oldValue
                               newValue: (id)newValue
 {
   if ([self observationInfo])
     {
-      _dispatchWillChange(self, key, ^(_NSKVOKeyObserver *keyObserver) {
-        NSMutableDictionary *change =
-          [NSMutableDictionary dictionaryWithObject:@(NSKeyValueChangeSetting)
-                                             forKey:NSKeyValueChangeKindKey];
-        _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
-        NSKeyValueObservingOptions options = keypathObserver.options;
-
-        if (options & NSKeyValueObservingOptionOld)
-          {
-            change[NSKeyValueChangeOldKey] = oldValue ? oldValue : [NSNull null];
-          }
-
-        keypathObserver.pendingChange = change;
-      });
-      _dispatchDidChange(self, key, ^(_NSKVOKeyObserver *keyObserver) {
-        _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
-        NSKeyValueObservingOptions options = keypathObserver.options;
-        NSMutableDictionary       *change = keypathObserver.pendingChange;
-        if ((options & NSKeyValueObservingOptionNew) &&
-            [change[NSKeyValueChangeKindKey] integerValue]
-              != NSKeyValueChangeRemoval)
-          {
-            change[NSKeyValueChangeNewKey] = newValue ? newValue : [NSNull null];
-          }
-      });
+      struct _kvoNotifyContext ctx = { oldValue, newValue };
+      _dispatchWillChange(self, key, _kvoWillNotifyChange, &ctx);
+      _dispatchDidChange(self, key, _kvoDidNotifyChange, &ctx);
     }
 }
 
@@ -1297,12 +1440,16 @@ NSArray (NSKeyValueObserving)
              options: (NSKeyValueObservingOptions)options
              context: (void *)context
 {
-  [indexes enumerateIndexesUsingBlock:^(NSUInteger index, BOOL *stop) {
-    [[self objectAtIndex:index] addObserver:observer
-                                 forKeyPath:keyPath
-                                    options:options
-                                    context:context];
-  }];
+  NSUInteger index = [indexes firstIndex];
+
+  while (index != NSNotFound)
+    {
+      [[self objectAtIndex:index] addObserver:observer
+                                   forKeyPath:keyPath
+                                      options:options
+                                      context:context];
+      index = [indexes indexGreaterThanIndex:index];
+    }
 }
 
 - (void)removeObserver: (id)observer
@@ -1310,11 +1457,15 @@ NSArray (NSKeyValueObserving)
             forKeyPath: (NSString *)keyPath
                context: (void *)context
 {
-  [indexes enumerateIndexesUsingBlock:^(NSUInteger index, BOOL *stop) {
-    [[self objectAtIndex:index] removeObserver:observer
-                                    forKeyPath:keyPath
-                                       context:context];
-  }];
+  NSUInteger index = [indexes firstIndex];
+
+  while (index != NSNotFound)
+    {
+      [[self objectAtIndex:index] removeObserver:observer
+                                      forKeyPath:keyPath
+                                         context:context];
+      index = [indexes indexGreaterThanIndex:index];
+    }
 }
 
 - (void)removeObserver: (NSObject *)observer

--- a/Source/NSKVOSwizzling.m
+++ b/Source/NSKVOSwizzling.m
@@ -1048,6 +1048,32 @@ GENERATE_PORTABLE_SETDISPATCH(portableMinusSet, NSKeyValueMinusSetMutation);
 GENERATE_PORTABLE_SETDISPATCH(portableIntersectSet,
   NSKeyValueIntersectSetMutation);
 
+/* Dictionary (arbitrary-key) mutation notifiers.  Unlike the setters above,
+ * the key is the runtime argument rather than one derived from the selector,
+ * so the cached key from the lookup is unused. */
+static void
+portableSetObjectForKey(id self, SEL _cmd, id object, NSString *key)
+{
+  NSString	*unused;
+  IMP		orig;
+
+  _NSKVOPortableLookup(self, _cmd, &unused, &orig);
+  [self willChangeValueForKey: key];
+  ((void (*)(id, SEL, id, NSString *)) orig)(self, _cmd, object, key);
+  [self didChangeValueForKey: key];
+}
+static void
+portableRemoveObjectForKey(id self, SEL _cmd, NSString *key)
+{
+  NSString	*unused;
+  IMP		orig;
+
+  _NSKVOPortableLookup(self, _cmd, &unused, &orig);
+  [self willChangeValueForKey: key];
+  ((void (*)(id, SEL, NSString *)) orig)(self, _cmd, key);
+  [self didChangeValueForKey: key];
+}
+
 static SEL
 formatSelector(NSString *format, ...)
 {
@@ -1206,6 +1232,17 @@ _NSKVOEnsureUnorderedCollectionWillNotify(id object, _NSKVOSwizzledClass *info,
     }
 }
 
+/* Make the object notify for arbitrary-key mutations, as NSMutableDictionary
+ * does, by overriding setObject:forKey: and removeObjectForKey: when present. */
+static inline void
+_NSKVOEnsureObjectIsKVOAware(id object, _NSKVOSwizzledClass *info)
+{
+  _NSKVOInstallOverride(object, info, @selector(setObject:forKey:),
+    @"", (IMP) portableSetObjectForKey);
+  _NSKVOInstallOverride(object, info, @selector(removeObjectForKey:),
+    @"", (IMP) portableRemoveObjectForKey);
+}
+
 /* NSKVOEnsureKeyWillNotify is the main entrypoint into the swizzling code. */
 void
 _NSKVOEnsureKeyWillNotify(id object, NSString *key)
@@ -1237,6 +1274,7 @@ _NSKVOEnsureKeyWillNotify(id object, NSString *key)
     _NSKVOEnsureSimpleKeyWillNotify(object, info, key, rawKey);
     _NSKVOEnsureOrderedCollectionWillNotify(object, info, key, rawKey);
     _NSKVOEnsureUnorderedCollectionWillNotify(object, info, key, rawKey);
+    _NSKVOEnsureObjectIsKVOAware(object, info);
     if (object_getClass(object) != info->subclass)
       {
 	object_setClass(object, info->subclass);

--- a/Source/NSKVOSwizzling.m
+++ b/Source/NSKVOSwizzling.m
@@ -42,20 +42,29 @@
   THE SOFTWARE.
 */
 
-/* This Key Value Observing Implementation is tied to libobjc2 */
+/* Key Value Observing setter swizzling.  There are two backends, selected on
+ * the runtime: the libobjc2 path adds notifying methods per object with
+ * object_addMethod_np; other runtimes install them on a per-class
+ * NSKVONotifying_<Class> subclass and switch the observed instance's isa.
+ */
 
 #import "common.h"
 #import "NSKVOInternal.h"
-
-#import <objc/encoding.h>
+#import "GSPThread.h"
 #import <objc/runtime.h>
-#import "NSKVOTypeEncodingCases.h"
-
 #import <Foundation/Foundation.h>
 
 #ifdef WIN32
 #define alloca(x) _alloca(x)
 #endif
+
+#if defined(__OBJC2__) && !defined(NSKVO_FORCE_PORTABLE)
+/* ==================================================================== *
+ *  libobjc2 backend: per-object method addition (object_addMethod_np).  *
+ * ==================================================================== */
+
+#import <objc/encoding.h>
+#import "NSKVOTypeEncodingCases.h"
 
 /* These are defined by the ABI and the runtime. */
 #define ABI_SUPER(obj) (((Class **) obj)[0][1])
@@ -442,12 +451,19 @@ NSKVO$removeObjectForKey$(id self, SEL _cmd, NSString *key)
   static void funcName(id self, SEL _cmd, type val)                            \
   {                                                                            \
     struct objc_super super = {self, ABI_SUPER(self)};                         \
-    NSString         *key = _keyForSelector(self, _cmd);                       \
     void (*imp)(id, SEL, type)                                                 \
       = (void (*)(id, SEL, type)) objc_msg_lookup_super(&super, _cmd);         \
-    [self willChangeValueForKey: key];                                         \
-    imp(self, _cmd, val);                                                      \
-    [self didChangeValueForKey: key];                                          \
+    if (nil == [self observationInfo])                                         \
+      {                                                                        \
+        imp(self, _cmd, val);                                                  \
+        return;                                                                \
+      }                                                                        \
+    {                                                                          \
+      NSString *key = _keyForSelector(self, _cmd);                             \
+      [self willChangeValueForKey: key];                                       \
+      imp(self, _cmd, val);                                                    \
+      [self didChangeValueForKey: key];                                        \
+    }                                                                          \
   }
 
 GENERATE_NOTIFYING_SET_IMPL(notifyingSetImplDouble, double);
@@ -704,3 +720,531 @@ _NSKVOEnsureKeyWillNotify(id object, NSString *key)
 
   free(rawKey);
 }
+
+#else
+/* ==================================================================== *
+ *  Portable backend: per-class NSKVONotifying_<Class> subclass.  Works  *
+ *  on any runtime that provides objc_allocateClassPair/object_setClass  *
+ *  (i.e. without libobjc2's per-object object_addMethod_np).            *
+ * ==================================================================== */
+
+#import "NSKVOTypeEncodingCases.h"
+
+/* Per public class: the notifying subclass, plus (keyed by selector name) the
+ * KVC key and the ORIGINAL setter IMP.  The original IMP is cached at install
+ * time.  Selectors are keyed by NAME: on the GNU runtime they are typed, so
+ * two selectors with the same name need not be the same pointer.
+ */
+@interface _NSKVOSwizzledClass : NSObject
+{
+@public
+  Class		subclass;
+  NSMapTable	*keyForSelector;
+  NSMapTable	*impForSelector;
+}
+@end
+
+/* One recursive lock guards all swizzle setup below.  The setup entry points
+ * nest (ensure -> info-for-class -> install-override), so it must be recursive.
+ * @synchronized is avoided because it requires Objective-C exceptions, which
+ * the GNU runtime does not enable on Windows. */
+static gs_mutex_t kvoSwizzleLock;
+
+@implementation _NSKVOSwizzledClass
++ (void) load
+{
+  GS_MUTEX_INIT_RECURSIVE(kvoSwizzleLock);
+}
+@end
+
+/* -class is overridden on the subclass so the observed object still reports
+ * its public class. */
+static Class
+_NSKVONotifyingClass(id self, SEL _cmd)
+{
+  return class_getSuperclass(object_getClass(self));
+}
+
+/* The public class of an object, seeing through a notifying subclass. */
+static Class
+_NSKVOPublicClass(id object)
+{
+  Class c = object_getClass(object);
+  if (class_getInstanceMethod(c, @selector(class)) != NULL
+    && class_getMethodImplementation(c, @selector(class)) == (IMP) _NSKVONotifyingClass)
+    return class_getSuperclass(c);
+  return c;
+}
+
+static _NSKVOSwizzledClass *
+_NSKVOInfoForClass(Class cls)
+{
+  static void	*assocKey = &assocKey;
+  _NSKVOSwizzledClass *info;
+
+  GS_MUTEX_LOCK(kvoSwizzleLock);
+  {
+    info = (_NSKVOSwizzledClass *) objc_getAssociatedObject(cls, &assocKey);
+    if (nil == info)
+      {
+	char name[256];
+
+	info = [_NSKVOSwizzledClass new];
+	snprintf(name, sizeof(name), "NSKVONotifying_%s", class_getName(cls));
+	info->subclass = objc_allocateClassPair(cls, name, 0);
+	info->keyForSelector = [[NSMapTable alloc] initWithKeyOptions:
+	  NSPointerFunctionsCStringPersonality | NSPointerFunctionsOpaqueMemory
+	  valueOptions: NSPointerFunctionsStrongMemory
+	  | NSPointerFunctionsObjectPersonality capacity: 4];
+	info->impForSelector = [[NSMapTable alloc] initWithKeyOptions:
+	  NSPointerFunctionsCStringPersonality | NSPointerFunctionsOpaqueMemory
+	  valueOptions: NSPointerFunctionsOpaqueMemory
+	  | NSPointerFunctionsOpaquePersonality capacity: 4];
+	class_addMethod(info->subclass, @selector(class),
+	  (IMP) _NSKVONotifyingClass, "#@:");
+	objc_registerClassPair(info->subclass);
+	objc_setAssociatedObject(cls, &assocKey, info, OBJC_ASSOCIATION_RETAIN);
+      }
+  }
+  GS_MUTEX_UNLOCK(kvoSwizzleLock);
+  return info;
+}
+
+/* Look up the KVC key and cached original IMP for a notifying setter call. */
+static inline void
+_NSKVOPortableLookup(id self, SEL _cmd, NSString **key, IMP *orig)
+{
+  _NSKVOSwizzledClass *info
+    = _NSKVOInfoForClass(class_getSuperclass(object_getClass(self)));
+  const char *name = sel_getName(_cmd);
+
+  *key = (NSString *) NSMapGet(info->keyForSelector, name);
+  *orig = (IMP) NSMapGet(info->impForSelector, name);
+}
+
+#define GENERATE_PORTABLE_SET_IMPL(funcName, type)                             \
+  static void funcName(id self, SEL _cmd, type val)                            \
+  {                                                                            \
+    NSString *key;                                                             \
+    IMP       orig;                                                            \
+    _NSKVOPortableLookup(self, _cmd, &key, &orig);                             \
+    [self willChangeValueForKey: key];                                         \
+    ((void (*)(id, SEL, type)) orig)(self, _cmd, val);                         \
+    [self didChangeValueForKey: key];                                          \
+  }
+
+GENERATE_PORTABLE_SET_IMPL(portableSetDouble, double);
+GENERATE_PORTABLE_SET_IMPL(portableSetFloat, float);
+GENERATE_PORTABLE_SET_IMPL(portableSetChar, signed char);
+GENERATE_PORTABLE_SET_IMPL(portableSetInt, int);
+GENERATE_PORTABLE_SET_IMPL(portableSetShort, short);
+GENERATE_PORTABLE_SET_IMPL(portableSetLong, long);
+GENERATE_PORTABLE_SET_IMPL(portableSetLongLong, long long);
+GENERATE_PORTABLE_SET_IMPL(portableSetUnsignedChar, unsigned char);
+GENERATE_PORTABLE_SET_IMPL(portableSetUnsignedInt, unsigned int);
+GENERATE_PORTABLE_SET_IMPL(portableSetUnsignedShort, unsigned short);
+GENERATE_PORTABLE_SET_IMPL(portableSetUnsignedLong, unsigned long);
+GENERATE_PORTABLE_SET_IMPL(portableSetUnsignedLongLong, unsigned long long);
+GENERATE_PORTABLE_SET_IMPL(portableSetObject, id);
+GENERATE_PORTABLE_SET_IMPL(portableSetPointer, void *);
+
+#define KVO_SET_IMPL_CASE(type, name, capitalizedName, encodingChar)           \
+    case encodingChar: {                                                       \
+      newImpl = (IMP) (&portableSet##capitalizedName);                         \
+      break;                                                                   \
+    }
+
+/* Setters whose value is a structure or array are passed on the stack.  We
+ * cannot know the exact prototype, so flatten the words the caller pushed and
+ * re-emit them to the original implementation.  This assumes variadic and
+ * non-variadic calls pass such arguments the same way, which holds on the
+ * platforms we support; the value size is capped (see below) accordingly. */
+static void
+portableVariadicSetImpl(id self, SEL _cmd, ...)
+{
+  NSString		*key;
+  IMP			orig;
+  NSMethodSignature	*sig = [self methodSignatureForSelector: _cmd];
+  size_t		argSz = objc_sizeof_type([sig getArgumentTypeAtIndex: 2]);
+  size_t		nStackArgs = argSz / sizeof(uintptr_t);
+  uintptr_t		*raw = (uintptr_t *) calloc(sizeof(uintptr_t), nStackArgs);
+  va_list		ap;
+  uintptr_t		i;
+
+  _NSKVOPortableLookup(self, _cmd, &key, &orig);
+
+  va_start(ap, _cmd);
+  for (i = 0; i < nStackArgs; ++i)
+    {
+      raw[i] = va_arg(ap, uintptr_t);
+    }
+  va_end(ap);
+
+  [self willChangeValueForKey: key];
+  switch (nStackArgs)
+    {
+      case 1:
+	((void (*)(id, SEL, uintptr_t)) orig)(self, _cmd, raw[0]);
+	break;
+      case 2:
+	((void (*)(id, SEL, uintptr_t, uintptr_t)) orig)
+	  (self, _cmd, raw[0], raw[1]);
+	break;
+      case 3:
+	((void (*)(id, SEL, uintptr_t, uintptr_t, uintptr_t)) orig)
+	  (self, _cmd, raw[0], raw[1], raw[2]);
+	break;
+      case 4:
+	((void (*)(id, SEL, uintptr_t, uintptr_t, uintptr_t, uintptr_t)) orig)
+	  (self, _cmd, raw[0], raw[1], raw[2], raw[3]);
+	break;
+      case 5:
+	((void (*)(id, SEL, uintptr_t, uintptr_t, uintptr_t, uintptr_t,
+	  uintptr_t)) orig)(self, _cmd, raw[0], raw[1], raw[2], raw[3], raw[4]);
+	break;
+      case 6:
+	((void (*)(id, SEL, uintptr_t, uintptr_t, uintptr_t, uintptr_t,
+	  uintptr_t, uintptr_t)) orig)
+	  (self, _cmd, raw[0], raw[1], raw[2], raw[3], raw[4], raw[5]);
+	break;
+      default:
+	NSLog(@"Can't override setter with more than 6"
+	  @" sizeof(long int) stack arguments.");
+	free(raw);
+	return;
+    }
+  [self didChangeValueForKey: key];
+
+  free(raw);
+}
+
+static SEL
+KVCSetterForPropertyName(NSObject *self, const char *key)
+{
+  SEL    sel;
+  size_t len = strlen(key);
+  char  *buf = (char *) alloca(3 + len + 2);
+
+  memcpy(buf + 4, key + 1, len);
+  buf[0] = 's'; buf[1] = 'e'; buf[2] = 't';
+  buf[3] = toupper(key[0]);
+  buf[3 + len] = ':';
+  buf[3 + len + 1] = '\0';
+  sel = sel_getUid(buf);
+  return [self respondsToSelector: sel] ? sel : (SEL) 0;
+}
+
+static char *
+mutableBufferFromString(NSString *string)
+{
+  NSUInteger	lengthInBytes = [string length] + 1;
+  char		*rawKey = (char *) malloc(lengthInBytes);
+
+  [string getCString: rawKey
+	   maxLength: lengthInBytes
+	    encoding: NSASCIIStringEncoding];
+  return rawKey;
+}
+
+/* Indexed (ordered to-many) mutation notifiers. */
+static void
+portableInsertObjectAtIndex(id self, SEL _cmd, id object, NSUInteger index)
+{
+  NSString	*key;
+  IMP		orig;
+  NSIndexSet	*indexes = [NSIndexSet indexSetWithIndex: index];
+
+  _NSKVOPortableLookup(self, _cmd, &key, &orig);
+  [self willChange: NSKeyValueChangeInsertion valuesAtIndexes: indexes forKey: key];
+  ((void (*)(id, SEL, id, NSUInteger)) orig)(self, _cmd, object, index);
+  [self didChange: NSKeyValueChangeInsertion valuesAtIndexes: indexes forKey: key];
+}
+static void
+portableInsertAtIndexes(id self, SEL _cmd, id objects, NSIndexSet *indexes)
+{
+  NSString	*key;
+  IMP		orig;
+
+  _NSKVOPortableLookup(self, _cmd, &key, &orig);
+  [self willChange: NSKeyValueChangeInsertion valuesAtIndexes: indexes forKey: key];
+  ((void (*)(id, SEL, id, NSIndexSet *)) orig)(self, _cmd, objects, indexes);
+  [self didChange: NSKeyValueChangeInsertion valuesAtIndexes: indexes forKey: key];
+}
+static void
+portableRemoveObjectAtIndex(id self, SEL _cmd, NSUInteger index)
+{
+  NSString	*key;
+  IMP		orig;
+  NSIndexSet	*indexes = [NSIndexSet indexSetWithIndex: index];
+
+  _NSKVOPortableLookup(self, _cmd, &key, &orig);
+  [self willChange: NSKeyValueChangeRemoval valuesAtIndexes: indexes forKey: key];
+  ((void (*)(id, SEL, NSUInteger)) orig)(self, _cmd, index);
+  [self didChange: NSKeyValueChangeRemoval valuesAtIndexes: indexes forKey: key];
+}
+static void
+portableRemoveAtIndexes(id self, SEL _cmd, NSIndexSet *indexes)
+{
+  NSString	*key;
+  IMP		orig;
+
+  _NSKVOPortableLookup(self, _cmd, &key, &orig);
+  [self willChange: NSKeyValueChangeRemoval valuesAtIndexes: indexes forKey: key];
+  ((void (*)(id, SEL, NSIndexSet *)) orig)(self, _cmd, indexes);
+  [self didChange: NSKeyValueChangeRemoval valuesAtIndexes: indexes forKey: key];
+}
+static void
+portableReplaceObjectAtIndex(id self, SEL _cmd, NSUInteger index, id object)
+{
+  NSString	*key;
+  IMP		orig;
+  NSIndexSet	*indexes = [NSIndexSet indexSetWithIndex: index];
+
+  _NSKVOPortableLookup(self, _cmd, &key, &orig);
+  [self willChange: NSKeyValueChangeReplacement valuesAtIndexes: indexes forKey: key];
+  ((void (*)(id, SEL, NSUInteger, id)) orig)(self, _cmd, index, object);
+  [self didChange: NSKeyValueChangeReplacement valuesAtIndexes: indexes forKey: key];
+}
+static void
+portableReplaceAtIndexes(id self, SEL _cmd, NSIndexSet *indexes, id objects)
+{
+  NSString	*key;
+  IMP		orig;
+
+  _NSKVOPortableLookup(self, _cmd, &key, &orig);
+  [self willChange: NSKeyValueChangeReplacement valuesAtIndexes: indexes forKey: key];
+  ((void (*)(id, SEL, NSIndexSet *, id)) orig)(self, _cmd, indexes, objects);
+  [self didChange: NSKeyValueChangeReplacement valuesAtIndexes: indexes forKey: key];
+}
+
+/* Unordered (set to-many) mutation notifiers. */
+#define GENERATE_PORTABLE_SETDISPATCH(funcName, Kind)                          \
+  static void funcName(id self, SEL _cmd, NSSet *set)                          \
+  {                                                                            \
+    NSString *key;                                                             \
+    IMP       orig;                                                            \
+    _NSKVOPortableLookup(self, _cmd, &key, &orig);                             \
+    [self willChangeValueForKey: key withSetMutation: Kind usingObjects: set]; \
+    ((void (*)(id, SEL, NSSet *)) orig)(self, _cmd, set);                      \
+    [self didChangeValueForKey: key withSetMutation: Kind usingObjects: set];  \
+  }
+#define GENERATE_PORTABLE_SETDISPATCH_INDIVIDUAL(funcName, Kind)               \
+  static void funcName(id self, SEL _cmd, id obj)                              \
+  {                                                                            \
+    NSSet    *set = [NSSet setWithObject: obj];                                \
+    NSString *key;                                                             \
+    IMP       orig;                                                            \
+    _NSKVOPortableLookup(self, _cmd, &key, &orig);                             \
+    [self willChangeValueForKey: key withSetMutation: Kind usingObjects: set]; \
+    ((void (*)(id, SEL, id)) orig)(self, _cmd, obj);                           \
+    [self didChangeValueForKey: key withSetMutation: Kind usingObjects: set];  \
+  }
+GENERATE_PORTABLE_SETDISPATCH_INDIVIDUAL(portableUnionIndividual,
+  NSKeyValueUnionSetMutation);
+GENERATE_PORTABLE_SETDISPATCH_INDIVIDUAL(portableMinusIndividual,
+  NSKeyValueMinusSetMutation);
+GENERATE_PORTABLE_SETDISPATCH(portableUnionSet, NSKeyValueUnionSetMutation);
+GENERATE_PORTABLE_SETDISPATCH(portableMinusSet, NSKeyValueMinusSetMutation);
+GENERATE_PORTABLE_SETDISPATCH(portableIntersectSet,
+  NSKeyValueIntersectSetMutation);
+
+static SEL
+formatSelector(NSString *format, ...)
+{
+  NSString	*s;
+  SEL		sel;
+  va_list	ap;
+
+  va_start(ap, format);
+  s = [[NSString alloc] initWithFormat: format arguments: ap];
+  sel = NSSelectorFromString([s autorelease]);
+  va_end(ap);
+  return sel;
+}
+
+/* Override sel on the notifying subclass with notifyImp (once per selector),
+ * caching the original implementation and the KVC key for the setter body. */
+static void
+_NSKVOInstallOverride(id object, _NSKVOSwizzledClass *info, SEL sel,
+  NSString *key, IMP notifyImp)
+{
+  Method	m;
+
+  if ((SEL) 0 == sel || ![object respondsToSelector: sel])
+    {
+      return;
+    }
+  GS_MUTEX_LOCK(kvoSwizzleLock);
+  {
+    if (NSMapGet(info->impForSelector, sel_getName(sel)) == NULL)
+      {
+	m = class_getInstanceMethod(_NSKVOPublicClass(object), sel);
+	if (NULL == m)
+	  {
+	    GS_MUTEX_UNLOCK(kvoSwizzleLock);
+	    return;
+	  }
+	NSMapInsert(info->keyForSelector, sel_getName(sel), key);
+	NSMapInsert(info->impForSelector, sel_getName(sel),
+	  (void *) method_getImplementation(m));
+	class_addMethod(info->subclass, sel, notifyImp,
+	  method_getTypeEncoding(m));
+      }
+  }
+  GS_MUTEX_UNLOCK(kvoSwizzleLock);
+}
+
+/* invariant: rawKey has already been capitalized */
+static inline void
+_NSKVOEnsureSimpleKeyWillNotify(id object, _NSKVOSwizzledClass *info,
+  NSString *key, const char *rawKey)
+{
+  SEL			sel = KVCSetterForPropertyName(object, rawKey);
+  Method		originalMethod;
+  const char		*types;
+  const char		*valueType;
+  NSMethodSignature	*sig;
+  IMP			newImpl = NULL;
+
+  if ((SEL) 0 == sel)
+    {
+      return;
+    }
+  originalMethod = class_getInstanceMethod(_NSKVOPublicClass(object), sel);
+  types = method_getTypeEncoding(originalMethod);
+  if (!types)
+    {
+      return;
+    }
+  sig = [NSMethodSignature signatureWithObjCTypes: types];
+  valueType = [sig getArgumentTypeAtIndex: 2];
+
+  switch (valueType[0])
+    {
+      OBJC_APPLY_ALL_TYPE_ENCODINGS(KVO_SET_IMPL_CASE);
+      case '{':
+      case '[':
+	{
+	  size_t valueSize = objc_sizeof_type(valueType);
+
+	  if (valueSize > 6 * sizeof(uintptr_t))
+	    {
+	      [NSException raise: NSInvalidArgumentException
+			  format: @"Class %s key %@ has a value size of %u bytes"
+		@", and cannot currently be KVO compliant.",
+		class_getName(_NSKVOPublicClass(object)), key,
+		(unsigned int) valueSize];
+	    }
+	  newImpl = (IMP) (&portableVariadicSetImpl);
+	  break;
+	}
+      default:
+	[NSException raise: NSInvalidArgumentException
+		    format: @"Class %s is not KVO compliant for key %@.",
+	  class_getName(_NSKVOPublicClass(object)), key];
+	return;
+    }
+  _NSKVOInstallOverride(object, info, sel, key, newImpl);
+}
+
+/* invariant: rawKey has already been capitalized */
+static inline void
+_NSKVOEnsureOrderedCollectionWillNotify(id object, _NSKVOSwizzledClass *info,
+  NSString *key, const char *rawKey)
+{
+  SEL insertOne = formatSelector(@"insertObject:in%sAtIndex:", rawKey);
+  SEL insertMany = formatSelector(@"insert%s:atIndexes:", rawKey);
+
+  if ([object respondsToSelector: insertOne]
+    || [object respondsToSelector: insertMany])
+    {
+      _NSKVOInstallOverride(object, info, insertOne, key,
+	(IMP) portableInsertObjectAtIndex);
+      _NSKVOInstallOverride(object, info, insertMany, key,
+	(IMP) portableInsertAtIndexes);
+      _NSKVOInstallOverride(object, info,
+	formatSelector(@"removeObjectFrom%sAtIndex:", rawKey), key,
+	(IMP) portableRemoveObjectAtIndex);
+      _NSKVOInstallOverride(object, info,
+	formatSelector(@"remove%sAtIndexes:", rawKey), key,
+	(IMP) portableRemoveAtIndexes);
+      _NSKVOInstallOverride(object, info,
+	formatSelector(@"replaceObjectIn%sAtIndex:withObject:", rawKey), key,
+	(IMP) portableReplaceObjectAtIndex);
+      _NSKVOInstallOverride(object, info,
+	formatSelector(@"replace%sAtIndexes:with%s:", rawKey, rawKey), key,
+	(IMP) portableReplaceAtIndexes);
+    }
+}
+
+/* invariant: rawKey has already been capitalized */
+static inline void
+_NSKVOEnsureUnorderedCollectionWillNotify(id object, _NSKVOSwizzledClass *info,
+  NSString *key, const char *rawKey)
+{
+  SEL addOne = formatSelector(@"add%sObject:", rawKey);
+  SEL addMany = formatSelector(@"add%s:", rawKey);
+  SEL removeOne = formatSelector(@"remove%sObject:", rawKey);
+  SEL removeMany = formatSelector(@"remove%s:", rawKey);
+
+  if (([object respondsToSelector: addOne]
+    || [object respondsToSelector: addMany])
+    && ([object respondsToSelector: removeOne]
+      || [object respondsToSelector: removeMany]))
+    {
+      _NSKVOInstallOverride(object, info, addOne, key,
+	(IMP) portableUnionIndividual);
+      _NSKVOInstallOverride(object, info, addMany, key,
+	(IMP) portableUnionSet);
+      _NSKVOInstallOverride(object, info, removeOne, key,
+	(IMP) portableMinusIndividual);
+      _NSKVOInstallOverride(object, info, removeMany, key,
+	(IMP) portableMinusSet);
+      _NSKVOInstallOverride(object, info,
+	formatSelector(@"intersect%s:", rawKey), key,
+	(IMP) portableIntersectSet);
+    }
+}
+
+/* NSKVOEnsureKeyWillNotify is the main entrypoint into the swizzling code. */
+void
+_NSKVOEnsureKeyWillNotify(id object, NSString *key)
+{
+  char			*rawKey;
+  Class			cls;
+  Class			underlyingCls;
+  _NSKVOSwizzledClass	*info;
+
+  cls = [object class];
+  underlyingCls = [object _underlyingClass];
+  /* If cls differs from underlyingCls, object is actually a proxy. */
+  if (cls != underlyingCls)
+    {
+      object = [object valueForKey: @"self"];
+    }
+
+  if (![underlyingCls automaticallyNotifiesObserversForKey: key])
+    {
+      return;
+    }
+
+  rawKey = mutableBufferFromString(key);
+  rawKey[0] = toupper(rawKey[0]);
+
+  GS_MUTEX_LOCK(kvoSwizzleLock);
+  {
+    info = _NSKVOInfoForClass(_NSKVOPublicClass(object));
+    _NSKVOEnsureSimpleKeyWillNotify(object, info, key, rawKey);
+    _NSKVOEnsureOrderedCollectionWillNotify(object, info, key, rawKey);
+    _NSKVOEnsureUnorderedCollectionWillNotify(object, info, key, rawKey);
+    if (object_getClass(object) != info->subclass)
+      {
+	object_setClass(object, info->subclass);
+      }
+  }
+  GS_MUTEX_UNLOCK(kvoSwizzleLock);
+
+  free(rawKey);
+}
+
+#endif

--- a/Tests/base/NSKVOSupport/general.m
+++ b/Tests/base/NSKVOSupport/general.m
@@ -49,15 +49,6 @@
  [NSMutableDictionary dictionaryWithObjectsAndKeys: V, K, nil]
 #define BOXBOOL(V) [NSNumber numberWithBool: (V)]
 
-#if defined (__OBJC2__)
-#define FLAKY_ON_GCC_START
-#define FLAKY_ON_GCC_END
-#else
-#define FLAKY_ON_GCC_START \
-  testHopeful = YES;
-#define FLAKY_ON_GCC_END \
-  testHopeful = NO;
-#endif
 
 @interface TestKVOSelfObserver : NSObject
 {
@@ -565,7 +556,6 @@ static void
 BasicChangeNotification()
 {
   START_SET("BasicChangeNotification");
-  FLAKY_ON_GCC_START
 
   TestKVOObject   *observed = [[[TestKVOObject alloc] init] autorelease];
   TestKVOObserver *observer = [[[TestKVOObserver alloc] init] autorelease];
@@ -601,7 +591,6 @@ BasicChangeNotification()
                           forKeyPath:@"basicObjectProperty"],
             "remove observer should not throw");
 
-  FLAKY_ON_GCC_END
   END_SET("BasicChangeNotification");
 }
 
@@ -709,7 +698,6 @@ static void
 CascadingNotificationWithEmptyLeaf()
 {
   START_SET("CascadingNotificationWithEmptyLeaf");
-  FLAKY_ON_GCC_START
 
   TestKVOObject   *observed = [[[TestKVOObject alloc] init] autorelease];
   TestKVOObserver *observer = [[[TestKVOObserver alloc] init] autorelease];
@@ -763,7 +751,6 @@ CascadingNotificationWithEmptyLeaf()
                           forKeyPath:@"cascadableKey.basicObjectProperty"],
             "remove observer should not throw");
 
-  FLAKY_ON_GCC_END
   END_SET("CascadingNotificationWithEmptyLeaf");
 }
 
@@ -803,7 +790,6 @@ static void
 DependentKeyNotification()
 {
   START_SET("DependentKeyNotification");
-  FLAKY_ON_GCC_START
 
   TestKVOObject   *observed = [[[TestKVOObject alloc] init] autorelease];
   TestKVOObserver *observer = [[[TestKVOObserver alloc] init] autorelease];
@@ -835,7 +821,6 @@ DependentKeyNotification()
              "The new value stored in the change notification should be "
              "!!!Hello!!! (the derived object).");
 
-  FLAKY_ON_GCC_END
   END_SET("DependentKeyNotification");
 }
 
@@ -916,7 +901,6 @@ static void
 DisabledNotification()
 { // No notification for non-notifying keypaths.
   START_SET("DisabledNotification");
-  FLAKY_ON_GCC_START
 
   NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
   TestKVOObject     *observed = [[[TestKVOObject alloc] init] autorelease];
@@ -938,7 +922,6 @@ DisabledNotification()
             "remove observer should not throw");
   PASS_RUNS([pool release], "release should not throw");
 
-  FLAKY_ON_GCC_END
   END_SET("DisabledNotification");
 }
 
@@ -946,7 +929,6 @@ static void
 DisabledInitialNotification()
 { // Initial notification for non-notifying keypaths.
   START_SET("DisabledInitialNotification");
-  FLAKY_ON_GCC_START
 
   NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
   TestKVOObject     *observed = [[[TestKVOObject alloc] init] autorelease];
@@ -977,7 +959,6 @@ DisabledInitialNotification()
             "remove observer should not throw");
   PASS_RUNS([pool release], "release should not throw");
 
-  FLAKY_ON_GCC_END
   END_SET("DisabledInitialNotification");
 }
 
@@ -1018,7 +999,6 @@ DictionaryNotification()
 { // Basic notification on a dictionary, which does not have properties or
   // ivars.
   START_SET("DictionaryNotification");
-  FLAKY_ON_GCC_START
 
   NSMutableDictionary *observed = [NSMutableDictionary dictionary];
   TestKVOObserver     *observer = [[[TestKVOObserver alloc] init] autorelease];
@@ -1058,7 +1038,6 @@ DictionaryNotification()
                           forKeyPath:@"subKey.basicObjectProperty"],
             "remove observer should not throw");
 
-  FLAKY_ON_GCC_END
   END_SET("DictionaryNotification");
 }
 
@@ -1066,7 +1045,6 @@ static void
 BasicDeregistration()
 { // Deregistration test
   START_SET("BasicDeregistration");
-  FLAKY_ON_GCC_START
 
   TestKVOObject   *observed = [[[TestKVOObject alloc] init] autorelease];
   TestKVOObserver *observer = [[[TestKVOObserver alloc] init] autorelease];
@@ -1102,7 +1080,6 @@ BasicDeregistration()
 
   PASS([changes count] == 0, "No changes on cascadableKey.basicObjectProperty should have fired.");
 
-  FLAKY_ON_GCC_END
   END_SET("BasicDeregistration");
 }
 
@@ -1290,7 +1267,6 @@ static void
 SubpathWithMultipleReplacement()
 { // Test key value replacement and re-registration (3)
   START_SET("SubpathWithMultipleReplacement");
-  FLAKY_ON_GCC_START
 
   TestKVOObject   *observed = [[TestKVOObject alloc] init];
   TestKVOObserver *observer = [[TestKVOObserver alloc] init];
@@ -1318,7 +1294,6 @@ SubpathWithMultipleReplacement()
   [observer release];
   [observed release];
 
-  FLAKY_ON_GCC_END
   END_SET("SubpathWithMultipleReplacement");
 }
 
@@ -1429,7 +1404,6 @@ static void
 CyclicDependency()
 { // Make sure that dependency loops don't cause crashes.
   START_SET("CyclicDependency");
-  FLAKY_ON_GCC_START
 
   TestKVOObject   *observed = [[TestKVOObject alloc] init];
   TestKVOObserver *observer = [[TestKVOObserver alloc] init];
@@ -1458,7 +1432,6 @@ CyclicDependency()
   [observer release];
   [observed release];
 
-  FLAKY_ON_GCC_END
   END_SET("CyclicDependency");
 }
 
@@ -1466,7 +1439,6 @@ static void
 ObserveAllProperties()
 {
   START_SET("ObserveAllProperties");
-  FLAKY_ON_GCC_START
 
   TestKVOObject   *observed = AUTORELEASE([[TestKVOObject alloc] init]);
   TestKVOObserver *observer = [[[TestKVOObserver alloc] init] autorelease];
@@ -1526,7 +1498,6 @@ ObserveAllProperties()
             "remove observer for keyPath cascadableKey.basicObjectProperty "
             "should not throw");
 
-  FLAKY_ON_GCC_END
   END_SET("ObserveAllProperties");
 }
 
@@ -1534,7 +1505,6 @@ static void
 RemoveWithoutContext()
 { // Test removal without specifying context.
   START_SET("RemoveWithoutContext");
-  FLAKY_ON_GCC_START
 
   TestKVOObject   *observed = [[TestKVOObject alloc] init];
   TestKVOObserver *observer = [[TestKVOObserver alloc] init];
@@ -1565,7 +1535,6 @@ RemoveWithoutContext()
   [observer release];
   [observed release];
 
-  FLAKY_ON_GCC_END
   END_SET("RemoveWithoutContext");
 }
 
@@ -1573,7 +1542,6 @@ static void
 RemoveWithDuplicateContext()
 { // Test adding duplicate contexts
   START_SET("RemoveWithDuplicateContext");
-  FLAKY_ON_GCC_START
 
   TestKVOObject   *observed = [[[TestKVOObject alloc] init] autorelease];
   TestKVOObserver *observer = [[[TestKVOObserver alloc] init] autorelease];
@@ -1610,7 +1578,6 @@ RemoveWithDuplicateContext()
                              context:(void *) (1)],
             "removing observer forKeyPath=basicObjectProperty does not throw");
 
-  FLAKY_ON_GCC_END
   END_SET("RemoveWithDuplicateContext");
 }
 
@@ -1618,7 +1585,6 @@ static void
 RemoveOneOfTwoObservers()
 { // Test adding duplicate contexts
   START_SET("RemoveOneOfTwoObservers");
-  FLAKY_ON_GCC_START
 
   TestKVOObject   *observed = [[[TestKVOObject alloc] init] autorelease];
   TestKVOObserver *observer = [[[TestKVOObserver alloc] init] autorelease];
@@ -1657,7 +1623,6 @@ RemoveOneOfTwoObservers()
                           forKeyPath:@"basicObjectProperty"],
             "removing observer should not throw");
 
-  FLAKY_ON_GCC_END
   END_SET("RemoveOneOfTwoObservers");
 }
 
@@ -1665,7 +1630,6 @@ static void
 RemoveUnregistered()
 { // Test removing an urnegistered observer
   START_SET("RemoveUnregistered");
-  FLAKY_ON_GCC_START
 
   TestKVOObject   *observed = [[[TestKVOObject alloc] init] autorelease];
   TestKVOObserver *observer = [[[TestKVOObserver alloc] init] autorelease];
@@ -1677,7 +1641,6 @@ RemoveUnregistered()
     (NSString*)nil,
     "Removing an unregistered observer should throw an exception.")
 
-  FLAKY_ON_GCC_END
   END_SET("RemoveUnregistered");
 }
 
@@ -1764,7 +1727,6 @@ static void
 SubpathOnDerivedKey()
 {
   START_SET("SubpathOnDerivedKey");
-  FLAKY_ON_GCC_START
 
   NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
   TestKVOObject     *observed = [[[TestKVOObject alloc] init] autorelease];
@@ -1795,7 +1757,6 @@ SubpathOnDerivedKey()
             "remove observer should not throw");
   PASS_RUNS([pool release], "release pool should not throw");
 
-  FLAKY_ON_GCC_END
   END_SET("SubpathOnDerivedKey");
 }
 
@@ -1803,7 +1764,6 @@ static void
 SubpathWithDerivedKeyBasedOnSubpath()
 {
   START_SET("SubpathWithDerivedKeyBasedOnSubpath");
-  FLAKY_ON_GCC_START
 
   NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
   TestKVOObject     *observed = [[[TestKVOObject alloc] init] autorelease];
@@ -1840,7 +1800,6 @@ SubpathWithDerivedKeyBasedOnSubpath()
             "remove observer should not throw");
   PASS_RUNS([pool release], "release pool should not throw");
 
-  FLAKY_ON_GCC_END
   END_SET("SubpathWithDerivedKeyBasedOnSubpath");
 }
 
@@ -1848,7 +1807,6 @@ static void
 MultipleObservers()
 {
   START_SET("MultipleObservers");
-  FLAKY_ON_GCC_START
 
   NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
   TestKVOObject     *observed = [[[TestKVOObject alloc] init] autorelease];
@@ -1908,7 +1866,6 @@ MultipleObservers()
 
   PASS_RUNS([pool release], "release pool should not throw");
 
-  FLAKY_ON_GCC_END
   END_SET("MultipleObservers");
 }
 
@@ -1916,7 +1873,6 @@ static void
 DerivedKeyDependentOnDerivedKey()
 {
   START_SET("DerivedKeyDependentOnDerivedKey");
-  FLAKY_ON_GCC_START
 
   NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
   TestKVOObject     *observed = [[[TestKVOObject alloc] init] autorelease];
@@ -1954,7 +1910,6 @@ DerivedKeyDependentOnDerivedKey()
             "should not throw");
   PASS_RUNS([pool release], "release pool should not throw");
 
-  FLAKY_ON_GCC_END
   END_SET("DerivedKeyDependentOnDerivedKey");
 }
 
@@ -1962,7 +1917,6 @@ static void
 DerivedKeyDependentOnTwoKeys()
 {
   START_SET("DerivedKeyDependentOnTwoKeys");
-  FLAKY_ON_GCC_START
 
   NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
   TestKVOObject     *observed = [[[TestKVOObject alloc] init] autorelease];
@@ -2000,7 +1954,6 @@ DerivedKeyDependentOnTwoKeys()
             "remove observer should not throw");
   PASS_RUNS([pool release], "release pool should not throw");
 
-  FLAKY_ON_GCC_END
   END_SET("DerivedKeyDependentOnTwoKeys");
 }
 
@@ -2008,7 +1961,6 @@ static void
 DerivedKeyDependentOnTwoSubKeys()
 {
   START_SET("DerivedKeyDependentOnTwoSubKeys");
-  FLAKY_ON_GCC_START
 
   NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
   TestKVOObject     *observed = [[[TestKVOObject alloc] init] autorelease];
@@ -2056,7 +2008,6 @@ DerivedKeyDependentOnTwoSubKeys()
             "remove observer should not throw");
   PASS_RUNS([pool release], "release pool should not throw");
 
-  FLAKY_ON_GCC_END
   END_SET("DerivedKeyDependentOnTwoSubKeys");
 }
 

--- a/Tests/base/NSKVOSupport/kvoToMany.m
+++ b/Tests/base/NSKVOSupport/kvoToMany.m
@@ -383,7 +383,7 @@ typedef void (*PerformBlock)(Observee *);
                      count:(NSUInteger)count
 {
   [_observer setCallbacks:callbacks count:count];
-  @try
+  NS_DURING
     {
       [_observee addObserver:_observer
                   forKeyPath:keyPath
@@ -392,10 +392,11 @@ typedef void (*PerformBlock)(Observee *);
       fn(_observee);
       [_observee removeObserver:_observer forKeyPath:keyPath];
     }
-  @catch (NSException *e)
+  NS_HANDLER
     {
-      NSLog(@"Test failed with exception: %@", e);
+      NSLog(@"Test failed with exception: %@", localException);
     }
+  NS_ENDHANDLER
 }
 
 - (NSUInteger)hits

--- a/Tests/base/NSKVOSupport/kvoToMany.m
+++ b/Tests/base/NSKVOSupport/kvoToMany.m
@@ -48,8 +48,6 @@
 #define BOXF(V) [NSNumber numberWithFloat: (V)]
 #define BOXI(V) [NSNumber numberWithInteger: (V)]
 
-#if defined(__OBJC2__)
-
 @interface Observee : NSObject
 {
   NSMutableArray *_bareArray;
@@ -67,11 +65,8 @@
 
 @end
 
-typedef void (^ChangeCallback)(NSString *, id, NSDictionary *, void *);
-typedef void (^PerformBlock)(Observee *);
-
-#define CHANGE_CB                                                              \
-  ^(NSString * keyPath, id object, NSDictionary * change, void *context)
+typedef void (*ChangeCallback)(NSString *, id, NSDictionary *, void *);
+typedef void (*PerformBlock)(Observee *);
 
 @implementation Observee
 - (instancetype)init
@@ -295,10 +290,14 @@ typedef void (^PerformBlock)(Observee *);
 @end
 
 @interface TestObserver : NSObject
-@property (nonatomic, strong)
-  NSMutableArray<void (^)(NSString *, id, NSDictionary *, void *)> *callbacks;
-@property (nonatomic) NSUInteger                                    hits;
-@property (nonatomic) NSUInteger callbackIndex;
+{
+  ChangeCallback *_callbacks;
+  NSUInteger      _callbackCount;
+  NSUInteger      _callbackIndex;
+  NSUInteger      _hits;
+}
+- (void)setCallbacks:(ChangeCallback *)callbacks count:(NSUInteger)count;
+- (NSUInteger)hits;
 @end
 
 @implementation TestObserver
@@ -307,28 +306,25 @@ typedef void (^PerformBlock)(Observee *);
   self = [super init];
   if (self)
     {
-      _callbacks = [NSMutableArray new];
+      _callbacks = NULL;
+      _callbackCount = 0;
       _hits = 0;
       _callbackIndex = 0;
     }
   return self;
 }
 
-- (void)dealloc
+- (NSUInteger)hits
 {
-  [_callbacks release];
-  [super dealloc];
+  return _hits;
 }
 
-- (void)performBlock:(void (^)(void))block
-  andExpectChangeCallbacks:
-    (NSArray<void (^)(NSString *, id, NSDictionary *, void *)> *)callbacks
+- (void)setCallbacks:(ChangeCallback *)callbacks count:(NSUInteger)count
 {
-  self.hits = 0;
-  self.callbackIndex = 0;
-  ASSIGN(_callbacks, callbacks);
-
-  block();
+  _callbacks = callbacks;
+  _callbackCount = count;
+  _callbackIndex = 0;
+  _hits = 0;
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath
@@ -336,23 +332,27 @@ typedef void (^PerformBlock)(Observee *);
                         change:(NSDictionary *)change
                        context:(void *)context
 {
-  if (self.callbacks.count > 0)
+  if (_callbackCount > 0)
     {
-      void (^callback)(NSString *, id, NSDictionary *, void *)
-        = self.callbacks[_callbackIndex];
-      _callbackIndex = (_callbackIndex + 1) % [_callbacks count];
-      callback(keyPath, object, change, context);
+      _callbacks[_callbackIndex](keyPath, object, change, context);
+      _callbackIndex = (_callbackIndex + 1) % _callbackCount;
     }
-  self.hits++;
+  _hits++;
 }
 @end
 
 @interface                                  TestFacade : NSObject
-@property (nonatomic, strong) Observee     *observee;
-@property (nonatomic, strong) TestObserver *observer;
+{
+  Observee     *_observee;
+  TestObserver *_observer;
+}
+@property (nonatomic, retain) Observee     *observee;
+@property (nonatomic, retain) TestObserver *observer;
 @end
 
 @implementation TestFacade
+@synthesize observee = _observee;
+@synthesize observer = _observer;
 + (instancetype)newWithObservee:(Observee *)observee
 {
   return [[TestFacade alloc] initWithObservee:observee];
@@ -376,40 +376,26 @@ typedef void (^PerformBlock)(Observee *);
   [super dealloc];
 }
 
-- (void)performBlock:(void (^)(Observee *))block
-  andExpectChangeCallbacks:
-    (NSArray<void (^)(NSString *, id, NSDictionary *, void *)> *)callbacks
+- (void)observeKeyPath:(NSString *)keyPath
+           withOptions:(NSKeyValueObservingOptions)options
+          performingFn:(PerformBlock)fn
+  andExpectChangeCallbacks:(ChangeCallback *)callbacks
+                     count:(NSUInteger)count
 {
+  [_observer setCallbacks:callbacks count:count];
   @try
     {
-      [_observer
-                    performBlock:^{
-                      block(_observee);
-                    }
-        andExpectChangeCallbacks:callbacks];
+      [_observee addObserver:_observer
+                  forKeyPath:keyPath
+                     options:options
+                     context:nil];
+      fn(_observee);
+      [_observee removeObserver:_observer forKeyPath:keyPath];
     }
-  @catch (NSException *exception)
+  @catch (NSException *e)
     {
-      NSLog(@"Test failed with exception: %@", exception);
+      NSLog(@"Test failed with exception: %@", e);
     }
-}
-
-- (void)observeKeyPath:(NSString *)keyPath
-               withOptions:(NSKeyValueObservingOptions)options
-           performingBlock:(void (^)(Observee *))block
-  andExpectChangeCallbacks:
-    (NSArray<void (^)(NSString *, id, NSDictionary *, void *)> *)callbacks
-{
-  [self
-                performBlock:^(Observee *observee) {
-                  [observee addObserver:self.observer
-                             forKeyPath:keyPath
-                                options:options
-                                context:nil];
-                  block(observee);
-                  [observee removeObserver:self.observer forKeyPath:keyPath];
-                }
-    andExpectChangeCallbacks:callbacks];
 }
 
 - (NSUInteger)hits
@@ -419,11 +405,17 @@ typedef void (^PerformBlock)(Observee *);
 @end
 
 @interface                                 DummyObject : NSObject
+{
+  NSString    *_name;
+  DummyObject *_sub;
+}
 @property (nonatomic, copy) NSString      *name;
 @property (nonatomic, retain) DummyObject *sub;
 @end
 
 @implementation DummyObject
+@synthesize name = _name;
+@synthesize sub = _sub;
 + (instancetype)makeDummy
 {
   DummyObject *ret = [[DummyObject new] autorelease];
@@ -441,6 +433,24 @@ typedef void (^PerformBlock)(Observee *);
 @end
 
 static void
+bareArray_illegalNotification(NSString *keyPath, id object,
+                              NSDictionary *change, void *context)
+{
+  // Any notification here is illegal.
+  (void)keyPath;
+  (void)object;
+  (void)change;
+  (void)context;
+  PASS(NO, "Any notification here is illegal.");
+}
+
+static void
+bareArray_addObject(Observee *observee)
+{
+  [observee addObjectToBareArray:@"hello"];
+}
+
+static void
 ToMany_NoNotificationOnBareArray()
 {
   START_SET("ToMany_NoNotificationOnBareArray");
@@ -449,15 +459,10 @@ ToMany_NoNotificationOnBareArray()
   TestFacade *facade = [TestFacade newWithObservee:observee];
 
   [facade observeKeyPath:@"bareArray"
-                 withOptions:0
-             performingBlock:^(Observee *observee) {
-               [observee addObjectToBareArray:@"hello"];
-             }
-    andExpectChangeCallbacks: [NSArray arrayWithObjects:
-      ^(NSString *keyPath, id object, NSDictionary *change,
-        void *context) { // Any notification here is illegal.
-        PASS(NO, "Any notification here is illegal.");
-      }, nil]];
+             withOptions:0
+            performingFn:bareArray_addObject
+    andExpectChangeCallbacks:(ChangeCallback[]){bareArray_illegalNotification}
+                       count:1];
   PASS([facade hits] == 0, "No notifications were sent");
 
   [facade release];
@@ -467,76 +472,167 @@ ToMany_NoNotificationOnBareArray()
 }
 
 static void
+notifyingArray_firstInsertCallback(NSString *keyPath, id object,
+                                   NSDictionary *change, void *context)
+{
+  NSIndexSet *indexes;
+
+  (void)keyPath;
+  (void)object;
+  (void)context;
+
+  PASS_EQUAL(BOXI(NSKeyValueChangeInsertion), [change objectForKey: NSKeyValueChangeKindKey],
+             "firstInsertCallback: Change is an insertion");
+
+  indexes = [change objectForKey: NSKeyValueChangeIndexesKey];
+
+  PASS(indexes != nil, "firstInsertCallback: Indexes are not nil");
+  PASS([indexes firstIndex] == 0, "firstInsertCallback: Index is 0");
+
+  if (![[change objectForKey: NSKeyValueChangeNotificationIsPriorKey] boolValue])
+    {
+      PASS_EQUAL(@"object1", [[change objectForKey: NSKeyValueChangeNewKey] objectAtIndex:0],
+                 "firstInsertCallback: New object is 'object1'");
+    }
+}
+
+static void
+notifyingArray_secondInsertCallback(NSString *keyPath, id object,
+                                    NSDictionary *change, void *context)
+{
+  NSIndexSet *indexes;
+
+  (void)keyPath;
+  (void)object;
+  (void)context;
+
+  // We should get an add on index 1 of "object2"
+  PASS_EQUAL(BOXI(NSKeyValueChangeInsertion), [change objectForKey: NSKeyValueChangeKindKey],
+             "secondInsertCallback: Change is an insertion");
+
+  indexes = [change objectForKey: NSKeyValueChangeIndexesKey];
+
+  PASS(indexes != nil, "secondInsertCallback: Indexes are not nil");
+  PASS([indexes firstIndex] == 1, "secondInsertCallback: Index is 1");
+
+  if (![[change objectForKey: NSKeyValueChangeNotificationIsPriorKey] boolValue])
+    {
+      PASS_EQUAL(@"object2", [[change objectForKey: NSKeyValueChangeNewKey] objectAtIndex:0],
+                 "secondInsertCallback: New object is 'object2'");
+    }
+}
+
+static void
+notifyingArray_removalCallback(NSString *keyPath, id object,
+                               NSDictionary *change, void *context)
+{
+  NSIndexSet *indexes;
+
+  (void)keyPath;
+  (void)object;
+  (void)context;
+
+  PASS_EQUAL(BOXI(NSKeyValueChangeRemoval), [change objectForKey: NSKeyValueChangeKindKey],
+             "removalCallback: Change is a removal");
+
+  indexes = [change objectForKey: NSKeyValueChangeIndexesKey];
+
+  PASS(indexes != nil, "removalCallback: Indexes are not nil");
+  PASS([indexes firstIndex] == 0, "removalCallback: Index is 0");
+  if ([[change objectForKey: NSKeyValueChangeNotificationIsPriorKey] boolValue])
+    {
+      PASS_EQUAL(@"object1", [[change objectForKey: NSKeyValueChangeOldKey] objectAtIndex:0],
+                 "removalCallback: Old object is 'object1'");
+    }
+}
+
+static void
+notifyingArray_illegalChangeNotification(NSString *keyPath, id object,
+                                         NSDictionary *change, void *context)
+{
+  (void)keyPath;
+  (void)object;
+  (void)change;
+  (void)context;
+  PASS(NO, "illegalChangeNotification: was called");
+}
+
+static void
+notifyingArray_initialNotificationCallback(NSString *keyPath, id object,
+                                           NSDictionary *change, void *context)
+{
+  NSArray *expectedArray = [NSArray arrayWithObjects: @"object2", nil];
+
+  (void)keyPath;
+  (void)object;
+  (void)context;
+
+  PASS_EQUAL(expectedArray, [change objectForKey: NSKeyValueChangeNewKey],
+    "Initial notification: New array is 'object2'");
+  NSLog(@"Initial notification: New array is %@",
+        [change objectForKey: NSKeyValueChangeNewKey]);
+}
+
+static void
+notifyingArray_manualMutation1(Observee *observee)
+{
+  [observee addObjectToManualArray:@"object1"];
+  [observee addObjectToManualArray:@"object2"];
+  [observee removeObjectFromManualArrayIndex:0];
+}
+
+static void
+notifyingArray_manualMutation2(Observee *observee)
+{
+  [observee addObjectToManualArray:@"object1"];
+  [observee addObjectToManualArray:@"object2"];
+  [observee removeObjectFromManualArrayIndex:0];
+}
+
+static void
+notifyingArray_emptyMutation(Observee *observee)
+{
+  (void)observee;
+}
+
+static void
+notifyingArray_kvcMediatedMutation(Observee *observee)
+{
+  // This array is not assisted with setter functions and should go
+  // through the get/mutate/set codepath.
+  NSMutableArray *mediatedVersionOfArray =
+    [observee mutableArrayValueForKey:@"kvcMediatedArray"];
+  [mediatedVersionOfArray addObject:@"object1"];
+  [mediatedVersionOfArray addObject:@"object2"];
+  [mediatedVersionOfArray removeObjectAtIndex:0];
+}
+
+static void
+notifyingArray_helpersMediatedMutation(Observee *observee)
+{
+  // This array is assisted by setter functions, and should also
+  // dispatch one notification per change.
+  NSMutableArray *mediatedVersionOfArray =
+    [observee mutableArrayValueForKey:@"arrayWithHelpers"];
+  [mediatedVersionOfArray addObject:@"object1"];
+  [mediatedVersionOfArray addObject:@"object2"];
+  [mediatedVersionOfArray removeObjectAtIndex:0];
+}
+
+static void
+notifyingArray_helpersManualMutation(Observee *observee)
+{
+  // This array is assisted by setter functions, and should also
+  // dispatch one notification per change.
+  [observee insertObject:@"object1" inArrayWithHelpersAtIndex:0];
+  [observee insertObject:@"object2" inArrayWithHelpersAtIndex:1];
+  [observee removeObjectFromArrayWithHelpersAtIndex:0];
+}
+
+static void
 ToMany_NotifyingArray()
 {
   START_SET("ToMany_NotifyingArray");
-
-  ChangeCallback firstInsertCallback;
-  ChangeCallback secondInsertCallback;
-  ChangeCallback removalCallback;
-  ChangeCallback illegalChangeNotification;
-
-  /* Callback Setup */
-
-  firstInsertCallback = CHANGE_CB
-  {
-    NSIndexSet *indexes;
-
-    PASS_EQUAL(BOXI(NSKeyValueChangeInsertion), change[NSKeyValueChangeKindKey],
-               "firstInsertCallback: Change is an insertion");
-
-    indexes = change[NSKeyValueChangeIndexesKey];
-
-    PASS(indexes != nil, "firstInsertCallback: Indexes are not nil");
-    PASS([indexes firstIndex] == 0, "firstInsertCallback: Index is 0");
-
-    if (![change[NSKeyValueChangeNotificationIsPriorKey] boolValue])
-      {
-        PASS_EQUAL(@"object1", [change[NSKeyValueChangeNewKey] objectAtIndex:0],
-                   "firstInsertCallback: New object is 'object1'");
-      }
-  };
-
-  secondInsertCallback = CHANGE_CB
-  {
-    NSIndexSet *indexes;
-
-    // We should get an add on index 1 of "object2"
-    PASS_EQUAL(BOXI(NSKeyValueChangeInsertion), change[NSKeyValueChangeKindKey],
-               "secondInsertCallback: Change is an insertion");
-
-    indexes = change[NSKeyValueChangeIndexesKey];
-
-    PASS(indexes != nil, "secondInsertCallback: Indexes are not nil");
-    PASS([indexes firstIndex] == 1, "secondInsertCallback: Index is 1");
-
-    if (![change[NSKeyValueChangeNotificationIsPriorKey] boolValue])
-      {
-        PASS_EQUAL(@"object2", [change[NSKeyValueChangeNewKey] objectAtIndex:0],
-                   "secondInsertCallback: New object is 'object2'");
-      }
-  };
-
-  removalCallback = CHANGE_CB
-  {
-    NSIndexSet *indexes;
-
-    PASS_EQUAL(BOXI(NSKeyValueChangeRemoval), change[NSKeyValueChangeKindKey],
-               "removalCallback: Change is a removal");
-
-    indexes = change[NSKeyValueChangeIndexesKey];
-
-    PASS(indexes != nil, "removalCallback: Indexes are not nil");
-    PASS([indexes firstIndex] == 0, "removalCallback: Index is 0");
-    if ([change[NSKeyValueChangeNotificationIsPriorKey] boolValue])
-      {
-        PASS_EQUAL(@"object1", [change[NSKeyValueChangeOldKey] objectAtIndex:0],
-                   "removalCallback: Old object is 'object1'");
-      }
-  };
-
-  illegalChangeNotification
-    = CHANGE_CB{PASS(NO, "illegalChangeNotification: was called")};
 
   /* Testing manually notifiying array (utilizes add and remove meths in
    * Observee) */
@@ -549,16 +645,14 @@ ToMany_NotifyingArray()
 
   // This test expects one change for each key; any more than that is a failure.
   [facade observeKeyPath:@"manualNotificationArray"
-                 withOptions:NSKeyValueObservingOptionOld
-                             | NSKeyValueObservingOptionNew
-             performingBlock:^(Observee *observee) {
-               [observee addObjectToManualArray:@"object1"];
-               [observee addObjectToManualArray:@"object2"];
-               [observee removeObjectFromManualArrayIndex:0];
-             }
-    andExpectChangeCallbacks: [NSArray arrayWithObjects:
-      firstInsertCallback, secondInsertCallback, removalCallback,
-      illegalChangeNotification, nil]];
+             withOptions:NSKeyValueObservingOptionOld
+                         | NSKeyValueObservingOptionNew
+            performingFn:notifyingArray_manualMutation1
+    andExpectChangeCallbacks:(ChangeCallback[]){
+      notifyingArray_firstInsertCallback, notifyingArray_secondInsertCallback,
+      notifyingArray_removalCallback,
+      notifyingArray_illegalChangeNotification}
+                       count:4];
   PASS([facade hits] == 3, "Three notifications were sent");
 
   [facade release];
@@ -569,18 +663,16 @@ ToMany_NotifyingArray()
   // This test expects two change notifications for each key; any more than that
   // is a failure.
   [facade observeKeyPath:@"manualNotificationArray"
-                 withOptions:NSKeyValueObservingOptionPrior
-                             | NSKeyValueObservingOptionOld
-                             | NSKeyValueObservingOptionNew
-             performingBlock:^(Observee *observee) {
-               [observee addObjectToManualArray:@"object1"];
-               [observee addObjectToManualArray:@"object2"];
-               [observee removeObjectFromManualArrayIndex:0];
-             }
-    andExpectChangeCallbacks: [NSArray arrayWithObjects:
-      firstInsertCallback, firstInsertCallback, secondInsertCallback,
-      secondInsertCallback, removalCallback, removalCallback,
-      illegalChangeNotification, nil]];
+             withOptions:NSKeyValueObservingOptionPrior
+                         | NSKeyValueObservingOptionOld
+                         | NSKeyValueObservingOptionNew
+            performingFn:notifyingArray_manualMutation2
+    andExpectChangeCallbacks:(ChangeCallback[]){
+      notifyingArray_firstInsertCallback, notifyingArray_firstInsertCallback,
+      notifyingArray_secondInsertCallback, notifyingArray_secondInsertCallback,
+      notifyingArray_removalCallback, notifyingArray_removalCallback,
+      notifyingArray_illegalChangeNotification}
+                       count:7];
 
   PASS([facade hits] == 6, "Six notifications were sent");
   PASS_EQUAL(([NSArray arrayWithObjects: @"object2", nil]),
@@ -589,41 +681,26 @@ ToMany_NotifyingArray()
 
   // This test expects one change notification: the initial one. Any more than
   // that is a failure.
-  ChangeCallback initialNotificationCallback = CHANGE_CB
-  {
-    NSArray *expectedArray = [NSArray arrayWithObjects: @"object2", nil];
-    PASS_EQUAL(expectedArray, change[NSKeyValueChangeNewKey],
-      "Initial notification: New array is 'object2'");
-    NSLog(@"Initial notification: New array is %@",
-          change[NSKeyValueChangeNewKey]);
-  };
-
   [facade observeKeyPath:@"manualNotificationArray"
-                 withOptions:NSKeyValueObservingOptionInitial
-                             | NSKeyValueObservingOptionNew
-             performingBlock:^(Observee *observee) {
-             }
-    andExpectChangeCallbacks: [NSArray arrayWithObjects:
-      initialNotificationCallback, illegalChangeNotification, nil
-    ]];
+             withOptions:NSKeyValueObservingOptionInitial
+                         | NSKeyValueObservingOptionNew
+            performingFn:notifyingArray_emptyMutation
+    andExpectChangeCallbacks:(ChangeCallback[]){
+      notifyingArray_initialNotificationCallback,
+      notifyingArray_illegalChangeNotification}
+                       count:2];
   PASS([facade hits] == 1, "One notification was sent");
 
   /* Testing mediated array */
   [facade observeKeyPath:@"kvcMediatedArray"
-                 withOptions:NSKeyValueObservingOptionOld
-                             | NSKeyValueObservingOptionNew
-             performingBlock:^(Observee *observee) {
-               // This array is not assisted with setter functions and should go
-               // through the get/mutate/set codepath.
-               NSMutableArray *mediatedVersionOfArray =
-                 [observee mutableArrayValueForKey:@"kvcMediatedArray"];
-               [mediatedVersionOfArray addObject:@"object1"];
-               [mediatedVersionOfArray addObject:@"object2"];
-               [mediatedVersionOfArray removeObjectAtIndex:0];
-             }
-    andExpectChangeCallbacks: [NSArray arrayWithObjects:
-      firstInsertCallback, secondInsertCallback, removalCallback,
-      illegalChangeNotification, nil]];
+             withOptions:NSKeyValueObservingOptionOld
+                         | NSKeyValueObservingOptionNew
+            performingFn:notifyingArray_kvcMediatedMutation
+    andExpectChangeCallbacks:(ChangeCallback[]){
+      notifyingArray_firstInsertCallback, notifyingArray_secondInsertCallback,
+      notifyingArray_removalCallback,
+      notifyingArray_illegalChangeNotification}
+                       count:4];
   PASS([facade hits] == 3, "Three notifications were sent");
 
   [facade release];
@@ -633,20 +710,14 @@ ToMany_NotifyingArray()
   observee = [Observee new];
   facade = [TestFacade newWithObservee:observee];
   [facade observeKeyPath:@"arrayWithHelpers"
-                 withOptions:NSKeyValueObservingOptionOld
-                             | NSKeyValueObservingOptionNew
-             performingBlock:^(Observee *observee) {
-               // This array is assisted by setter functions, and should also
-               // dispatch one notification per change.
-               NSMutableArray *mediatedVersionOfArray =
-                 [observee mutableArrayValueForKey:@"arrayWithHelpers"];
-               [mediatedVersionOfArray addObject:@"object1"];
-               [mediatedVersionOfArray addObject:@"object2"];
-               [mediatedVersionOfArray removeObjectAtIndex:0];
-             }
-    andExpectChangeCallbacks: [NSArray arrayWithObjects:
-      firstInsertCallback, secondInsertCallback, removalCallback,
-      illegalChangeNotification, nil]];
+             withOptions:NSKeyValueObservingOptionOld
+                         | NSKeyValueObservingOptionNew
+            performingFn:notifyingArray_helpersMediatedMutation
+    andExpectChangeCallbacks:(ChangeCallback[]){
+      notifyingArray_firstInsertCallback, notifyingArray_secondInsertCallback,
+      notifyingArray_removalCallback,
+      notifyingArray_illegalChangeNotification}
+                       count:4];
   PASS([facade hits] == 3, "Three notifications were sent");
 
   [facade release];
@@ -657,18 +728,14 @@ ToMany_NotifyingArray()
   // In this test, we use the same arrayWithHelpers as above, but interact with
   // it manually.
   [facade observeKeyPath:@"arrayWithHelpers"
-                 withOptions:NSKeyValueObservingOptionOld
-                             | NSKeyValueObservingOptionNew
-             performingBlock:^(Observee *observee) {
-               // This array is assisted by setter functions, and should also
-               // dispatch one notification per change.
-               [observee insertObject:@"object1" inArrayWithHelpersAtIndex:0];
-               [observee insertObject:@"object2" inArrayWithHelpersAtIndex:1];
-               [observee removeObjectFromArrayWithHelpersAtIndex:0];
-             }
-    andExpectChangeCallbacks: [NSArray arrayWithObjects:
-      firstInsertCallback, secondInsertCallback, removalCallback,
-      illegalChangeNotification, nil]];
+             withOptions:NSKeyValueObservingOptionOld
+                         | NSKeyValueObservingOptionNew
+            performingFn:notifyingArray_helpersManualMutation
+    andExpectChangeCallbacks:(ChangeCallback[]){
+      notifyingArray_firstInsertCallback, notifyingArray_secondInsertCallback,
+      notifyingArray_removalCallback,
+      notifyingArray_illegalChangeNotification}
+                       count:4];
   PASS([facade hits] == 3, "Three notifications were sent");
 
   [facade release];
@@ -678,44 +745,66 @@ ToMany_NotifyingArray()
 }
 
 static void
+kvcAgg_insertCallbackPost(NSString *keyPath, id object, NSDictionary *change,
+                          void *context)
+{
+  (void)keyPath;
+  (void)object;
+  (void)context;
+
+  PASS([change objectForKey: NSKeyValueChangeNotificationIsPriorKey] == nil, "Post change");
+  PASS_EQUAL(BOXI(NSKeyValueChangeSetting), [change objectForKey: NSKeyValueChangeKindKey],
+             "Change is a setting");
+  PASS_EQUAL(BOXI(0), [change objectForKey: NSKeyValueChangeOldKey], "Old value is 0");
+  PASS_EQUAL(BOXI(1), [change objectForKey: NSKeyValueChangeNewKey], "New value is 1");
+
+  NSIndexSet *indexes = [change objectForKey: NSKeyValueChangeIndexesKey];
+  PASS(indexes == nil, "Indexes are nil");
+}
+
+static void
+kvcAgg_illegalChangeNotification(NSString *keyPath, id object,
+                                 NSDictionary *change, void *context)
+{
+  (void)keyPath;
+  (void)object;
+  (void)change;
+  (void)context;
+  PASS(NO, "illegalChangeNotification");
+}
+
+static void
+kvcAgg_mediatedMutation(Observee *observee)
+{
+  // This array is assisted by setter functions, and should also
+  // dispatch one notification per change.
+  NSMutableArray *mediatedVersionOfArray =
+    [observee mutableArrayValueForKey:@"arrayWithHelpers"];
+  [mediatedVersionOfArray addObject:@"object1"];
+}
+
+static void
+kvcAgg_manualMutation(Observee *observee)
+{
+  // This array is assisted by setter functions, and should also
+  // dispatch one notification per change.
+  [observee insertObject:@"object1" inArrayWithHelpersAtIndex:0];
+}
+
+static void
 ToMany_KVCMediatedArrayWithHelpers_AggregateFunction()
 {
   START_SET("ToMany_KVCMediatedArrayWithHelpers_AggregateFunction");
 
-  ChangeCallback insertCallbackPost;
-  ChangeCallback illegalChangeNotification;
-
-  insertCallbackPost = CHANGE_CB
-  {
-    PASS(change[NSKeyValueChangeNotificationIsPriorKey] == nil, "Post change");
-    PASS_EQUAL(BOXI(NSKeyValueChangeSetting), change[NSKeyValueChangeKindKey],
-               "Change is a setting");
-    PASS_EQUAL(BOXI(0), change[NSKeyValueChangeOldKey], "Old value is 0");
-    PASS_EQUAL(BOXI(1), change[NSKeyValueChangeNewKey], "New value is 1");
-
-    NSIndexSet *indexes = change[NSKeyValueChangeIndexesKey];
-    PASS(indexes == nil, "Indexes are nil");
-  };
-
-  illegalChangeNotification = CHANGE_CB
-  {
-    PASS(NO, "illegalChangeNotification");
-  };
-
   Observee   *observee = [Observee new];
   TestFacade *facade = [TestFacade newWithObservee:observee];
   [facade observeKeyPath:@"arrayWithHelpers.@count"
-                 withOptions:NSKeyValueObservingOptionOld
-                             | NSKeyValueObservingOptionNew
-             performingBlock:^(Observee *observee) {
-               // This array is assisted by setter functions, and should also
-               // dispatch one notification per change.
-               NSMutableArray *mediatedVersionOfArray =
-                 [observee mutableArrayValueForKey:@"arrayWithHelpers"];
-               [mediatedVersionOfArray addObject:@"object1"];
-             }
-    andExpectChangeCallbacks: [NSArray arrayWithObjects:
-      insertCallbackPost, illegalChangeNotification, nil]];
+             withOptions:NSKeyValueObservingOptionOld
+                         | NSKeyValueObservingOptionNew
+            performingFn:kvcAgg_mediatedMutation
+    andExpectChangeCallbacks:(ChangeCallback[]){
+      kvcAgg_insertCallbackPost, kvcAgg_illegalChangeNotification}
+                       count:2];
   PASS([facade hits] == 1, "One notification was sent");
 
   [facade release];
@@ -726,15 +815,12 @@ ToMany_KVCMediatedArrayWithHelpers_AggregateFunction()
   // In this test, we use the same arrayWithHelpers as above, but interact with
   // it manually.
   [facade observeKeyPath:@"arrayWithHelpers.@count"
-                 withOptions:NSKeyValueObservingOptionOld
-                             | NSKeyValueObservingOptionNew
-             performingBlock:^(Observee *observee) {
-               // This array is assisted by setter functions, and should also
-               // dispatch one notification per change.
-               [observee insertObject:@"object1" inArrayWithHelpersAtIndex:0];
-             }
-    andExpectChangeCallbacks: [NSArray arrayWithObjects:
-      insertCallbackPost, illegalChangeNotification, nil]];
+             withOptions:NSKeyValueObservingOptionOld
+                         | NSKeyValueObservingOptionNew
+            performingFn:kvcAgg_manualMutation
+    andExpectChangeCallbacks:(ChangeCallback[]){
+      kvcAgg_insertCallbackPost, kvcAgg_illegalChangeNotification}
+                       count:2];
   PASS([facade hits] == 1, "One notification was sent");
 
   [facade release];
@@ -744,48 +830,62 @@ ToMany_KVCMediatedArrayWithHelpers_AggregateFunction()
 }
 
 static void
+toOne_insertCallbackPost(NSString *keyPath, id object, NSDictionary *change,
+                         void *context)
+{
+  (void)keyPath;
+  (void)object;
+  (void)context;
+
+  PASS([change objectForKey: NSKeyValueChangeNotificationIsPriorKey] == nil, "Post change");
+  PASS_EQUAL(BOXI(NSKeyValueChangeSetting), [change objectForKey: NSKeyValueChangeKindKey],
+             "Change is a setting");
+  NSArray *expectedOld = [NSArray arrayWithObjects: @"Value", nil];
+  PASS_EQUAL(expectedOld, [change objectForKey: NSKeyValueChangeOldKey],
+             "Old value is correct");
+  NSArray *expectedNew = [NSArray arrayWithObjects: @"Value", @"Value", nil];
+  PASS_EQUAL(expectedNew, [change objectForKey: NSKeyValueChangeNewKey],
+             "New value is correct");
+  NSIndexSet *indexes = [change objectForKey: NSKeyValueChangeIndexesKey];
+  PASS(indexes == nil, "Indexes are nil");
+}
+
+static void
+toOne_illegalChangeNotification(NSString *keyPath, id object,
+                                NSDictionary *change, void *context)
+{
+  (void)keyPath;
+  (void)object;
+  (void)change;
+  (void)context;
+  PASS(NO, "illegalChangeNotification");
+}
+
+static void
+toOne_insertMutation(Observee *observee)
+{
+  // This array is assisted by setter functions, and should also
+  // dispatch one notification per change.
+  [observee insertObject:[DummyObject makeDummy]
+    inArrayWithHelpersAtIndex:0];
+}
+
+static void
 ToMany_ToOne_ShouldDowngradeForOrderedObservation()
 {
   START_SET("ToMany_ToOne_ShouldDowngradeForOrderedObservation");
-
-  ChangeCallback insertCallbackPost;
-  ChangeCallback illegalChangeNotification;
-
-  insertCallbackPost = CHANGE_CB
-  {
-    PASS(change[NSKeyValueChangeNotificationIsPriorKey] == nil, "Post change");
-    PASS_EQUAL(BOXI(NSKeyValueChangeSetting), change[NSKeyValueChangeKindKey],
-               "Change is a setting");
-    NSArray *expectedOld = [NSArray arrayWithObjects: @"Value", nil];
-    PASS_EQUAL(expectedOld, change[NSKeyValueChangeOldKey],
-               "Old value is correct");
-    NSArray *expectedNew = [NSArray arrayWithObjects: @"Value", @"Value", nil];
-    PASS_EQUAL(expectedNew, change[NSKeyValueChangeNewKey],
-               "New value is correct");
-    NSIndexSet *indexes = change[NSKeyValueChangeIndexesKey];
-    PASS(indexes == nil, "Indexes are nil");
-  };
-
-  illegalChangeNotification = CHANGE_CB
-  {
-    PASS(NO, "illegalChangeNotification");
-  };
 
   Observee *observee = [Observee new];
   [observee insertObject:[DummyObject makeDummy] inArrayWithHelpersAtIndex:0];
 
   TestFacade *facade = [TestFacade newWithObservee:observee];
   [facade observeKeyPath:@"arrayWithHelpers.name"
-                 withOptions:NSKeyValueObservingOptionOld
-                             | NSKeyValueObservingOptionNew
-             performingBlock:^(Observee *observee) {
-               // This array is assisted by setter functions, and should also
-               // dispatch one notification per change.
-               [observee insertObject:[DummyObject makeDummy]
-                 inArrayWithHelpersAtIndex:0];
-             }
-    andExpectChangeCallbacks: [NSArray arrayWithObjects:
-      insertCallbackPost, illegalChangeNotification, nil]];
+             withOptions:NSKeyValueObservingOptionOld
+                         | NSKeyValueObservingOptionNew
+            performingFn:toOne_insertMutation
+    andExpectChangeCallbacks:(ChangeCallback[]){
+      toOne_insertCallbackPost, toOne_illegalChangeNotification}
+                       count:2];
   PASS([facade hits] == 1, "One notification was sent");
 
   [facade release];
@@ -795,23 +895,37 @@ ToMany_ToOne_ShouldDowngradeForOrderedObservation()
 }
 
 static void
+leak_onlyNewCallback(NSString *keyPath, id object, NSDictionary *change,
+                     void *context)
+{
+  (void)keyPath;
+  (void)object;
+  (void)context;
+  PASS([change objectForKey: NSKeyValueChangeNewKey] != nil, "New key is not nil");
+  PASS([change objectForKey: NSKeyValueChangeOldKey] == nil, "Old key is nil");
+}
+
+static void
+leak_illegalChangeNotification(NSString *keyPath, id object,
+                               NSDictionary *change, void *context)
+{
+  (void)keyPath;
+  (void)object;
+  (void)change;
+  (void)context;
+  PASS(NO, "illegalChangeNotification");
+}
+
+static void
+leak_addMutation(Observee *observee)
+{
+  [observee addObjectToManualArray:@"object1"];
+}
+
+static void
 ObserverInformationShouldNotLeak()
 {
   START_SET("ObserverInformationShouldNotLeak");
-
-  ChangeCallback onlyNewCallback;
-  ChangeCallback illegalChangeNotification;
-
-  onlyNewCallback = CHANGE_CB
-  {
-    PASS(change[NSKeyValueChangeNewKey] != nil, "New key is not nil");
-    PASS(change[NSKeyValueChangeOldKey] == nil, "Old key is nil");
-  };
-
-  illegalChangeNotification = CHANGE_CB
-  {
-    PASS(NO, "illegalChangeNotification");
-  };
 
   Observee   *observee = [Observee new];
   TestFacade *firstFacade = [TestFacade newWithObservee:observee];
@@ -823,11 +937,11 @@ ObserverInformationShouldNotLeak()
 
   TestFacade *facade = [TestFacade newWithObservee:observee];
   [facade observeKeyPath:@"manualNotificationArray"
-                 withOptions:NSKeyValueObservingOptionNew
-             performingBlock:^(Observee *observee) {
-               [observee addObjectToManualArray:@"object1"];
-             }
-    andExpectChangeCallbacks: [NSArray arrayWithObjects: onlyNewCallback, illegalChangeNotification, nil]];
+             withOptions:NSKeyValueObservingOptionNew
+            performingFn:leak_addMutation
+    andExpectChangeCallbacks:(ChangeCallback[]){
+      leak_onlyNewCallback, leak_illegalChangeNotification}
+                       count:2];
 
   [observee removeObserver:firstFacade.observer
                 forKeyPath:@"manualNotificationArray"];
@@ -841,7 +955,7 @@ ObserverInformationShouldNotLeak()
   END_SET("ObserverInformationShouldNotLeak");
 }
 
-static void
+static void __attribute__((unused))
 NSArrayShouldNotBeObservable()
 {
   START_SET("NSArrayShouldNotBeObservable");
@@ -915,15 +1029,15 @@ NSArrayObserveElements()
 
   // First two elements in range for observation so observer will receive
   // changes
-  [observeeArray[0] addObjectToManualArray:@"object1"];
-  [observeeArray[0] addObjectToManualArray:@"object2"];
+  [[observeeArray objectAtIndex: 0] addObjectToManualArray:@"object1"];
+  [[observeeArray objectAtIndex: 0] addObjectToManualArray:@"object2"];
   PASS([observer hits] == 2, "First two elements in range for observation");
 
-  [observeeArray[1] addObjectToManualArray:@"object1"];
+  [[observeeArray objectAtIndex: 1] addObjectToManualArray:@"object1"];
   PASS([observer hits] == 3, "Second element in range for observation");
 
   // But the third element is not so observer will not receive changes
-  [observeeArray[2] addObjectToManualArray:@"object1"];
+  [[observeeArray objectAtIndex: 2] addObjectToManualArray:@"object1"];
   PASS([observer hits] == 3, "Third element not in range for observation");
 
   PASS_RUNS([observeeArray
@@ -936,11 +1050,11 @@ NSArrayObserveElements()
 
   // Removed observer from first element, so modifying it will not report a
   // change
-  [observeeArray[0] addObjectToManualArray:@"object3"];
+  [[observeeArray objectAtIndex: 0] addObjectToManualArray:@"object3"];
   PASS([observer hits] == 3, "First element observer removed");
 
   // But the second element is still being observed
-  [observeeArray[1] addObjectToManualArray:@"object2"];
+  [[observeeArray objectAtIndex: 1] addObjectToManualArray:@"object2"];
   PASS([observer hits] == 4, "Second element still being observed");
 
   PASS_RUNS([observeeArray
@@ -951,7 +1065,7 @@ NSArrayObserveElements()
                         forKeyPath:@"manualNotificationArray"],
             "remove observer from second element");
 
-  [observeeArray[1] addObjectToManualArray:@"object3"];
+  [[observeeArray objectAtIndex: 1] addObjectToManualArray:@"object3"];
   PASS([observer hits] == 4, "Second element observer removed");
 
   [observer release];
@@ -990,117 +1104,209 @@ NSSetShouldNotBeObservable()
   END_SET("NSSetShouldNotBeObservable");
 }
 
+static BOOL setSetChanged = NO;
+
+static void
+setMut_unionCallback(NSString *keyPath, id object, NSDictionary *change,
+                     void *context)
+{
+  (void)keyPath;
+  (void)object;
+  (void)context;
+  PASS_EQUAL(BOXI(NSKeyValueChangeInsertion), [change objectForKey: NSKeyValueChangeKindKey],
+             "Union change is an insertion");
+  NSSet *expected = [NSSet setWithObjects:BOXI(1), BOXI(2), BOXI(3), nil];
+  PASS_EQUAL([change objectForKey: NSKeyValueChangeNewKey], expected,
+             "Union new key is correct");
+  PASS([change objectForKey: NSKeyValueChangeOldKey] == nil, "Union old key is nil");
+}
+
+static void
+setMut_minusCallback(NSString *keyPath, id object, NSDictionary *change,
+                     void *context)
+{
+  (void)keyPath;
+  (void)object;
+  (void)context;
+  PASS_EQUAL([change objectForKey: NSKeyValueChangeKindKey], BOXI(NSKeyValueChangeRemoval),
+             "Minus change is a removal");
+  PASS_EQUAL([change objectForKey: NSKeyValueChangeOldKey], [NSSet setWithObject:BOXI(1)],
+             "Minus old key is correct");
+  PASS([change objectForKey: NSKeyValueChangeNewKey] == nil, "Minus new key is nil");
+}
+
+static void
+setMut_addCallback(NSString *keyPath, id object, NSDictionary *change,
+                   void *context)
+{
+  (void)keyPath;
+  (void)object;
+  (void)context;
+  PASS_EQUAL(BOXI(NSKeyValueChangeInsertion), [change objectForKey: NSKeyValueChangeKindKey],
+             "Add change is an insertion");
+  NSLog(@"Change %@", change);
+  PASS_EQUAL([NSSet setWithObject:BOXI(1)], [change objectForKey: NSKeyValueChangeNewKey],
+             "Add new key is correct");
+  PASS([change objectForKey: NSKeyValueChangeOldKey] == nil, "Add old key is nil");
+}
+
+static void
+setMut_removeCallback(NSString *keyPath, id object, NSDictionary *change,
+                      void *context)
+{
+  (void)keyPath;
+  (void)object;
+  (void)context;
+  PASS_EQUAL(BOXI(NSKeyValueChangeRemoval), [change objectForKey: NSKeyValueChangeKindKey],
+             "Remove change is a removal");
+  PASS_EQUAL([NSSet setWithObject:BOXI(1)], [change objectForKey: NSKeyValueChangeOldKey],
+             "Remove old key is correct");
+  PASS([change objectForKey: NSKeyValueChangeNewKey] == nil, "Remove new key is nil");
+}
+
+static void
+setMut_intersectCallback(NSString *keyPath, id object, NSDictionary *change,
+                         void *context)
+{
+  (void)keyPath;
+  (void)object;
+  (void)context;
+  PASS_EQUAL(BOXI(NSKeyValueChangeRemoval), [change objectForKey: NSKeyValueChangeKindKey],
+             "Intersect change is a removal");
+  NSSet *expected = [NSSet setWithObject:BOXI(3)];
+  PASS_EQUAL(expected, [change objectForKey: NSKeyValueChangeOldKey],
+             "Intersect old key is correct");
+  PASS([change objectForKey: NSKeyValueChangeNewKey] == nil, "Intersect new key is nil");
+}
+
+static void
+setMut_setCallback(NSString *keyPath, id object, NSDictionary *change,
+                   void *context)
+{
+  (void)keyPath;
+  (void)object;
+  (void)context;
+  if (setSetChanged)
+    {
+      PASS_EQUAL(BOXI(NSKeyValueChangeReplacement),
+                 [change objectForKey: NSKeyValueChangeKindKey],
+                 "Set change is a replacement");
+      PASS_EQUAL([NSSet setWithObject:BOXI(2)], [change objectForKey: NSKeyValueChangeOldKey],
+                 "Set old key is correct");
+      PASS_EQUAL([NSSet setWithObject:BOXI(3)], [change objectForKey: NSKeyValueChangeNewKey],
+                 "Set new key is correct");
+    }
+  // setXxx method is not automatically swizzled for observation
+  else
+    {
+      PASS_EQUAL(BOXI(NSKeyValueChangeSetting), [change objectForKey: NSKeyValueChangeKindKey],
+                 "Set change is a setting");
+      PASS_EQUAL([NSSet setWithObject:BOXI(3)], [change objectForKey: NSKeyValueChangeOldKey],
+                 "Set old key is correct");
+      PASS_EQUAL([NSSet setWithObject:BOXI(3)], [change objectForKey: NSKeyValueChangeNewKey],
+                 "Set new key is correct");
+    }
+}
+
+static void
+setMut_illegalChangeNotification(NSString *keyPath, id object,
+                                 NSDictionary *change, void *context)
+{
+  (void)keyPath;
+  (void)object;
+  (void)change;
+  (void)context;
+  PASS(NO, "illegalChangeNotification");
+}
+
+static void
+setMut_helpersMutation(Observee *observee)
+{
+  // This set is assisted by setter functions, and should also
+  // dispatch one notification per change.
+  [observee
+    addSetWithHelpers:[NSSet setWithObjects:BOXI(1), BOXI(2), BOXI(3), nil]];
+  [observee removeSetWithHelpers:[NSSet setWithObject:BOXI(1)]];
+  [observee addSetWithHelpersObject:BOXI(1)];
+  [observee removeSetWithHelpersObject:BOXI(1)];
+  [observee intersectSetWithHelpers:[NSSet setWithObject:BOXI(2)]];
+  [observee setSetWithHelpers:[NSSet setWithObject:BOXI(3)]];
+}
+
+static void
+setMut_kvcMediatedMutation(Observee *observee)
+{
+  // Proxy mutable set should dispatch one notification per change
+  // The proxy set is a NSKeyValueIvarMutableSet
+  NSMutableSet *proxySet =
+    [observee mutableSetValueForKey:@"kvcMediatedSet"];
+  [proxySet unionSet:[NSSet setWithObjects:BOXI(1), BOXI(2), BOXI(3), nil]];
+  [proxySet minusSet:[NSSet setWithObject:BOXI(1)]];
+  [proxySet addObject:BOXI(1)];
+  [proxySet removeObject:BOXI(1)];
+  [proxySet intersectSet:[NSSet setWithObject:BOXI(2)]];
+  [proxySet setSet:[NSSet setWithObject:BOXI(3)]];
+}
+
+static void
+setMut_manualMutation(Observee *observee)
+{
+  // Manually should dispatch one notification per change
+  [observee manualUnionSet:[NSSet setWithObjects:BOXI(1), BOXI(2), BOXI(3), nil]];
+  [observee manualMinusSet:[NSSet setWithObject:BOXI(1)]];
+  [observee manualSetAddObject:BOXI(1)];
+  [observee manualSetRemoveObject:BOXI(1)];
+  [observee manualIntersectSet:[NSSet setWithObject:BOXI(2)]];
+  [observee manualSetSet:[NSSet setWithObject:BOXI(3)]];
+}
+
+static void
+setMut_proxyMutation(Observee *observee)
+{
+  // Proxy mutable set should dispatch one notification per change
+  // The proxy set is a NSKeyValueIvarMutableSet
+  NSMutableSet *proxySet =
+    [observee mutableSetValueForKey:@"proxySet"];
+  [proxySet unionSet:[NSSet setWithObjects:BOXI(1), BOXI(2), BOXI(3), nil]];
+  [proxySet minusSet:[NSSet setWithObject:BOXI(1)]];
+  [proxySet addObject:BOXI(1)];
+  [proxySet removeObject:BOXI(1)];
+  [proxySet intersectSet:[NSSet setWithObject:BOXI(2)]];
+  [proxySet setSet:[NSSet setWithObject:BOXI(3)]];
+}
+
+static void
+setMut_proxyRoMutation(Observee *observee)
+{
+  NSMutableSet *proxySet =
+    [observee mutableSetValueForKey:@"proxyRoSet"];
+  [proxySet unionSet:[NSSet setWithObjects:BOXI(1), BOXI(2), BOXI(3), nil]];
+  [proxySet minusSet:[NSSet setWithObject:BOXI(1)]];
+  [proxySet addObject:BOXI(1)];
+  [proxySet removeObject:BOXI(1)];
+  [proxySet intersectSet:[NSSet setWithObject:BOXI(2)]];
+  [proxySet setSet:[NSSet setWithObject:BOXI(3)]];
+}
+
 static void
 NSSetMutationMethods()
 {
   START_SET("NSSetMutationMethods");
 
-  __block BOOL setSetChanged = NO;
-
-  // Union with @({@(1), @(2), @(3)}) to get @({@(1), @(2), @(3)})
-  ChangeCallback unionCallback = CHANGE_CB
-  {
-    PASS_EQUAL(BOXI(NSKeyValueChangeInsertion), change[NSKeyValueChangeKindKey],
-               "Union change is an insertion");
-    NSSet *expected = [NSSet setWithObjects:BOXI(1), BOXI(2), BOXI(3), nil];
-    PASS_EQUAL(change[NSKeyValueChangeNewKey], expected,
-               "Union new key is correct");
-    PASS(change[NSKeyValueChangeOldKey] == nil, "Union old key is nil");
-  };
-
-  // Minus with @({@(1)}) to get @({@(2), @(3)})
-  ChangeCallback minusCallback = CHANGE_CB
-  {
-    PASS_EQUAL(change[NSKeyValueChangeKindKey], BOXI(NSKeyValueChangeRemoval),
-               "Minus change is a removal");
-    PASS_EQUAL(change[NSKeyValueChangeOldKey], [NSSet setWithObject:BOXI(1)],
-               "Minus old key is correct");
-    PASS(change[NSKeyValueChangeNewKey] == nil, "Minus new key is nil");
-  };
-
-  // Add @(1) to @({@(2), @(3)}) to get @({@(1), @(2), @(3)})
-  ChangeCallback addCallback = CHANGE_CB
-  {
-    PASS_EQUAL(BOXI(NSKeyValueChangeInsertion), change[NSKeyValueChangeKindKey],
-               "Add change is an insertion");
-    NSLog(@"Change %@", change);
-    PASS_EQUAL([NSSet setWithObject:BOXI(1)], change[NSKeyValueChangeNewKey],
-               "Add new key is correct");
-    PASS(change[NSKeyValueChangeOldKey] == nil, "Add old key is nil");
-  };
-
-  // Remove @(1) from @({@(1), @(2), @(3)}) to get @({@(2), @(3)})
-  ChangeCallback removeCallback = CHANGE_CB
-  {
-    PASS_EQUAL(BOXI(NSKeyValueChangeRemoval), change[NSKeyValueChangeKindKey],
-               "Remove change is a removal");
-    PASS_EQUAL([NSSet setWithObject:BOXI(1)], change[NSKeyValueChangeOldKey],
-               "Remove old key is correct");
-    PASS(change[NSKeyValueChangeNewKey] == nil, "Remove new key is nil");
-  };
-
-  // Intersect with @({@(2)}) to get @({2})
-  ChangeCallback intersectCallback = CHANGE_CB
-  {
-    PASS_EQUAL(BOXI(NSKeyValueChangeRemoval), change[NSKeyValueChangeKindKey],
-               "Intersect change is a removal");
-    NSSet *expected = [NSSet setWithObject:BOXI(3)];
-    PASS_EQUAL(expected, change[NSKeyValueChangeOldKey],
-               "Intersect old key is correct");
-    PASS(change[NSKeyValueChangeNewKey] == nil, "Intersect new key is nil");
-  };
-
-  // Set with @({@(3)}) to get @({@(3)})
-  ChangeCallback setCallback = CHANGE_CB
-  {
-    if (setSetChanged)
-      {
-        PASS_EQUAL(BOXI(NSKeyValueChangeReplacement),
-                   change[NSKeyValueChangeKindKey],
-                   "Set change is a replacement");
-        PASS_EQUAL([NSSet setWithObject:BOXI(2)], change[NSKeyValueChangeOldKey],
-                   "Set old key is correct");
-        PASS_EQUAL([NSSet setWithObject:BOXI(3)], change[NSKeyValueChangeNewKey],
-                   "Set new key is correct");
-      }
-    // setXxx method is not automatically swizzled for observation
-    else
-      {
-        PASS_EQUAL(BOXI(NSKeyValueChangeSetting), change[NSKeyValueChangeKindKey],
-                   "Set change is a setting");
-        PASS_EQUAL([NSSet setWithObject:BOXI(3)], change[NSKeyValueChangeOldKey],
-                   "Set old key is correct");
-        PASS_EQUAL([NSSet setWithObject:BOXI(3)], change[NSKeyValueChangeNewKey],
-                   "Set new key is correct");
-      }
-  };
-
-  ChangeCallback illegalChangeNotification = CHANGE_CB
-  {
-    PASS(NO, "illegalChangeNotification");
-  };
+  setSetChanged = NO;
 
   Observee   *observee = [Observee new];
   TestFacade *facade = [TestFacade newWithObservee:observee];
 
   [facade observeKeyPath:@"setWithHelpers"
-                 withOptions:NSKeyValueObservingOptionNew
-                             | NSKeyValueObservingOptionOld
-             performingBlock:^(Observee *observee) {
-               // This set is assisted by setter functions, and should also
-               // dispatch one notification per change.
-               [observee
-                 addSetWithHelpers:[NSSet setWithObjects:BOXI(1), BOXI(2), BOXI(3), nil]];
-               [observee removeSetWithHelpers:[NSSet setWithObject:BOXI(1)]];
-               [observee addSetWithHelpersObject:BOXI(1)];
-               [observee removeSetWithHelpersObject:BOXI(1)];
-               [observee intersectSetWithHelpers:[NSSet setWithObject:BOXI(2)]];
-               [observee setSetWithHelpers:[NSSet setWithObject:BOXI(3)]];
-             }
-    andExpectChangeCallbacks: [NSArray arrayWithObjects:
-      unionCallback, minusCallback, addCallback, removeCallback,
-      intersectCallback, setCallback, illegalChangeNotification, nil
-    ]];
+             withOptions:NSKeyValueObservingOptionNew
+                         | NSKeyValueObservingOptionOld
+            performingFn:setMut_helpersMutation
+    andExpectChangeCallbacks:(ChangeCallback[]){
+      setMut_unionCallback, setMut_minusCallback, setMut_addCallback,
+      setMut_removeCallback, setMut_intersectCallback, setMut_setCallback,
+      setMut_illegalChangeNotification}
+                       count:7];
   PASS([facade hits] == 6, "All six notifications were sent (setWithHelpers)");
 
   setSetChanged = YES;
@@ -1112,23 +1318,14 @@ NSSetMutationMethods()
   facade = [TestFacade newWithObservee:observee];
 
   [facade observeKeyPath:@"kvcMediatedSet"
-                 withOptions:NSKeyValueObservingOptionNew
-                             | NSKeyValueObservingOptionOld
-             performingBlock:^(Observee *observee) {
-               // Proxy mutable set should dispatch one notification per change
-               // The proxy set is a NSKeyValueIvarMutableSet
-               NSMutableSet *proxySet =
-                 [observee mutableSetValueForKey:@"kvcMediatedSet"];
-               [proxySet unionSet:[NSSet setWithObjects:BOXI(1), BOXI(2), BOXI(3), nil]];
-               [proxySet minusSet:[NSSet setWithObject:BOXI(1)]];
-               [proxySet addObject:BOXI(1)];
-               [proxySet removeObject:BOXI(1)];
-               [proxySet intersectSet:[NSSet setWithObject:BOXI(2)]];
-               [proxySet setSet:[NSSet setWithObject:BOXI(3)]];
-             }
-    andExpectChangeCallbacks: [NSArray arrayWithObjects:
-      unionCallback, minusCallback, addCallback, removeCallback,
-      intersectCallback, setCallback, illegalChangeNotification, nil]];
+             withOptions:NSKeyValueObservingOptionNew
+                         | NSKeyValueObservingOptionOld
+            performingFn:setMut_kvcMediatedMutation
+    andExpectChangeCallbacks:(ChangeCallback[]){
+      setMut_unionCallback, setMut_minusCallback, setMut_addCallback,
+      setMut_removeCallback, setMut_intersectCallback, setMut_setCallback,
+      setMut_illegalChangeNotification}
+                       count:7];
   PASS([facade hits] == 6, "All six notifications were sent (kvcMediatedSet)");
 
   [observee release];
@@ -1138,64 +1335,42 @@ NSSetMutationMethods()
   facade = [TestFacade newWithObservee:observee];
 
   [facade observeKeyPath:@"manualNotificationSet"
-                 withOptions:NSKeyValueObservingOptionNew
-                             | NSKeyValueObservingOptionOld
-             performingBlock:^(Observee *observee) {
-               // Manually should dispatch one notification per change
-               [observee manualUnionSet:[NSSet setWithObjects:BOXI(1), BOXI(2), BOXI(3), nil]];
-               [observee manualMinusSet:[NSSet setWithObject:BOXI(1)]];
-               [observee manualSetAddObject:BOXI(1)];
-               [observee manualSetRemoveObject:BOXI(1)];
-               [observee manualIntersectSet:[NSSet setWithObject:BOXI(2)]];
-               [observee manualSetSet:[NSSet setWithObject:BOXI(3)]];
-             }
-    andExpectChangeCallbacks: [NSArray arrayWithObjects:
-      unionCallback, minusCallback, addCallback, removeCallback,
-      intersectCallback, setCallback, illegalChangeNotification, nil]];
+             withOptions:NSKeyValueObservingOptionNew
+                         | NSKeyValueObservingOptionOld
+            performingFn:setMut_manualMutation
+    andExpectChangeCallbacks:(ChangeCallback[]){
+      setMut_unionCallback, setMut_minusCallback, setMut_addCallback,
+      setMut_removeCallback, setMut_intersectCallback, setMut_setCallback,
+      setMut_illegalChangeNotification}
+                       count:7];
   PASS([facade hits] == 6,
        "All six notifications were sent (manualNotificationSet)");
 
   /* Indirect proxy (add<key>Object, etc.) to test
    * NSKeyValueFastMutableSet */
   [facade observeKeyPath:@"proxySet"
-                 withOptions:NSKeyValueObservingOptionNew
-                             | NSKeyValueObservingOptionOld
-             performingBlock:^(Observee *observee) {
-               // Proxy mutable set should dispatch one notification per change
-               // The proxy set is a NSKeyValueIvarMutableSet
-               NSMutableSet *proxySet =
-                 [observee mutableSetValueForKey:@"proxySet"];
-               [proxySet unionSet:[NSSet setWithObjects:BOXI(1), BOXI(2), BOXI(3), nil]];
-               [proxySet minusSet:[NSSet setWithObject:BOXI(1)]];
-               [proxySet addObject:BOXI(1)];
-               [proxySet removeObject:BOXI(1)];
-               [proxySet intersectSet:[NSSet setWithObject:BOXI(2)]];
-               [proxySet setSet:[NSSet setWithObject:BOXI(3)]];
-             }
-    andExpectChangeCallbacks: [NSArray arrayWithObjects:
-      unionCallback, minusCallback, addCallback, removeCallback,
-      intersectCallback, setCallback, illegalChangeNotification, nil]];
+             withOptions:NSKeyValueObservingOptionNew
+                         | NSKeyValueObservingOptionOld
+            performingFn:setMut_proxyMutation
+    andExpectChangeCallbacks:(ChangeCallback[]){
+      setMut_unionCallback, setMut_minusCallback, setMut_addCallback,
+      setMut_removeCallback, setMut_intersectCallback, setMut_setCallback,
+      setMut_illegalChangeNotification}
+                       count:7];
   PASS([facade hits] == 6, "All six notifications were sent (proxySet)");
 
   /* Indirect slow proxy via NSInvocation to test NSKeyValueSlowMutableSet */
   /* Indirect proxy (add<key>Object, etc.) to test
    * NSKeyValueFastMutableSet */
   [facade observeKeyPath:@"proxyRoSet"
-                 withOptions:NSKeyValueObservingOptionNew
-                             | NSKeyValueObservingOptionOld
-             performingBlock:^(Observee *observee) {
-               NSMutableSet *proxySet =
-                 [observee mutableSetValueForKey:@"proxyRoSet"];
-               [proxySet unionSet:[NSSet setWithObjects:BOXI(1), BOXI(2), BOXI(3), nil]];
-               [proxySet minusSet:[NSSet setWithObject:BOXI(1)]];
-               [proxySet addObject:BOXI(1)];
-               [proxySet removeObject:BOXI(1)];
-               [proxySet intersectSet:[NSSet setWithObject:BOXI(2)]];
-               [proxySet setSet:[NSSet setWithObject:BOXI(3)]];
-             }
-    andExpectChangeCallbacks: [NSArray arrayWithObjects:
-      unionCallback, minusCallback, addCallback, removeCallback,
-      intersectCallback, setCallback, illegalChangeNotification, nil]];
+             withOptions:NSKeyValueObservingOptionNew
+                         | NSKeyValueObservingOptionOld
+            performingFn:setMut_proxyRoMutation
+    andExpectChangeCallbacks:(ChangeCallback[]){
+      setMut_unionCallback, setMut_minusCallback, setMut_addCallback,
+      setMut_removeCallback, setMut_intersectCallback, setMut_setCallback,
+      setMut_illegalChangeNotification}
+                       count:7];
   PASS([facade hits] == 6, "All six notifications were sent (proxySet)");
 
   [observee release];
@@ -1227,20 +1402,3 @@ main(int argc, char *argv[])
 
   return 0;
 }
-
-#else
-
-int
-main(int argc, const char *argv[])
-{
-  NSAutoreleasePool *pool = [NSAutoreleasePool new];
-
-  NSLog(@"This test requires an Objective-C 2.0 runtime and is not supported "
-        @"on this platform.");
-
-  DESTROY(pool);
-
-  return 0;
-}
-
-#endif

--- a/Tests/base/NSKVOSupport/newoldvalues.m
+++ b/Tests/base/NSKVOSupport/newoldvalues.m
@@ -2,15 +2,6 @@
 #import "ObjectTesting.h"
 #import "Testing.h"
 
-#if defined (__OBJC2__)
-#define FLAKY_ON_GCC_START
-#define FLAKY_ON_GCC_END
-#else
-#define FLAKY_ON_GCC_START \
-  testHopeful = YES;
-#define FLAKY_ON_GCC_END \
-  testHopeful = NO;
-#endif
 
 @class Bar;
 
@@ -195,7 +186,6 @@ main(int argc, char *argv[])
   NSAutoreleasePool *arp = [NSAutoreleasePool new];
 
   START_SET("newoldvalues");
-  FLAKY_ON_GCC_START
 
   Bar *bar = [Bar new];
   [bar setX: 0];
@@ -229,7 +219,6 @@ main(int argc, char *argv[])
   PASS([obs1 receivedCalls] == 3, "num observe calls");
   PASS([obs2 receivedCalls] == 2, "num observe calls");
   
-  FLAKY_ON_GCC_END
   END_SET("newoldvalues");
 
 

--- a/configure
+++ b/configure
@@ -15027,21 +15027,12 @@ if test ${enable_newkvo+y}
 then :
   enableval=$enable_newkvo;
 else $as_nop
-
-if test "$OBJC_RUNTIME_LIB" = "ng"; then
   enable_newkvo=yes
-else
-  enable_newkvo=no
-fi
 fi
 
 if test "x$enable_newkvo" = "xyes"
 then
-  if test "$OBJC_RUNTIME_LIB" = "ng"; then
-    HAVE_NEWKVO=1
-  else
-    echo "You are not using the new runtime ... newkvo not available"
-  fi
+  HAVE_NEWKVO=1
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -3830,19 +3830,10 @@ AC_SUBST(HAVE_LIBDISPATCH_RUNLOOP)
 HAVE_NEWKVO=0
 AC_ARG_ENABLE(newkvo,
   [AS_HELP_STRING([--disable-newkvo],
-  [Disable new KVO implementation])],,[
-if test "$OBJC_RUNTIME_LIB" = "ng"; then
-  enable_newkvo=yes
-else
-  enable_newkvo=no
-fi])
+  [Disable new KVO implementation])],,[enable_newkvo=yes])
 if test "x$enable_newkvo" = "xyes"
 then
-  if test "$OBJC_RUNTIME_LIB" = "ng"; then
-    HAVE_NEWKVO=1
-  else
-    echo "You are not using the new runtime ... newkvo not available"
-  fi
+  HAVE_NEWKVO=1
 fi
 AC_SUBST(HAVE_NEWKVO)
 


### PR DESCRIPTION
Add a per-class swizzling backend, using an NSKVONotifying_<Class> subclass and object_setClass, for runtimes that
lack that extension, and build the new KVO on every runtime.

--disable-newkvo keeps the old implementation.

The GNU runtime needed portability work.  The observer classes get explicit instance variables, as gcc does not synthesize them from the property declarations, and a recursive gs_mutex replaces @synchronized, which cannot be used on Windows where the GNU runtime does not enable Objective-C exceptions.  

Performance is on par with the previous KVO implementation on the libobjc2 hot path.
