### PR TITLE
NSUnarchiver: decode a char into a wider integer destination

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2026-07-27 Todd White <todd.white@thalion.global>
+
+	* Source/NSUnarchiver.m: Decode a char archived value into a wider
+	integer destination (short/int/long/long long), preserving the sign
+	of the archived char.  BOOL is a char on most platforms but an int
+	with the libobjc2 runtime on Windows, so a gorm (which encodes BOOL
+	as unsigned char) failed to load there with "expected int and got
+	unsigned char".  See gnustep/libs-gui#318 and gnustep/libs-gui#405.
+	* Tests/base/NSArchiver/charWidening.m: Test the char to integer
+	widening.
+
 2026-07-27 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Headers/GNUstepBase/GSIMap.h:

--- a/Source/NSUnarchiver.m
+++ b/Source/NSUnarchiver.m
@@ -1213,14 +1213,48 @@ scalarSize(char type)
       case _GSC_CHR:
       case _GSC_UCHR:
 	/* Encoding of chars is not consistant across platforms, so we
-	   loosen the type checking a little */
-	if (*type != type_map[_GSC_CHR] && *type != type_map[_GSC_UCHR])
+	   loosen the type checking a little.  BOOL is a char on most
+	   platforms, but the libobjc2 runtime defines it as an int on
+	   Windows (unless built with STRICT_APPLE_COMPATIBILITY), so a char
+	   in the archive may have to widen into a larger integer
+	   destination for an archive (such as a gorm) to decode there. */
+	if (*type == type_map[_GSC_CHR] || *type == type_map[_GSC_UCHR])
+	  {
+	    (*desImp)(src, desSel, address, type, &cursor, nil);
+	    return;
+	  }
+	else if (*type == _C_SHT || *type == _C_USHT
+	  || *type == _C_INT || *type == _C_UINT
+	  || *type == _C_LNG || *type == _C_ULNG
+	  || *type == _C_LNG_LNG || *type == _C_ULNG_LNG)
+	  {
+	    unsigned char	c;
+	    long long		v;
+
+	    (*desImp)(src, desSel, &c, @encode(unsigned char), &cursor, nil);
+	    if ((info & _GSC_MASK) == _GSC_UCHR)
+	      v = (long long)c;
+	    else
+	      v = (long long)(signed char)c;
+
+	    switch (*type)
+	      {
+		case _C_SHT:
+		case _C_USHT:	*(short*)address = (short)v; break;
+		case _C_INT:
+		case _C_UINT:	*(int*)address = (int)v; break;
+		case _C_LNG:
+		case _C_ULNG:	*(long*)address = (long)v; break;
+		default:	*(long long*)address = v; break;
+	      }
+	    return;
+	  }
+	else
 	  {
 	    [NSException raise: NSInternalInconsistencyException
 		        format: @"expected %s and got %s",
 		    typeToName1(*type), typeToName2(info)];
 	  }
-	(*desImp)(src, desSel, address, type, &cursor, nil);
 	return;
 
       case _GSC_SHT:

--- a/Tests/base/NSArchiver/charWidening.m
+++ b/Tests/base/NSArchiver/charWidening.m
@@ -1,0 +1,110 @@
+#import <Foundation/NSArchiver.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSException.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import "Testing.h"
+
+/* A value archived as a char must decode into a wider integer destination.
+   BOOL is a char on most platforms but an int with the libobjc2 runtime on
+   Windows, so a gorm (which encodes BOOL as unsigned char) has to decode its
+   BOOL values into int slots there.  Before this was handled, the decode
+   raised "expected int and got unsigned char".  (gnustep/libs-gui#318, #405) */
+
+static NSData *
+archiveUChar(unsigned char c)
+{
+  NSMutableData *d = [NSMutableData data];
+  NSArchiver *a = [[NSArchiver alloc] initForWritingWithMutableData: d];
+  [a encodeValueOfObjCType: @encode(unsigned char) at: &c];
+  [a release];
+  return d;
+}
+
+static NSData *
+archiveSChar(signed char c)
+{
+  NSMutableData *d = [NSMutableData data];
+  NSArchiver *a = [[NSArchiver alloc] initForWritingWithMutableData: d];
+  [a encodeValueOfObjCType: @encode(signed char) at: &c];
+  [a release];
+  return d;
+}
+
+/* Decode data as an int, returning whether it succeeded without an exception. */
+static BOOL
+decodeAsInt(NSData *data, int *out)
+{
+  NSUnarchiver *u = [[NSUnarchiver alloc] initForReadingWithData: data];
+  BOOL ok = YES;
+
+  NS_DURING
+    [u decodeValueOfObjCType: @encode(int) at: out];
+  NS_HANDLER
+    ok = NO;
+  NS_ENDHANDLER
+  [u release];
+  return ok;
+}
+
+int
+main(void)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  int i = -1;
+  short s = -1;
+  long l = -1;
+  long long ll = -1;
+  unsigned char uc = 0;
+  NSUnarchiver *u;
+
+  PASS(decodeAsInt(archiveUChar(1), &i) && i == 1,
+    "an unsigned char archived as 1 decodes into an int as 1");
+  PASS(decodeAsInt(archiveUChar(0), &i) && i == 0,
+    "an unsigned char archived as 0 decodes into an int as 0");
+  PASS(decodeAsInt(archiveUChar(255), &i) && i == 255,
+    "an unsigned char archived as 255 decodes into an int as 255");
+
+  PASS(decodeAsInt(archiveSChar(-5), &i) && i == -5,
+    "a signed char archived as -5 decodes into an int as -5");
+  PASS(decodeAsInt(archiveSChar(-128), &i) && i == -128,
+    "a signed char archived as -128 decodes into an int as -128");
+
+  u = [[NSUnarchiver alloc] initForReadingWithData: archiveUChar(200)];
+  NS_DURING
+    [u decodeValueOfObjCType: @encode(short) at: &s];
+  NS_HANDLER
+    s = -1;
+  NS_ENDHANDLER
+  [u release];
+  PASS(s == 200, "an unsigned char decodes into a short");
+
+  u = [[NSUnarchiver alloc] initForReadingWithData: archiveUChar(200)];
+  NS_DURING
+    [u decodeValueOfObjCType: @encode(long) at: &l];
+  NS_HANDLER
+    l = -1;
+  NS_ENDHANDLER
+  [u release];
+  PASS(l == 200, "an unsigned char decodes into a long");
+
+  u = [[NSUnarchiver alloc] initForReadingWithData: archiveUChar(200)];
+  NS_DURING
+    [u decodeValueOfObjCType: @encode(long long) at: &ll];
+  NS_HANDLER
+    ll = -1;
+  NS_ENDHANDLER
+  [u release];
+  PASS(ll == 200, "an unsigned char decodes into a long long");
+
+  u = [[NSUnarchiver alloc] initForReadingWithData: archiveUChar(42)];
+  NS_DURING
+    [u decodeValueOfObjCType: @encode(unsigned char) at: &uc];
+  NS_HANDLER
+    uc = 0;
+  NS_ENDHANDLER
+  [u release];
+  PASS(uc == 42, "an unsigned char still decodes into an unsigned char unchanged");
+
+  [arp release]; arp = nil;
+  return 0;
+}


### PR DESCRIPTION
Fixes the Windows gorm loading failure reported in gnustep/libs-gui#318 and gnustep/libs-gui#405.

BOOL is a char on most platforms, but the libobjc2 runtime defines it as an int on Windows unless built with STRICT_APPLE_COMPATIBILITY. A gorm encodes BOOL as unsigned char, so on Windows the decode reads those values into int slots and raises "expected int and got unsigned char" (the backtrace on libs-gui#318 shows this decoding NSMenuItem._enable). Every gorm then fails to load, including menus, panels and the print panel from libs-gui#405.

NSUnarchiver already widens a float into a double and converts integer sizes across platforms, but a char could only decode into a char. This widens a char archived value into a short, int, long or long long destination, preserving the sign of the archived char. A matching char destination is unchanged.

Tests/base/NSArchiver/charWidening.m covers the widening: unsigned and signed char into int/short/long/long long, edge values, and that a matching char destination still decodes unchanged. base/NSArchiver and base/coding pass, including the cross-architecture archive fixtures in base/coding.

@gcasa mentioned looking into this on libs-gui#318; this is the NSUnarchiver side of it.
