### PR TITLE
GSSocketStream: do not offer write space on a closing socket (win32)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2026-07-07  Todd White <todd.white@thalion.global>
+
+	* Source/GSSocketStream.m (-[GSSocketInputStream _dispatch],
+	-[GSSocketOutputStream _dispatch]): Do not send a
+	NSStreamEventHasSpaceAvailable event while the socket event set
+	includes FD_CLOSE.  On winsock the socket reports space available
+	even once the peer has closed the connection, so the stream kept
+	offering space for writing after the close and a write was attempted
+	on the closed connection.
+
 2026-07-06 Todd White <todd.white@thalion.global>
 
 	* Source/NSCalendar.m

--- a/Source/GSSocketStream.m
+++ b/Source/GSSocketStream.m
@@ -2394,7 +2394,8 @@ setNonBlocking(SOCKET fd)
 	   * signalled again.
 	   */
 	  while ([_sibling _unhandledData] == NO
-	    && [_sibling hasSpaceAvailable])
+	    && [_sibling hasSpaceAvailable]
+	    && 0 == (events.lNetworkEvents & FD_CLOSE))
 	    {
 	      [_sibling _sendEvent: NSStreamEventHasSpaceAvailable];
 	    }
@@ -2909,7 +2910,8 @@ setNonBlocking(SOCKET fd)
 	   * failure/closure or a write blocked and we have not been
 	   * signalled again.
 	   */
-	  while ([self _unhandledData] == NO && [self hasSpaceAvailable])
+	  while ([self _unhandledData] == NO && [self hasSpaceAvailable]
+	    && 0 == (events.lNetworkEvents & FD_CLOSE))
 	    {
 	      [self _sendEvent: NSStreamEventHasSpaceAvailable];
 	    }


### PR DESCRIPTION
On Windows `-[GSSocketInputStream _dispatch]` and `-[GSSocketOutputStream _dispatch]` send `NSStreamEventHasSpaceAvailable` whenever the socket reports space available. A socket still reports space once the peer has closed the connection, so when `WSAEnumNetworkEvents` returns an event set containing `FD_CLOSE` the stream offers space for writing and a write is attempted on the closing connection. Serving a single response with the keepalive test helper, this writes the response a second time and the following write fails.

Skip the space-available notification when `FD_CLOSE` is set.

This is the second of the two problems described in #266; the first (the assertion in `_dispatch`) is a separate ordering issue and is not addressed here.

Reproduced on Windows (MSYS2 UCRT64, gnustep-base 1.31.1) with `Tests/base/NSURL/Helpers/keepalive.m` and a curl request: before the change the response body is written twice and the second write fails; afterwards it is written once. `Tests/base/NSURL` passes.
