### PR TITLE
Adopt NSSecureCoding in the plist substrate classes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,17 @@
+2026-07-08  Todd White <todd.white@thalion.global>
+
+	* Headers/Foundation/NSString.h, Headers/Foundation/NSData.h,
+	Headers/Foundation/NSDate.h, Headers/Foundation/NSValue.h,
+	Headers/Foundation/NSArray.h, Headers/Foundation/NSDictionary.h,
+	Headers/Foundation/NSSet.h: Declare NSSecureCoding conformance on the
+	plist substrate classes.
+	* Source/NSString.m, Source/NSData.m, Source/NSDate.m,
+	Source/NSNumber.m, Source/NSArray.m, Source/NSDictionary.m,
+	Source/NSSet.m (+[... supportsSecureCoding]): Implement, returning YES,
+	so a container of secure classes can be decoded securely.
+	* Tests/base/NSKeyedArchiver/secure_coding.m: Add cases for decoding a
+	plist container (array, dictionary) of a secure class.
+
 2026-07-07  Todd White <todd.white@thalion.global>
 
 	* configure.ac: Detect the 5-argument (Solaris) form of

--- a/Headers/Foundation/NSArray.h
+++ b/Headers/Foundation/NSArray.h
@@ -58,7 +58,7 @@ typedef NSUInteger NSBinarySearchingOptions;
 
 GS_EXPORT_CLASS
 @interface GS_GENERIC_CLASS(NSArray, __covariant ElementT) : NSObject
-  <NSCoding, NSCopying, NSMutableCopying, NSFastEnumeration>
+  <NSCoding, NSSecureCoding, NSCopying, NSMutableCopying, NSFastEnumeration>
 
 + (instancetype) array;
 + (instancetype) arrayWithArray: (GS_GENERIC_CLASS(NSArray, ElementT) *)array;

--- a/Headers/Foundation/NSData.h
+++ b/Headers/Foundation/NSData.h
@@ -99,7 +99,7 @@ DEFINE_BLOCK_TYPE(GSDataDeallocatorBlock, void, void*, NSUInteger);
 #endif
 
 GS_EXPORT_CLASS
-@interface NSData : NSObject <NSCoding, NSCopying, NSMutableCopying>
+@interface NSData : NSObject <NSCoding, NSSecureCoding, NSCopying, NSMutableCopying>
 
 // Allocating and Initializing a Data Object
 

--- a/Headers/Foundation/NSDate.h
+++ b/Headers/Foundation/NSDate.h
@@ -56,7 +56,7 @@ GS_EXPORT const NSTimeInterval NSTimeIntervalSince1970;
 @class NSTimeZoneDetail;
 
 GS_EXPORT_CLASS
-@interface NSDate : NSObject <NSCoding,NSCopying>
+@interface NSDate : NSObject <NSCoding, NSSecureCoding, NSCopying>
 {
 }
 

--- a/Headers/Foundation/NSDictionary.h
+++ b/Headers/Foundation/NSDictionary.h
@@ -39,7 +39,7 @@ extern "C" {
 GS_EXPORT_CLASS
 @interface GS_GENERIC_CLASS(NSDictionary,
   __covariant KeyT:id<NSCopying>, __covariant ValT)
-  : NSObject <NSCoding, NSCopying, NSMutableCopying, NSFastEnumeration>
+  : NSObject <NSCoding, NSSecureCoding, NSCopying, NSMutableCopying, NSFastEnumeration>
 + (instancetype) dictionary;
 + (instancetype) dictionaryWithContentsOfFile: (NSString*)path;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)

--- a/Headers/Foundation/NSSet.h
+++ b/Headers/Foundation/NSSet.h
@@ -43,7 +43,7 @@ extern "C" {
 @class NSString;
 
 GS_EXPORT_CLASS
-@interface GS_GENERIC_CLASS(NSSet, __covariant ElementT) : NSObject <NSCoding,
+@interface GS_GENERIC_CLASS(NSSet, __covariant ElementT) : NSObject <NSCoding, NSSecureCoding,
                                                              NSCopying,
                                                              NSMutableCopying,
                                                              NSFastEnumeration>

--- a/Headers/Foundation/NSString.h
+++ b/Headers/Foundation/NSString.h
@@ -514,7 +514,7 @@ DEFINE_BLOCK_TYPE(GSNSStringLineEnumerationBlock, void, NSString *line, BOOL *st
  */
 
 GS_EXPORT_CLASS
-@interface NSString :NSObject <NSCoding, NSCopying, NSMutableCopying>
+@interface NSString :NSObject <NSCoding, NSSecureCoding, NSCopying, NSMutableCopying>
 
 + (instancetype) string;
 + (instancetype) stringWithCharacters: (const unichar*)chars

--- a/Headers/Foundation/NSValue.h
+++ b/Headers/Foundation/NSValue.h
@@ -190,7 +190,7 @@ GS_EXPORT_CLASS
  * be type-converted if necessary, using standard C conversion rules.
  */
 GS_EXPORT_CLASS
-@interface NSNumber : NSValue <NSCopying,NSCoding>
+@interface NSNumber : NSValue <NSCopying, NSCoding, NSSecureCoding>
 
 // Allocating and Initializing
 

--- a/Source/NSArray.m
+++ b/Source/NSArray.m
@@ -166,6 +166,11 @@ static SEL	rlSel;
     }
 }
 
++ (BOOL) supportsSecureCoding
+{
+  return YES;
+}
+
 + (id) allocWithZone: (NSZone*)z
 {
   if (self == NSArrayClass)

--- a/Source/NSData.m
+++ b/Source/NSData.m
@@ -635,6 +635,11 @@ failure:
     }
 }
 
++ (BOOL) supportsSecureCoding
+{
+  return YES;
+}
+
 + (id) allocWithZone: (NSZone*)z
 {
   if (self == NSDataAbstract)

--- a/Source/NSDate.m
+++ b/Source/NSDate.m
@@ -734,6 +734,11 @@ otherTime(NSDate* other)
     }
 }
 
++ (BOOL) supportsSecureCoding
+{
+  return YES;
+}
+
 + (id) alloc
 {
   if (self == abstractClass)

--- a/Source/NSDictionary.m
+++ b/Source/NSDictionary.m
@@ -117,6 +117,11 @@ static SEL	appSel;
     }
 }
 
++ (BOOL) supportsSecureCoding
+{
+  return YES;
+}
+
 + (id) allocWithZone: (NSZone*)z
 {
   if (self == NSDictionaryClass)

--- a/Source/NSNumber.m
+++ b/Source/NSNumber.m
@@ -674,6 +674,11 @@ static NSBoolNumber *boolN;		// Boolean NO (integer 0)
     }
 }
 
++ (BOOL) supportsSecureCoding
+{
+  return YES;
+}
+
 - (const char *) objCType
 {
   /* All concrete NSNumber types must implement this so we know which one

--- a/Source/NSSet.m
+++ b/Source/NSSet.m
@@ -80,6 +80,11 @@ static Class NSMutableSet_concrete_class;
     }
 }
 
++ (BOOL) supportsSecureCoding
+{
+  return YES;
+}
+
 /**
  *  New autoreleased empty set.
  */

--- a/Source/NSString.m
+++ b/Source/NSString.m
@@ -1281,6 +1281,11 @@ register_printf_atsign ()
     }
 }
 
++ (BOOL) supportsSecureCoding
+{
+  return YES;
+}
+
 + (id) allocWithZone: (NSZone*)z
 {
   if (self == NSStringClass)

--- a/Tests/base/NSKeyedArchiver/secure_coding.m
+++ b/Tests/base/NSKeyedArchiver/secure_coding.m
@@ -4,10 +4,10 @@
  * allowed-class set and NSSecureCoding conformance, returning nil and an
  * NSError on a violation rather than instantiating an arbitrary class.
  *
- * These use a purpose-built NSSecureCoding class: the standard Foundation
- * classes do not yet adopt NSSecureCoding, so an archive of, say, an NSArray
- * cannot yet be decoded securely.  The enforcement itself is what is tested
- * here.
+ * The enforcement uses a purpose-built NSSecureCoding class, and the plist
+ * substrate classes (NSString, NSNumber, NSData, NSDate, NSArray,
+ * NSDictionary, NSSet) adopt NSSecureCoding so that containers of secure
+ * classes can be decoded securely.
  */
 
 #import <Foundation/Foundation.h>
@@ -135,6 +135,103 @@ int main(void)
     PASS_EQUAL(obj, @"hello",
       "a plist primitive is decoded even when its class is not listed");
   END_SET("plist primitives are implicitly allowed")
+
+  START_SET("a plist container adopting NSSecureCoding is decoded")
+    /* An array of a custom secure class.  Before the plist classes
+     * adopted NSSecureCoding this failed, because NSArray was not
+     * marked as supporting it. */
+    SCWidget	*w = [[SCWidget alloc] init];
+    NSData	*data;
+    NSError	*err = nil;
+    id		obj;
+
+    [w setName: @"in-array"];
+    data = archive([NSArray arrayWithObject: w]);
+    [w release];
+
+    /* The dedicated array entry point permits NSArray implicitly. */
+    obj = [NSKeyedUnarchiver
+      unarchivedArrayOfObjectsOfClasses: [NSSet setWithObject: [SCWidget class]]
+                               fromData: data error: &err];
+    PASS(obj != nil && [obj isKindOfClass: [NSArray class]] && [obj count] == 1
+      && [[obj objectAtIndex: 0] isKindOfClass: [SCWidget class]] && err == nil,
+      "unarchivedArrayOfObjectsOfClasses: decodes an array of a secure class");
+
+    /* The general entry point requires NSArray to be listed as well. */
+    err = nil;
+    obj = [NSKeyedUnarchiver
+      unarchivedObjectOfClasses: [NSSet setWithObjects:
+        [NSArray class], [SCWidget class], nil]
+                       fromData: data error: &err];
+    PASS(obj != nil && [obj isKindOfClass: [NSArray class]] && err == nil,
+      "an array is decoded when NSArray and the element class are listed");
+
+    /* A container is not implicit: without NSArray the decode fails. */
+    err = nil;
+    obj = [NSKeyedUnarchiver
+      unarchivedObjectOfClasses: [NSSet setWithObject: [SCWidget class]]
+                       fromData: data error: &err];
+    PASS(obj == nil && err != nil,
+      "an array is rejected when NSArray is not in the allowed set");
+
+    /* The allowed set applies tree-wide: the element class must be listed. */
+    err = nil;
+    obj = [NSKeyedUnarchiver
+      unarchivedObjectOfClasses: [NSSet setWithObject: [NSArray class]]
+                       fromData: data error: &err];
+    PASS(obj == nil && err != nil,
+      "an array is rejected when its element class is not in the allowed set");
+  END_SET("a plist container adopting NSSecureCoding is decoded")
+
+  START_SET("a dictionary of a secure class is decoded")
+    SCWidget	*w = [[SCWidget alloc] init];
+    NSData	*data;
+    NSError	*err = nil;
+    id		obj;
+
+    [w setName: @"in-dict"];
+    data = archive([NSDictionary dictionaryWithObject: w forKey: @"k"]);
+    [w release];
+
+    obj = [NSKeyedUnarchiver
+      unarchivedDictionaryWithKeysOfClasses: [NSSet setWithObject: [NSString class]]
+                             objectsOfClasses: [NSSet setWithObject: [SCWidget class]]
+                                     fromData: data error: &err];
+    PASS(obj != nil && [obj isKindOfClass: [NSDictionary class]]
+      && [[obj objectForKey: @"k"] isKindOfClass: [SCWidget class]] && err == nil,
+      "unarchivedDictionaryWithKeysOfClasses:objectsOfClasses: decodes a dictionary");
+  END_SET("a dictionary of a secure class is decoded")
+
+  START_SET("mutable variants inherit NSSecureCoding")
+    /* The mutable classes are not changed directly; they inherit both the
+     * protocol conformance and +supportsSecureCoding from their immutable
+     * superclass. */
+    PASS([NSMutableString conformsToProtocol: @protocol(NSSecureCoding)]
+      && [NSMutableString supportsSecureCoding]
+      && [NSMutableData conformsToProtocol: @protocol(NSSecureCoding)]
+      && [NSMutableArray conformsToProtocol: @protocol(NSSecureCoding)]
+      && [NSMutableDictionary conformsToProtocol: @protocol(NSSecureCoding)]
+      && [NSMutableSet conformsToProtocol: @protocol(NSSecureCoding)]
+      && [NSMutableSet supportsSecureCoding],
+      "the mutable variants inherit NSSecureCoding conformance");
+
+    SCWidget		*w = [[SCWidget alloc] init];
+    NSMutableArray	*ma;
+    NSData		*data;
+    NSError		*err = nil;
+    id			obj;
+
+    [w setName: @"mutable"];
+    ma = [NSMutableArray arrayWithObject: w];
+    [w release];
+    data = archive(ma);
+    obj = [NSKeyedUnarchiver
+      unarchivedArrayOfObjectsOfClasses: [NSSet setWithObject: [SCWidget class]]
+                               fromData: data error: &err];
+    PASS(obj != nil && [obj count] == 1
+      && [[obj objectAtIndex: 0] isKindOfClass: [SCWidget class]] && err == nil,
+      "a mutable array of a secure class is decoded");
+  END_SET("mutable variants inherit NSSecureCoding")
 
   return 0;
 }


### PR DESCRIPTION
Second part of the secure-coding support for #639; follows the enforcement change (#686).

The enforcement rejects any class that does not both conform to `NSSecureCoding` and return YES from `+supportsSecureCoding`. Only `NSUserActivity` adopted the protocol, so a secure decode whose root or contents were standard classes (an array, a dictionary) failed even when the classes were listed. This adopts `NSSecureCoding` in the plist substrate classes you asked for first: `NSString`, `NSNumber`, `NSData`, `NSDate`, `NSArray`, `NSDictionary`, `NSSet`. Only the abstract classes are changed; the mutable variants and concrete cluster members inherit conformance (`+conformsToProtocol:` walks the superclass chain).

`secure_coding.m` gains cases for decoding an array and a dictionary of a secure class, and confirms the container-not-implicit and tree-wide rules: an array is rejected when `NSArray` is not listed, or when its element class is not; it decodes when both are listed, and via the dedicated `unarchivedArrayOfObjectsOfClasses:` / `unarchivedDictionaryWithKeysOfClasses:objectsOfClasses:` entry points.

I verified these against Apple Foundation on a macOS runner: the array and dictionary scenarios behave identically (rejected when the container or an element class is unlisted, decoded otherwise). `Tests/base/NSKeyedArchiver`, `NSArray`, `NSDictionary`, `NSString`, `NSSet`, `NSData` all still pass.
