### PR TITLE
NSHost: support the 5-argument gethostbyname_r

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2026-07-07  Todd White <todd.white@thalion.global>
+
+	* configure.ac: Detect the 5-argument (Solaris) form of
+	gethostbyname_r in addition to the 6-argument (glibc) form, and
+	record the argument count in GS_GETHOSTBYNAME_R_ARGS.
+	* configure: Regenerate.
+	* Headers/GNUstepBase/config.h.in: Regenerate.
+	* Source/NSHost.m (-[NSHost(Private) _addHostName:withNames:addresses:]):
+	Use the 5-argument gethostbyname_r, which returns the struct hostent*
+	directly, on systems that provide that form.
+
 2026-07-06 Todd White <todd.white@thalion.global>
 
 	* Source/NSCalendar.m

--- a/Headers/GNUstepBase/config.h.in
+++ b/Headers/GNUstepBase/config.h.in
@@ -195,6 +195,9 @@
 /* Built in default value for GNUstep user_dir web apps */
 #undef GNUSTEP_TARGET_USER_DIR_WEB_APPS
 
+/* Number of arguments taken by gethostbyname_r (5 or 6). */
+#undef GS_GETHOSTBYNAME_R_ARGS
+
 /* Define to 1 if you have the <alloca.h> header file. */
 #undef HAVE_ALLOCA_H
 
@@ -314,7 +317,7 @@
 /* Define to 1 if you have the `gethostbyname' function. */
 #undef HAVE_GETHOSTBYNAME
 
-/* Define to 1 if your system has gethostbyname_r with 6 arguments. */
+/* Define to 1 if your system has a reentrant gethostbyname_r. */
 #undef HAVE_GETHOSTBYNAME_R
 
 /* Define to 1 if you have the `getlogin' function. */

--- a/Source/NSHost.m
+++ b/Source/NSHost.m
@@ -551,8 +551,13 @@ etcHosts(BOOL flush)
       int		err;
 
       [names addObject: name];
+#if	GS_GETHOSTBYNAME_R_ARGS == 5
+      entry = gethostbyname_r(n, &entry_buf, buf, sizeof(buf), &err);
+      if (entry != NULL)
+#else
       if (0 == gethostbyname_r(n, &entry_buf, buf, sizeof(buf), &entry, &err)
 	&& entry != NULL)
+#endif
 	{
 	  [self _addEntry: entry withNames: names addresses: addresses];
 	}

--- a/configure
+++ b/configure
@@ -7821,7 +7821,10 @@ then :
 fi
 
 
-  #we check for 6 argument version, 5 argument version exists in the wild but we don't support it
+  # The glibc form takes 6 arguments, returns an int and yields the result
+  # through a struct hostent** parameter.  The Solaris form takes 5 arguments
+  # and returns the struct hostent* directly.
+  gs_gethostbyname_r_args=0
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for gethostbyname_r with 6 arguments" >&5
 printf %s "checking for gethostbyname_r with 6 arguments... " >&6; }
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -7840,9 +7843,7 @@ if ac_fn_c_try_link "$LINENO"
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
-
-printf "%s\n" "#define HAVE_GETHOSTBYNAME_R 1" >>confdefs.h
-
+          gs_gethostbyname_r_args=6
 else $as_nop
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
@@ -7850,6 +7851,42 @@ printf "%s\n" "no" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
+  if test "$gs_gethostbyname_r_args" = "0"; then
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for gethostbyname_r with 5 arguments" >&5
+printf %s "checking for gethostbyname_r with 5 arguments... " >&6; }
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdlib.h>
+                          #include <netdb.h>
+int
+main (void)
+{
+struct hostent *r = gethostbyname_r((const char *)NULL, (struct hostent *)NULL, (char *)NULL, (int)0, (int *)NULL);
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+            gs_gethostbyname_r_args=5
+else $as_nop
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+  fi
+  if test "$gs_gethostbyname_r_args" != "0"; then
+
+printf "%s\n" "#define HAVE_GETHOSTBYNAME_R 1" >>confdefs.h
+
+
+printf "%s\n" "#define GS_GETHOSTBYNAME_R_ARGS $gs_gethostbyname_r_args" >>confdefs.h
+
+  fi
 fi
 
 if test "x$ac_cv_func_gethostbyname_r" = "xno"; then

--- a/configure.ac
+++ b/configure.ac
@@ -1700,16 +1700,34 @@ if test "x$have_gethostbyname_r_public_declaration" = "xyes"; then
   # some systems already have gethostbyname_r so we don't need to build ours in main/utils.c
   AC_SEARCH_LIBS(gethostbyname_r, [socket nsl])
 
-  #we check for 6 argument version, 5 argument version exists in the wild but we don't support it
+  # The glibc form takes 6 arguments, returns an int and yields the result
+  # through a struct hostent** parameter.  The Solaris form takes 5 arguments
+  # and returns the struct hostent* directly.
+  gs_gethostbyname_r_args=0
   AC_MSG_CHECKING(for gethostbyname_r with 6 arguments)
   AC_LINK_IFELSE(
 	[AC_LANG_PROGRAM([#include <stdlib.h>
                           #include <netdb.h>],
                          [int r = gethostbyname_r((const char *)NULL, (struct hostent *)NULL, (char *)NULL, (int)0, (struct hostent **)NULL, (int *)NULL);])],
-         AC_MSG_RESULT(yes)
-         AC_DEFINE([HAVE_GETHOSTBYNAME_R], 1, [Define to 1 if your system has gethostbyname_r with 6 arguments.]),
-         AC_MSG_RESULT(no)
+         [AC_MSG_RESULT(yes)
+          gs_gethostbyname_r_args=6],
+         [AC_MSG_RESULT(no)]
   )
+  if test "$gs_gethostbyname_r_args" = "0"; then
+    AC_MSG_CHECKING(for gethostbyname_r with 5 arguments)
+    AC_LINK_IFELSE(
+	[AC_LANG_PROGRAM([#include <stdlib.h>
+                          #include <netdb.h>],
+                         [struct hostent *r = gethostbyname_r((const char *)NULL, (struct hostent *)NULL, (char *)NULL, (int)0, (int *)NULL);])],
+           [AC_MSG_RESULT(yes)
+            gs_gethostbyname_r_args=5],
+           [AC_MSG_RESULT(no)]
+    )
+  fi
+  if test "$gs_gethostbyname_r_args" != "0"; then
+    AC_DEFINE([HAVE_GETHOSTBYNAME_R], 1, [Define to 1 if your system has a reentrant gethostbyname_r.])
+    AC_DEFINE_UNQUOTED([GS_GETHOSTBYNAME_R_ARGS], $gs_gethostbyname_r_args, [Number of arguments taken by gethostbyname_r (5 or 6).])
+  fi
 fi
 
 if test "x$ac_cv_func_gethostbyname_r" = "xno"; then


### PR DESCRIPTION
Only the 6-argument glibc form of `gethostbyname_r` was detected and used. Solaris and some other systems provide a 5-argument form that returns the `struct hostent*` directly rather than through a result parameter.

`configure` now checks for the 6-argument form and, failing that, the 5-argument form, recording the count in `GS_GETHOSTBYNAME_R_ARGS`. `-[NSHost(Private) _addHostName:withNames:addresses:]` calls the matching form.

The 6-argument path is unchanged and verified on Linux (Tests/base/NSHost passes, 88 tests). I have no Solaris system to exercise the 5-argument path on, so I validated it against a stub with the Solaris signature: the 6-argument configure test fails to compile against a 5-argument declaration while the 5-argument test links, and the NSHost call site compiles and returns the entry correctly when built with the 5-argument form.

Implements #552.
