### PR TITLE
NSHost: support the 5-argument gethostbyaddr_r

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2026-07-08  Todd White <todd.white@thalion.global>
+
+	* Source/NSHost.m
+	(-[NSHost(Private) _addHostAddress:withNames:addresses:]): Call the
+	5-argument gethostbyaddr_r, which returns the struct hostent* directly,
+	on systems that provide that form.  The 5-argument gethostbyname_r
+	support added the equivalent for gethostbyname_r but missed its
+	companion gethostbyaddr_r, so the build failed on Solaris.  The Solaris
+	prototype takes the address as char*, so it is cast; it is still the
+	binary address rather than an ascii string.
+
 2026-07-07  Todd White <todd.white@thalion.global>
 
 	* configure.ac: Detect the 5-argument (Solaris) form of

--- a/Source/NSHost.m
+++ b/Source/NSHost.m
@@ -506,8 +506,14 @@ etcHosts(BOOL flush)
 	  return;
 	}
 
+#if	GS_GETHOSTBYNAME_R_ARGS == 5
+      entry = gethostbyaddr_r((const char *)&ip_addr, sizeof(ip_addr), AF_INET,
+	&entry_buf, buf, sizeof(buf), &err);
+      if (entry != NULL)
+#else
       if (0 == gethostbyaddr_r(&ip_addr, sizeof(ip_addr), AF_INET,
 	&entry_buf, buf, sizeof(buf), &entry, &err) && entry != NULL)
+#endif
 	{
 	  [self _addEntry: entry withNames: names addresses: addresses];
 	}


### PR DESCRIPTION
Follow-up to #692. That change added support for the 5-argument `gethostbyname_r` but missed its companion `gethostbyaddr_r`, which `-[NSHost(Private) _addHostAddress:withNames:addresses:]` uses, so the build failed on Solaris (reported by @rmottola in #552).

Call the 5-argument `gethostbyaddr_r` there too, reusing `GS_GETHOSTBYNAME_R_ARGS`; the existing code already guards `gethostbyaddr_r` under `HAVE_GETHOSTBYNAME_R`, so it assumes the two travel together. The Solaris prototype takes the address as `char*`, so the argument is cast, but it is still the binary address (`sizeof(struct in_addr)` bytes) rather than an ascii string.

The 6-argument path is unchanged and verified on Linux (Tests/base/NSHost passes). I have no Solaris system, so I validated the 5-argument path against a stub with the Solaris signature: the branch compiles with `-Wall -Werror` (the cast silences the incompatible-pointer warning that the direct mirror left) and calls the 7-argument form correctly.

Part of #552.
