### PR TITLE
NSNumber: hash by numeric value rather than truncating

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,16 @@
 2026-07-08  Todd White <todd.white@thalion.global>
 
+	* Source/NSNumber.m (GSHashDouble, -[NSNumber hash]): Derive the hash
+	from -doubleValue by reducing the value modulo a Mersenne prime, so
+	that equal numbers held in different types hash equally (as -isEqual:
+	requires) and fractional values no longer collide on their integral
+	part.
+	* Tests/base/NSNumber/NSNumber_hash.m: New test for the -hash /
+	-isEqual: contract, for fractional scattering and for non-finite
+	values.
+
+2026-07-08  Todd White <todd.white@thalion.global>
+
 	* Headers/Foundation/NSString.h, Headers/Foundation/NSData.h,
 	Headers/Foundation/NSDate.h, Headers/Foundation/NSValue.h,
 	Headers/Foundation/NSArray.h, Headers/Foundation/NSDictionary.h,

--- a/Source/NSNumber.m
+++ b/Source/NSNumber.m
@@ -50,6 +50,91 @@
 #  include <objc/runtime.h>
 #endif
 
+#include <math.h>
+#include <stdint.h>
+
+/* An NSNumber compares equal to another whenever -compare: returns
+ * NSOrderedSame, and that comparison is performed on the -doubleValue of
+ * the two numbers (except between two integers, which are compared as
+ * integers but then have identical -doubleValue anyway).  A conforming
+ * -hash must therefore be a function of -doubleValue alone; hashing the
+ * raw storage would give equal numbers held in different types (an int
+ * and a double of the same value) different hashes and break their use as
+ * dictionary keys.
+ *
+ * This maps the value into the range of a Mersenne prime modulus, after
+ * the manner of CPython's number hashing, so that the whole value
+ * contributes to the hash and an integral value hashes to that integer.
+ */
+#if	UINTPTR_MAX > 0xffffffffUL
+#  define	GS_HASH_BITS	61
+#else
+#  define	GS_HASH_BITS	31
+#endif
+#define	GS_HASH_MODULUS	(((NSUInteger)1 << GS_HASH_BITS) - 1)
+#define	GS_HASH_INF	((NSUInteger)314159)
+
+static NSUInteger
+GSHashDouble(double value)
+{
+  int		e, sign;
+  double	m;
+  NSUInteger	x, y;
+
+  if (isnan(value))
+    {
+      return 0;
+    }
+  if (isinf(value))
+    {
+      return (value > 0) ? GS_HASH_INF : (NSUInteger)(0 - GS_HASH_INF);
+    }
+
+  m = frexp(value, &e);
+  sign = 1;
+  if (m < 0)
+    {
+      sign = -1;
+      m = -m;
+    }
+
+  /* Consume the mantissa 28 bits at a time, accumulating modulo the
+   * prime.  28 is below GS_HASH_BITS for both the 32 and 64 bit case.
+   */
+  x = 0;
+  while (m)
+    {
+      x = ((x << 28) & GS_HASH_MODULUS) | (x >> (GS_HASH_BITS - 28));
+      m *= 268435456.0;			/* 2^28 */
+      e -= 28;
+      y = (NSUInteger)m;		/* pull out the integer part */
+      m -= y;
+      x += y;
+      if (x >= GS_HASH_MODULUS)
+	{
+	  x -= GS_HASH_MODULUS;
+	}
+    }
+
+  /* Fold in the exponent, reduced modulo GS_HASH_BITS. */
+  e = e % GS_HASH_BITS;
+  if (e < 0)
+    {
+      e += GS_HASH_BITS;
+    }
+  x = ((x << e) & GS_HASH_MODULUS) | (x >> (GS_HASH_BITS - e));
+
+  if (sign < 0)
+    {
+      x = 0 - x;
+    }
+  if (x == (NSUInteger)-1)
+    {
+      x = (NSUInteger)-2;
+    }
+  return x;
+}
+
 /*
  * NSNumber implementation.  This matches the behaviour of Apple's
  * implementation.  Values in the range -1 to 12 inclusive are mapped to
@@ -713,7 +798,7 @@ static NSBoolNumber *boolN;		// Boolean NO (integer 0)
 
 - (NSUInteger) hash
 {
-  return (unsigned)[self doubleValue];
+  return GSHashDouble([self doubleValue]);
 }
 
 - (NSString*) stringValue

--- a/Tests/base/NSNumber/NSNumber_hash.m
+++ b/Tests/base/NSNumber/NSNumber_hash.m
@@ -1,0 +1,115 @@
+#import "ObjectTesting.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSArray.h>
+#import <Foundation/NSValue.h>
+
+#include <math.h>
+
+int main()
+{
+  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
+
+  START_SET("equal numbers hash equally regardless of type")
+    /* -isEqual: on NSNumber is defined by -compare:, which promotes to
+     * double when the two numbers have different types, so numbers with
+     * the same value held as int, long long, unsigned, float or double
+     * all compare equal and therefore must hash equally. */
+    NSMutableArray	*nums = [NSMutableArray array];
+    long long		iv[] = {0, 1, -1, 42, -42, 255, 256, 65536,
+      2147483647LL, 2147483648LL, 4294967296LL};
+    unsigned		i;
+    NSUInteger		a, b, n;
+    BOOL		ok = YES;
+
+    for (i = 0; i < sizeof(iv) / sizeof(iv[0]); i++)
+      {
+	long long	v = iv[i];
+
+	[nums addObject: [NSNumber numberWithInt: (int)v]];
+	[nums addObject: [NSNumber numberWithLongLong: v]];
+	if (v >= 0)
+	  {
+	    [nums addObject: [NSNumber numberWithUnsignedLongLong:
+	      (unsigned long long)v]];
+	  }
+	[nums addObject: [NSNumber numberWithFloat: (float)v]];
+	[nums addObject: [NSNumber numberWithDouble: (double)v]];
+      }
+
+    n = [nums count];
+    for (a = 0; a < n && ok; a++)
+      {
+	for (b = 0; b < n && ok; b++)
+	  {
+	    NSNumber	*x = [nums objectAtIndex: a];
+	    NSNumber	*y = [nums objectAtIndex: b];
+
+	    if ([x isEqual: y] && [x hash] != [y hash])
+	      {
+		NSLog(@"%@ isEqual: %@ but %lu != %lu", x, y,
+		  (unsigned long)[x hash], (unsigned long)[y hash]);
+		ok = NO;
+	      }
+	  }
+      }
+    PASS(ok, "equal numbers of differing types produce equal hashes")
+
+    PASS([[NSNumber numberWithInt: 42] hash]
+      == [[NSNumber numberWithDouble: 42.0] hash]
+      && [[NSNumber numberWithInt: 42] hash]
+      == [[NSNumber numberWithFloat: 42.0f] hash],
+      "an integer and a floating point 42 hash equally")
+  END_SET("equal numbers hash equally regardless of type")
+
+  START_SET("the fractional part is not discarded")
+    /* Distinct fractional values must hash distinctly rather than all
+     * folding onto their common integral part. */
+    NSNumber	*a = [NSNumber numberWithDouble: 1.5];
+    NSNumber	*b = [NSNumber numberWithDouble: 1.7];
+    NSNumber	*c = [NSNumber numberWithDouble: 1.9];
+    unsigned	distinct = 0;
+    unsigned	i;
+    NSUInteger	seen[100];
+
+    PASS([a hash] != [b hash] && [b hash] != [c hash] && [a hash] != [c hash],
+      "1.5, 1.7 and 1.9 hash distinctly")
+
+    /* A scattering sanity check: the hashes of 0.5 .. 99.5 are mostly
+     * distinct rather than all folding onto their integral part. */
+    for (i = 0; i < 100; i++)
+      {
+	NSUInteger	h = [[NSNumber numberWithDouble: i + 0.5] hash];
+	unsigned	j;
+	BOOL		dup = NO;
+
+	for (j = 0; j < distinct; j++)
+	  {
+	    if (seen[j] == h)
+	      {
+		dup = YES;
+		break;
+	      }
+	  }
+	if (!dup)
+	  {
+	    seen[distinct++] = h;
+	  }
+      }
+    PASS(distinct > 95, "fractional values scatter across the hash range")
+  END_SET("the fractional part is not discarded")
+
+  START_SET("non-finite values are handled")
+    NSNumber	*pinf = [NSNumber numberWithDouble: INFINITY];
+    NSNumber	*ninf = [NSNumber numberWithDouble: -INFINITY];
+    NSNumber	*nan = [NSNumber numberWithDouble: NAN];
+
+    PASS([pinf hash] == [[NSNumber numberWithDouble: INFINITY] hash],
+      "+infinity hashes consistently")
+    PASS([pinf hash] != [ninf hash],
+      "+infinity and -infinity hash distinctly")
+    PASS([nan hash] == [nan hash], "a NaN hash does not crash")
+  END_SET("non-finite values are handled")
+
+  [arp release];
+  return 0;
+}


### PR DESCRIPTION
`-[NSNumber hash]` cast doubleValue to an integer, so every value sharing an integral part collided: 1.5 and 1.7 hashed alike.

This reduces doubleValue modulo a Mersenne prime, after the manner of CPython, so the fractional part contributes and an integral value still hashes to that integer.

The hash stays a function of doubleValue because that is what `-compare:` and `-isEqual:` use. NSNumber equality promotes to double, so a value held as int, float or double compares equal across those types and must hash equally. Hashing the raw storage, as #535 first tried, breaks that: the bit patterns of an int and a double of the same value differ, so equal numbers get different hashes and fail as dictionary keys.

One consequence worth noting: equality is not transitive across the precision boundary. A long long above 2^53 compares equal to the double it rounds to, so its hash must be that of the double, and distinct large integers can collide. That follows `-compare:` and cannot be avoided without changing comparison.

`Tests/base/NSNumber/NSNumber_hash.m` covers the `-hash`/`-isEqual:` contract, fractional scattering and non-finite values. 862 tests pass under both the GNU and libobjc2 runtimes.

This is an option for #535, following the doubleValue-based approach discussed there.
