### PR TITLE
Timer performance optimisation (and other run loop performance tweaks)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,31 @@
 2026-07-28 Richard Frith-Macdonald <rfm@gnu.org>
 
+	* Headers/Foundation/NSRunLoop.h:
+	* Headers/Foundation/NSTimer.h:
+	* Headers/GNUstepBase/GSIArray.h:
+	* Headers/GNUstepBase/GSMinHeap.h:
+	* Source/Additions/GSMinHeap.m:
+	* Source/GNUmakefile:
+	* Source/GSRunLoopCtxt.h:
+	* Source/GSRunLoopCtxt.m:
+	* Source/NSRunLoop.m:
+	* Source/NSTimer.m:
+	* Source/unix/GSRunLoopCtxt.m:
+	* Source/win32/GSRunLoopCtxt.m:
+	Change to use a min heap rather than an array of timers in each runloop
+	context.  This was done after testing three different timer
+	implementations to confirm that the theoretical benefits were seen in
+	practice (and that any slight overhead in the common case of a very
+	lightly loaded loop was negligible).  This also contains a change to
+	the way that timers are recorded in different run loop modes to improve
+	performance when firing and to iomprove lookup on every iteration.
+	The limitation of the new impelementation is that a run loop is limited
+	to having no more than 64 modes (adding to a 65th mode will raise an
+	exception), but this seems academic since programs typically operate
+	using only one to four modes anyway.
+
+2026-07-28 Richard Frith-Macdonald <rfm@gnu.org>
+
 	* Source/NSPathUtilities.m: Add support for XDG user directories.
 	* Tests/base/NSPathUtilities/userDomain.m: Add some user domain tests.
 	Adds support for XDG well known user directory definitions configured

--- a/Headers/Foundation/NSRunLoop.h
+++ b/Headers/Foundation/NSRunLoop.h
@@ -49,10 +49,9 @@ GS_EXPORT_CLASS
 #if	GS_EXPOSE(NSRunLoop)
   @private
   NSString		*_currentMode;
-  NSMapTable		*_contextMap;
   NSMutableArray	*_contextStack;
   NSMutableArray	*_timedPerformers;
-  void			*_extra;
+  void			*_internal;
 #endif
 }
 

--- a/Headers/Foundation/NSTimer.h
+++ b/Headers/Foundation/NSTimer.h
@@ -34,10 +34,8 @@ DEFINE_BLOCK_TYPE(GSTimerBlock, void, NSTimer*);
 extern "C" {
 #endif
 
-/*
- *	NB. NSRunLoop is optimised using a hack that knows about the
- *	class layout for the fire date and invialidation flag in NSTimer.
- *	These MUST remain the first two items in the class.
+/*	NB. NSRunLoop is optimised using a hack that knows about the
+ *	class layout for relevant information in NSTimer.
  *	Other classes must not attempt to use instance variables as
  *	they are subject to change.
  */
@@ -46,23 +44,16 @@ GS_EXPORT_CLASS
 {
 #if	GS_EXPOSE(NSTimer)
 @public
-  NSDate 	 *_date;	/* Must be 1st - for NSRunLoop optimisation */
-  BOOL		 _invalidated;	/* Must be 2nd - for NSRunLoop optimisation */
-  BOOL		 _repeats;
-  NSTimeInterval _interval;
-  id		 _target;
-  SEL		 _selector;
-  id		 _info;
-  GSTimerBlock   _block;
-#endif
-#if     GS_NONFRAGILE
-#else
-  /* Pointer to private additional data used to avoid breaking ABI
-   * when we don't have the non-fragile ABI available.
-   * Use this mechanism rather than changing the instance variable
-   * layout (see Source/GSInternal.h for details).
-   */
-  @private id _internal GS_UNUSED_IVAR;
+  NSDate 		*_date;		/* Must match NSRunLoop.m */
+  const void		*_loop;		/* Must match NSRunLoop.m */
+  uint64_t		_modeMask;	/* Must match NSRunLoop.m */
+  BOOL		 	_invalidated;	/* Must match NSRunLoop.m */
+  BOOL		 	_repeats;
+  NSTimeInterval 	_interval;
+  id		 	_target;
+  SEL		 	_selector;
+  id		 	_info;
+  GSTimerBlock   	_block;
 #endif
 }
 

--- a/Headers/GNUstepBase/GSIArray.h
+++ b/Headers/GNUstepBase/GSIArray.h
@@ -1,5 +1,5 @@
 /* A fast (Inline) array implementation without objc method overhead.
- * Copyright (C) 1998,1999  Free Software Foundation, Inc.
+ * Copyright (C) 1998,2026  Free Software Foundation, Inc.
  * 
  * Author:	Richard Frith-Macdonald <richard@brainstorm.co.uk>
  * Created:	Nov 1998
@@ -28,17 +28,23 @@
 #if	defined(GNUSTEP_BASE_INTERNAL)
 #import "Foundation/NSObject.h"
 #import "Foundation/NSException.h"
-#import "Foundation/NSGarbageCollector.h"
 #import "Foundation/NSZone.h"
 #else
 #import <Foundation/NSObject.h>
 #import <Foundation/NSException.h>
-#import <Foundation/NSGarbageCollector.h>
 #import <Foundation/NSZone.h>
 #endif
 
-/* To turn assertions on, define GSI_ARRAY_CHECKS */
-#define GSI_ARRAY_CHECKS 1
+/** To turn assertions on, define GSI_ARRAY_CHECKS */
+//#define GSI_ARRAY_CHECKS 1
+
+#if	!defined(GSI_ARRAY_MEMMOVE)
+/** From this threshold number of items to be moved in an array, the macro
+ * will use the memmove() function rather than a loop of assignments.
+ * If you do not define a value, the default threshold is used.
+ */
+#define	GSI_ARRAY_MEMMOVE	8
+#endif
 
 #if	defined(__cplusplus)
 extern "C" {
@@ -274,7 +280,7 @@ GSIArrayGrowTo(GSIArray array, unsigned next)
 GS_STATIC_INLINE void
 GSIArrayInsertItem(GSIArray array, GSIArrayItem item, unsigned index)
 {
-  unsigned int	i;
+  unsigned	i;
 
   GSI_ARRAY_CHECK;
   GSI_ARRAY_RETAIN(array, item);
@@ -282,32 +288,58 @@ GSIArrayInsertItem(GSIArray array, GSIArrayItem item, unsigned index)
     {
       GSIArrayGrow(array);
     }
-  for (i = array->count++; i > index; i--)
+  if ((i = array->count - index) >= GSI_ARRAY_MEMMOVE)
     {
-      array->ptr[i] = array->ptr[i-1];
+      if (index < array->count)
+	{
+	  memmove(array->ptr + (index+1), array->ptr + index,
+	    i * sizeof(GSIArrayItem));
+	}
+      array->count++;
     }
-  array->ptr[i] = item;
+  else
+    {
+      for (i = array->count++; i > index; i--)
+	{
+	  array->ptr[i] = array->ptr[i-1];
+	}
+    }
+  array->ptr[index] = item;
   GSI_ARRAY_CHECK;
 }
 
 GS_STATIC_INLINE void
 GSIArrayInsertItemNoRetain(GSIArray array, GSIArrayItem item, unsigned index)
 {
-  unsigned int	i;
+  unsigned	i;
 
   GSI_ARRAY_CHECK;
   if (array->count == array->cap)
     {
       GSIArrayGrow(array);
     }
-  for (i = array->count++; i > index; i--)
+  if ((i = array->count - index) >= GSI_ARRAY_MEMMOVE)
     {
-      array->ptr[i] = array->ptr[i-1];
+      if (index < array->count)
+	{
+	  memmove(array->ptr + (index+1), array->ptr + index,
+	    i * sizeof(GSIArrayItem));
+	}
+      array->count++;
     }
-  array->ptr[i] = item;
+  else
+    {
+      for (i = array->count++; i > index; i--)
+	{
+	  array->ptr[i] = array->ptr[i-1];
+	}
+    }
+  array->ptr[index] = item;
   GSI_ARRAY_CHECK;
 }
 
+/** Adds an item to the end of the array.
+ */
 GS_STATIC_INLINE void
 GSIArrayAddItem(GSIArray array, GSIArrayItem item)
 {
@@ -321,6 +353,8 @@ GSIArrayAddItem(GSIArray array, GSIArrayItem item)
   GSI_ARRAY_CHECK;
 }
 
+/** Adds an item to the end of the array without retaining it.
+ */
 GS_STATIC_INLINE void
 GSIArrayAddItemNoRetain(GSIArray array, GSIArrayItem item)
 {
@@ -333,15 +367,23 @@ GSIArrayAddItemNoRetain(GSIArray array, GSIArrayItem item)
   GSI_ARRAY_CHECK;
 }
 
-/*
- *	The comparator function takes two items as arguments, the first is the
- *	item to be added, the second is the item already in the array.
- *      The function should return NSOrderedAscending if the item to be
- *      added is 'less than' the item in the array, NSOrderedDescending
- *      if it is greater, and NSOrderedSame if it is equal.
+/** Searches the array for an item using the supplied sorter function which
+ * must provide the same sort relationship between the item argument and the
+ * items in the array that was used to create the array.<br />
+ * This will return either the index of a matching item (if more than one
+ * item matches it is indeterminate which item's index is returned) or the
+ * index of the first item greater than the one being searched for if no
+ * match is found (this may be the index of the end of the array if the
+ * array only contains smaller items than the one being searched for).<br />
+ *
+ * The comparator function takes two items as arguments, the first is the
+ * item to be matched, the second is the item already in the array.
+ * The function should return NSOrderedAscending if the item to be
+ * matched is 'less than' the item in the array, NSOrderedDescending
+ * if it is greater, and NSOrderedSame if it is equal.
  */
 GS_STATIC_INLINE unsigned
-GSIArraySearch(GSIArray array, GSIArrayItem item, 
+GSIArraySearch(GSIArray array, GSIArrayItem elem, 
   NSComparisonResult (*sorter)(GSIArrayItem, GSIArrayItem))
 {
   unsigned int	upper = array->count;
@@ -356,7 +398,7 @@ GSIArraySearch(GSIArray array, GSIArrayItem item,
     {
       NSComparisonResult comparison;
 
-      comparison = (*sorter)(item, (array->ptr[index]));
+      comparison = (*sorter)(elem, (array->ptr[index]));
       if (comparison == NSOrderedAscending)
         {
           upper = index;
@@ -373,13 +415,46 @@ GSIArraySearch(GSIArray array, GSIArrayItem item,
   return index;
 }
 
+/** Returns the index of the first item in the array matching elem and also
+ * returns the count of matching items.  If the returned count is zero then
+ * no matches were found.
+ */
+GS_STATIC_INLINE unsigned
+GSIArraySearchCount(GSIArray array, GSIArrayItem elem, 
+  NSComparisonResult (*sorter)(GSIArrayItem, GSIArrayItem), unsigned *count)
+{
+  unsigned	start = GSIArraySearch(array, elem, sorter);
+  unsigned	end = start;
+
+  while (start > 0
+    && (*sorter)(elem, (array->ptr[start - 1])) == NSOrderedSame)
+    {
+      start--;
+    }
+  while (end < array->count
+    && (*sorter)(elem, (array->ptr[end])) != NSOrderedAscending)
+    {
+      end++;
+    }
+  if (count)
+    {
+      *count = end - start;
+    }
+  return start;
+}
+
+/** Returns the insertion position for elem in array.  If the array contains
+ * one or more items equal to elem, the returned position will be immediately
+ * after the last of these (so the order of equal items in the array is
+ * the order in which those items were added using this method).
+ */
 GS_STATIC_INLINE unsigned
 GSIArrayInsertionPosition(GSIArray array, GSIArrayItem item, 
   NSComparisonResult (*sorter)(GSIArrayItem, GSIArrayItem))
 {
   unsigned int	index;
 
-  index = GSIArraySearch(array,item,sorter);
+  index = GSIArraySearch(array, item, sorter);
   /*
    *	Now skip past any equal items so the insertion point is AFTER any
    *	items that are equal to the new one.
@@ -412,6 +487,9 @@ GSIArrayCheckSort(GSIArray array,
 }
 #endif
 
+/** Inserts an item into a sorted array at the correct position to maintain
+ * equal items in insertion order.
+ */
 GS_STATIC_INLINE void
 GSIArrayInsertSorted(GSIArray array, GSIArrayItem item, 
   NSComparisonResult (*sorter)(GSIArrayItem, GSIArrayItem))
@@ -428,6 +506,9 @@ GSIArrayInsertSorted(GSIArray array, GSIArrayItem item,
 #endif
 }
 
+/** Inserts an item into a sorted array at the correct position to maintain
+ * equal items in insertion order.  Does not retain the inserted item.
+ */
 GS_STATIC_INLINE void
 GSIArrayInsertSortedNoRetain(GSIArray array, GSIArrayItem item,
   NSComparisonResult (*sorter)(GSIArrayItem, GSIArrayItem))
@@ -447,63 +528,108 @@ GSIArrayInsertSortedNoRetain(GSIArray array, GSIArrayItem item,
 GS_STATIC_INLINE void
 GSIArrayRemoveItemAtIndex(GSIArray array, unsigned index)
 {
-#if	defined(GSI_ARRAY_NO_RELEASE)
+  unsigned	remainder;
+#if	!defined(GSI_ARRAY_NO_RELEASE)
+  GSIArrayItem	tmp;
+#endif
+
 # ifdef	GSI_ARRAY_CHECKS
   NSCAssert(index < array->count, NSInvalidArgumentException);
 # endif
-  while (++index < array->count)
-    array->ptr[index-1] = array->ptr[index];
+
+  remainder = array->count - index - 1;
+#if	defined(GSI_ARRAY_NO_RELEASE)
+  if (remainder >= GSI_ARRAY_MEMMOVE)
+    {
+      memmove(array->ptr + index, array->ptr + (index + 1),
+	remainder * sizeof(GSIArrayItem));
+    }
+  else
+    {
+      while (++index < array->count)
+	{
+	  array->ptr[index-1] = array->ptr[index];
+	}
+    }
   array->count--;
 #else
-  GSIArrayItem	tmp;
-# ifdef	GSI_ARRAY_CHECKS
-  NSCAssert(index < array->count, NSInvalidArgumentException);
-# endif
   tmp = array->ptr[index];
-  while (++index < array->count)
-    array->ptr[index-1] = array->ptr[index];
+  if (remainder >= GSI_ARRAY_MEMMOVE)
+    {
+      memmove(array->ptr + index, array->ptr + (index + 1),
+	remainder * sizeof(GSIArrayItem));
+    }
+  else
+    {
+      while (++index < array->count)
+	{
+	  array->ptr[index-1] = array->ptr[index];
+	}
+    }
   array->count--;
   GSI_ARRAY_RELEASE(array, tmp);
 #endif
 }
 
 GS_STATIC_INLINE void
-GSIArrayRemoveLastItem(GSIArray array)
-{
-#ifdef	GSI_ARRAY_CHECKS
-  NSCAssert(array->count, NSInvalidArgumentException);
-#endif
-  array->count--;
-#if	!defined(GSI_ARRAY_NO_RELEASE)
-  GSI_ARRAY_RELEASE(array, array->ptr[array->count]);
-#endif
-}
-
-GS_STATIC_INLINE void
 GSIArrayRemoveItemAtIndexNoRelease(GSIArray array, unsigned index)
 {
+  unsigned	remainder;
 #ifdef	GSI_ARRAY_CHECKS
   NSCAssert(index < array->count, NSInvalidArgumentException);
 #endif
-  while (++index < array->count)
-    array->ptr[index-1] = array->ptr[index];
+  remainder = array->count - index - 1;
+  if (remainder >= GSI_ARRAY_MEMMOVE)
+    {
+      memmove(array->ptr + index, array->ptr + (index + 1),
+	remainder * sizeof(GSIArrayItem));
+    }
+  else
+    {
+      while (++index < array->count)
+	{
+	  array->ptr[index-1] = array->ptr[index];
+	}
+    }
   array->count--;
+}
+
+GS_STATIC_INLINE void
+GSIArrayRemoveLastItem(GSIArray array)
+{
+  if (array->count > 0)
+    {
+      array->count--;
+#if	!defined(GSI_ARRAY_NO_RELEASE)
+      GSI_ARRAY_RELEASE(array, array->ptr[array->count]);
+#endif
+    }
+}
+
+GS_STATIC_INLINE void
+GSIArrayRemoveLastItemNoRelease(GSIArray array)
+{
+  if (array->count > 0)
+    {
+      array->count--;
+    }
 }
 
 GS_STATIC_INLINE void
 GSIArraySetItemAtIndex(GSIArray array, GSIArrayItem item, unsigned index)
 {
-#if	defined(GSI_ARRAY_NO_RELEASE)
+#if	!defined(GSI_ARRAY_NO_RELEASE)
+  GSIArrayItem	tmp;
+#endif
+
 # ifdef	GSI_ARRAY_CHECKS
   NSCAssert(index < array->count, NSInvalidArgumentException);
 # endif
+
+#if	defined(GSI_ARRAY_NO_RELEASE)
   GSI_ARRAY_RETAIN(array, item);
   array->ptr[index] = item;
 #else
-  GSIArrayItem	tmp;
-# ifdef	GSI_ARRAY_CHECKS
-  NSCAssert(index < array->count, NSInvalidArgumentException);
-# endif
   tmp = array->ptr[index];
   GSI_ARRAY_RETAIN(array, item);
   array->ptr[index] = item;
@@ -556,31 +682,150 @@ GSIArrayClear(GSIArray array)
     }
 }
 
+/** Removes up to count items from the specified index onwards.
+ * If the index is outside the array, this does nothing.
+ * If the count is greater than the available items from the index,
+ * items to the end of the array are removed.<br />
+ *
+ */
 GS_STATIC_INLINE void
-GSIArrayRemoveItemsFromIndex(GSIArray array, unsigned index)
+GSIArrayRemoveItems(GSIArray array, unsigned index, unsigned count)
 {
   if (index < array->count)
     {
-#ifndef	GSI_ARRAY_NO_RELEASE
-      while (array->count-- > index)
+      unsigned	removeFrom = index;
+      unsigned	removeTo;
+      unsigned	remainder;
+
+      if (array->count - index < count)
 	{
-	  GSI_ARRAY_RELEASE(array, array->ptr[array->count]);
+	  count = array->count - index;
+	}
+      removeTo = index + count;
+      remainder = array->count - removeTo;
+      array->count -= count;
+#ifndef	GSI_ARRAY_NO_RELEASE
+      for (index = removeFrom; index < removeTo; index++)
+	{
+	  GSI_ARRAY_RELEASE(array, array->ptr[index]);
 	}
 #endif
-      array->count = index;
+      if (remainder >= GSI_ARRAY_MEMMOVE)
+	{
+	  memmove(array->ptr + removeFrom, array->ptr + removeTo,
+	    remainder * sizeof(GSIArrayItem));
+	}
+      else
+	{
+	  for (index = 0; index < remainder; index++)
+	    {
+	      array->ptr[removeFrom + index] = array->ptr[removeTo + index];
+	    }
+	}
     }
 }
 
+/** Acts as GSIArrayRemoveItemsNoRelease() but without releasing removed items.
+ */
+GS_STATIC_INLINE void
+GSIArrayRemoveItemsNoRelease(GSIArray array, unsigned index, unsigned count)
+{
+  if (index < array->count)
+    {
+      unsigned	removeFrom = index;
+      unsigned	removeTo;
+      unsigned	remainder;
+
+      if (array->count - index < count)
+	{
+	  count = array->count - index;
+	}
+      removeTo = index + count;
+      remainder = array->count - removeTo;
+      array->count -= count;
+      if (remainder >= GSI_ARRAY_MEMMOVE)
+	{
+	  memmove(array->ptr + removeFrom, array->ptr + removeTo,
+	    remainder * sizeof(GSIArrayItem));
+	}
+      else
+	{
+	  for (index = 0; index < remainder; index++)
+	    {
+	      array->ptr[removeFrom + index] = array->ptr[removeTo + index];
+	    }
+	}
+    }
+}
+
+/** Removes all items from the specified index onwards.
+ * If the index is outside the array, this does nothing.
+ */
+GS_STATIC_INLINE void
+GSIArrayRemoveItemsFromIndex(GSIArray array, unsigned index)
+{
+  GSIArrayRemoveItems(array, index, array->count);
+}
+
+/** Removes all items from the specified index onwards without releasing them.
+ */
+GS_STATIC_INLINE void
+GSIArrayRemoveItemsFromIndexNoRelease(GSIArray array, unsigned index)
+{
+  GSIArrayRemoveItemsNoRelease(array, index, array->count);
+}
+
+/** Removes all items from index zero onwards.
+ */
 GS_STATIC_INLINE void
 GSIArrayRemoveAllItems(GSIArray array)
 {
-#ifndef	GSI_ARRAY_NO_RELEASE
-  while (array->count--)
+  GSIArrayRemoveItemsFromIndex(array, 0);
+}
+
+/** Removes all items from index zero onwards without releasing them.
+ */
+GS_STATIC_INLINE void
+GSIArrayRemoveAllItemsNoRelease(GSIArray array)
+{
+  GSIArrayRemoveItemsFromIndexNoRelease(array, 0);
+}
+
+/** Remove leading and trailing items matching some criterion.
+ * The checker function takes an item as an argument and returns
+ * YES if it is to be trimmed.
+ */
+GS_STATIC_INLINE void
+GSIArrayTrim(GSIArray array, BOOL (*checker)(GSIArrayItem arg))
+{
+  unsigned	count = array->count;
+  unsigned	index = count;
+
+  /* Remove trailing items matching the criterion.
+   */
+  while (index > 0 && checker(array->ptr[index-1]))
     {
-      GSI_ARRAY_RELEASE(array, array->ptr[array->count]);
+      index--;
     }
-#endif
-  array->count = 0;
+  if (index != count)
+    {
+      GSIArrayRemoveItems(array, index, count - index);
+      count = array->count;
+    }
+
+  /* Skip past and remove any leading items, matching the criterion
+   */
+  for (index = 0; index < count; index++)
+    {
+      if (NO == checker(array->ptr[index]))
+	{
+	  break;
+	}
+    }
+  if (index > 0)
+    {
+      GSIArrayRemoveItems(array, 0, index);
+    }
 }
 
 GS_STATIC_INLINE void

--- a/Headers/GNUstepBase/GSMinHeap.h
+++ b/Headers/GNUstepBase/GSMinHeap.h
@@ -101,6 +101,11 @@ GS_EXPORT_CLASS
  */
 - (id) pop;
 
+/** Removes the first object from the heap and returns it.  Returns nil
+ * if the heap was already empty.  The returned object is not autoreleased.
+ */
+- (id) popRetained NS_RETURNS_RETAINED;
+
 /** Adds obj to the heap and returns YES on success.  May return NO on failure
  * (if obj was nil or if there is insufficient memory for the heap to grow).
  * The heap takes ownership of (retains) obj on success, but not on failure.

--- a/Source/Additions/GSMinHeap.m
+++ b/Source/Additions/GSMinHeap.m
@@ -360,6 +360,11 @@ heap_remove(MinHeapInternal *h, size_t index)
   return AUTORELEASE(heap_pop(internal));
 }
 
+- (id) popRetained
+{
+  return heap_pop(internal);
+}
+
 - (BOOL) push: (id)obj
 {
   if (obj != nil)

--- a/Source/GNUmakefile
+++ b/Source/GNUmakefile
@@ -175,6 +175,7 @@ GSICUString.m \
 GSOrderedSet.m \
 GSPrivateHash.m \
 GSQuickSort.m \
+GSRunLoopCtxt.m \
 GSRunLoopWatcher.m \
 GSSet.m \
 GSShellSort.m \

--- a/Source/GSRunLoopCtxt.h
+++ b/Source/GSRunLoopCtxt.h
@@ -1,7 +1,7 @@
 #ifndef __GSRunLoopCtxt_h_GNUSTEP_BASE_INCLUDE
 #define __GSRunLoopCtxt_h_GNUSTEP_BASE_INCLUDE
 /** 
-   Copyright (C) 2008-2009 Free Software Foundation, Inc.
+   Copyright (C) 2008-2026 Free Software Foundation, Inc.
 
    By: Richard Frith-Macdonald <richard@brainstorm.co.uk>
 
@@ -21,13 +21,13 @@
    License along with this library; if not, write to the Free
    Software Foundation, Inc., 31 Milk Street #960789 Boston, MA 02196 USA.
 
-   $Date$ $Revision$
 */
 
 #import "common.h"
 #import "Foundation/NSException.h"
 #import "Foundation/NSMapTable.h"
 #import "Foundation/NSRunLoop.h"
+#import "GNUstepBase/GSMinHeap.h"
 
 /*
  *      Setup for inline operation of arrays.
@@ -40,44 +40,26 @@
 
 #include "GNUstepBase/GSIArray.h"
 
-#ifdef  HAVE_POLL
-typedef struct{
-  int   limit;
-  short *index;
-}pollextra;
-#endif
-
 @class NSString;
 @class GSRunLoopWatcher;
 
 @interface	GSRunLoopCtxt : NSObject
 {
 @public
-  void		*extra;		/** Copy of the RunLoop ivar.		*/
+  void		*extra;		/** Common data for contexts in a loop  */
   NSString	*mode;		/** The mode for this context.		*/
+  unsigned	modeIndex;	/** Position of mode within run loop    */
   GSIArray	performers;	/** The actions to perform regularly.	*/
   unsigned	maxPerformers;
-  GSIArray	timers;		/** The timers set for the runloop mode */
-  unsigned	maxTimers;
   GSIArray	watchers;	/** The inputs set for the runloop mode */
   unsigned	maxWatchers;
-@private
-#if	defined(_WIN32)
-  NSMapTable    *handleMap;     
-  NSMapTable	*winMsgMap;
-#else
-  NSMapTable	*_efdMap;
-  NSMapTable	*_rfdMap;
-  NSMapTable	*_wfdMap;
-#endif
+  GSMinHeap	*timerHeap;
+  GSIArray      timers;         /** The timers set for the runloop mode */
+  unsigned	maxTimers;
+@protected
   GSIArray	_trigger;	// Watchers to trigger unconditionally.
   int		fairStart;	// For trying to ensure fair handling.
   BOOL		completed;	// To mark operation as completed.
-#ifdef	HAVE_POLL
-  unsigned int	pollfds_capacity;
-  unsigned int	pollfds_count;
-  struct pollfd	*pollfds;
-#endif
 }
 /* Check to see of the thread has been awakened, blocking until it
  * does get awakened or until the limit date has been reached.
@@ -85,11 +67,25 @@ typedef struct{
  * immediate return.
  */
 + (BOOL) awakenedBefore: (NSDate*)when;
+
+/* Remove any callback for the specified event which is set for an
+ * uncompleted poll operation.<br />
+ * This is called by nested event loops on contexts in outer loops
+ * when they handle an event ... removing the event from the outer
+ * loop ensures that it won't get handled twice, once by the inner
+ * loop and once by the outer one.
+ */
 - (void) endEvent: (void*)data
               for: (GSRunLoopWatcher*)watcher;
+
 - (void) endPoll;
-- (id) initWithMode: (NSString*)theMode extra: (void*)e;
+- (id) initWithMode: (NSString*)theMode extra: (void**)e;
 - (BOOL) pollUntil: (int)milliseconds within: (NSArray*)contexts;
+
+/* Callbacks for a map table whose values are watchers.
+ */
+- (const NSMapTableValueCallBacks) watcherCallbacks;
+
 @end
 
 #endif /* __GSRunLoopCtxt_h_GNUSTEP_BASE_INCLUDE */

--- a/Source/GSRunLoopCtxt.h
+++ b/Source/GSRunLoopCtxt.h
@@ -53,8 +53,7 @@
   unsigned	maxPerformers;
   GSIArray	watchers;	/** The inputs set for the runloop mode */
   unsigned	maxWatchers;
-  GSMinHeap	*timerHeap;
-  GSIArray      timers;         /** The timers set for the runloop mode */
+  GSMinHeap	*timerHeap;     /** The timers set for the runloop mode */
   unsigned	maxTimers;
 @protected
   GSIArray	_trigger;	// Watchers to trigger unconditionally.

--- a/Source/GSRunLoopCtxt.m
+++ b/Source/GSRunLoopCtxt.m
@@ -92,8 +92,6 @@ static const NSMapTableValueCallBacks WatcherMapValueCallBacks =
   RELEASE(timerHeap);
   GSIArrayEmpty(performers);
   NSZoneFree(performers->zone, (void*)performers);
-  GSIArrayEmpty(timers);
-  NSZoneFree(timers->zone, (void*)timers);
   GSIArrayEmpty(watchers);
   NSZoneFree(watchers->zone, (void*)watchers);
   GSIArrayEmpty(_trigger);
@@ -144,11 +142,9 @@ static const NSMapTableValueCallBacks WatcherMapValueCallBacks =
       z = [self zone];
       timerHeap = [[GSMinHeap alloc] initWithCapacity: 100 andComparator: NULL];
       performers = NSZoneMalloc(z, sizeof(GSIArray_t));
-      timers = NSZoneMalloc(z, sizeof(GSIArray_t));
       watchers = NSZoneMalloc(z, sizeof(GSIArray_t));
       _trigger = NSZoneMalloc(z, sizeof(GSIArray_t));
       GSIArrayInitWithZoneAndCapacity(performers, z, 8);
-      GSIArrayInitWithZoneAndCapacity(timers, z, 8);
       GSIArrayInitWithZoneAndCapacity(watchers, z, 8);
       GSIArrayInitWithZoneAndCapacity(_trigger, z, 8);
     }

--- a/Source/GSRunLoopCtxt.m
+++ b/Source/GSRunLoopCtxt.m
@@ -1,0 +1,168 @@
+/**
+ * The GSRunLoopCtxt stores context information to handle polling for
+ * events.  This information is associated with a particular runloop
+ * mode, and persists throughout the life of the runloop instance.
+ *
+ *	NB.  This class is private to NSRunLoop and must not be subclassed.
+ */
+
+#import "common.h"
+
+#import "Foundation/NSError.h"
+#import "Foundation/NSNotification.h"
+#import "Foundation/NSNotificationQueue.h"
+#import "Foundation/NSPort.h"
+#import "Foundation/NSStream.h"
+#define	GENERICCTXT	1
+#import "GSRunLoopCtxt.h"
+#import "GSRunLoopWatcher.h"
+#import "GSPrivate.h"
+
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
+
+static SEL	wRelSel;
+static SEL	wRetSel;
+static IMP	wRelImp;
+static IMP	wRetImp;
+
+static void
+wRelease(NSMapTable* t, void* w)
+{
+  (*wRelImp)((id)w, wRelSel);
+}
+
+static void
+wRetain(NSMapTable* t, const void* w)
+{
+  (*wRetImp)((id)w, wRetSel);
+}
+
+static const NSMapTableValueCallBacks WatcherMapValueCallBacks = 
+{
+  wRetain,
+  wRelease,
+  0
+};
+
+@implementation	GSRunLoopCtxt
+
++ (void) initialize
+{
+  wRelSel = @selector(release);
+  wRetSel = @selector(retain);
+  wRelImp = [[GSRunLoopWatcher class] instanceMethodForSelector: wRelSel];
+  wRetImp = [[GSRunLoopWatcher class] instanceMethodForSelector: wRetSel];
+}
+
++ (id) allocWithZone: (NSZone*)z
+{
+  static Class	c = Nil;
+
+  if (Nil == c)
+    {
+#if     defined(_WIN32)
+      c = NSClassFromString(@"GSRunLoopCtxtWin32");
+#else
+      c = NSClassFromString(@"GSRunLoopCtxtUnix");
+#endif
+    }
+  if (self == c)
+    {
+      return [super allocWithZone: z];
+    }
+  else
+    {
+      return [c allocWithZone: z];
+    }
+}
+
++ (BOOL) awakenedBefore: (NSDate*)when
+{
+  return NO;
+}
+
+- (void) dealloc
+{
+  RELEASE(mode);
+  RELEASE(timerHeap);
+  GSIArrayEmpty(performers);
+  NSZoneFree(performers->zone, (void*)performers);
+  GSIArrayEmpty(timers);
+  NSZoneFree(timers->zone, (void*)timers);
+  GSIArrayEmpty(watchers);
+  NSZoneFree(watchers->zone, (void*)watchers);
+  GSIArrayEmpty(_trigger);
+  NSZoneFree(_trigger->zone, (void*)_trigger);
+  DEALLOC
+}
+
+- (void) endEvent: (void*)data
+              for: (GSRunLoopWatcher*)watcher
+{
+  if (!completed)
+    {
+      unsigned i = GSIArrayCount(_trigger);
+
+      while (i-- > 0)
+        {
+          GSIArrayItem  item = GSIArrayItemAtIndex(_trigger, i);
+
+          if (item.obj == (id)watcher)
+            {
+              GSIArrayRemoveItemAtIndex(_trigger, i);
+              return;
+            }
+        }
+    }
+}
+
+/**
+ * Mark this poll context as having completed, so that if we are
+ * executing a re-entrant poll, the enclosing poll operations
+ * know they can stop what they are doing because an inner
+ * operation has done the job.
+ */
+- (void) endPoll
+{
+  completed = YES;
+}
+
+- (id) initWithMode: (NSString*)theMode extra: (void**)e
+{
+  self = [super init];
+  if (self != nil)
+    {
+      NSZone	*z;
+
+      mode = [theMode copy];
+      extra = *e;
+      z = [self zone];
+      timerHeap = [[GSMinHeap alloc] initWithCapacity: 100 andComparator: NULL];
+      performers = NSZoneMalloc(z, sizeof(GSIArray_t));
+      timers = NSZoneMalloc(z, sizeof(GSIArray_t));
+      watchers = NSZoneMalloc(z, sizeof(GSIArray_t));
+      _trigger = NSZoneMalloc(z, sizeof(GSIArray_t));
+      GSIArrayInitWithZoneAndCapacity(performers, z, 8);
+      GSIArrayInitWithZoneAndCapacity(timers, z, 8);
+      GSIArrayInitWithZoneAndCapacity(watchers, z, 8);
+      GSIArrayInitWithZoneAndCapacity(_trigger, z, 8);
+    }
+  return self;
+}
+
+- (BOOL) pollUntil: (int)milliseconds within: (NSArray*)contexts
+{
+  return NO;
+}
+
+- (const NSMapTableValueCallBacks) watcherCallbacks
+{
+  return WatcherMapValueCallBacks;
+}
+
+@end

--- a/Source/NSRunLoop.m
+++ b/Source/NSRunLoop.m
@@ -68,15 +68,6 @@ NSRunLoopMode const NSRunLoopCommonModes = @"NSRunLoopCommonModes";
 
 static NSDate	*theFuture = nil;
 
-/* Allow the 'TimerStyle' environment variable to control alternative
- * timer implementations for ease of testing.
- */
-static enum {
-  TS_SORTARY,	// Use a sorted array of timers in each context
-  TS_MINHEAP,	// Use a minheap of timers in each context
-  TS_SHAREDA	// Use sorted array shared between contexts
-} timerStyle = TS_SORTARY;
-
 
 
 /*
@@ -444,7 +435,6 @@ typedef struct {
   uint64_t		commonModeMask;		/* Common modes as mask */
   NSMapTable		*contextMap;		/* Hash lookup by mode */
   GSRunLoopCtxt		*contexts[64];		/* Context for each mode */
-  GSIArray		timers;			/* Timers not in contexts */
 } RunLoopInternal;
                                
 #define myvars	((RunLoopInternal*)_internal)
@@ -679,8 +669,6 @@ contextForMode(RunLoopInternal *loop, NSString *mode, BOOL shouldCreate)
       _internal = (RunLoopInternal*)NSZoneCalloc(z, 1, sizeof(RunLoopInternal));
       myvars->contextMap = NSCreateMapTable(
 	NSNonRetainedObjectMapKeyCallBacks, NSObjectMapValueCallBacks, 0);
-      myvars->timers = NSZoneMalloc(z, sizeof(GSIArray_t));
-      GSIArrayInitWithZoneAndCapacity(myvars->timers, z, 8);
       // The first mode must be NSDefaultRunLoopMode
       contextForMode(myvars, NSDefaultRunLoopMode, YES);
       myvars->commonModeMask |= UINT64_C(1);
@@ -834,27 +822,6 @@ contextForMode(RunLoopInternal *loop, NSString *mode, BOOL shouldCreate)
 {
   if (self == [NSRunLoop class])
     {
-      NSString	*s;
-
-      s = [[[NSProcessInfo processInfo] environment]
-	objectForKey: @"TimerStyle"];
-      if (s && [s caseInsensitiveCompare: @"SortAry"] == NSOrderedSame)
-	{
-	  timerStyle = TS_SORTARY;
-	}
-      else if (s && [s caseInsensitiveCompare: @"MinHeap"] == NSOrderedSame)
-	{
-	  timerStyle = TS_MINHEAP;
-	}
-      else if (s && [s caseInsensitiveCompare: @"SharedA"] == NSOrderedSame)
-	{
-	  timerStyle = TS_SHAREDA;
-	}
-      else
-	{
-	  timerStyle = TS_MINHEAP;
-	}
-
       [self currentRunLoop];
       theFuture = RETAIN([NSDate distantFuture]);
       RELEASE([NSObject leakAt: &theFuture]);
@@ -958,9 +925,6 @@ static GSMainQueueDrainer 	*drainer = nil;
 	{
 	  NSFreeMapTable(myvars->contextMap);
 	}
-      GSIArrayEmpty(myvars->timers);
-      NSZoneFree(myvars->timers->zone, (void*)myvars->timers);
-
       NSZoneFree(NSDefaultMallocZone(), myvars);
       _internal = NULL;
     }
@@ -978,36 +942,6 @@ static GSMainQueueDrainer 	*drainer = nil;
 
 
 
-/* Comparator for timers
- */
-static NSComparisonResult
-sorter(GSIArrayItem a, GSIArrayItem b)
-{
-  return [(NSTimer*)a.obj compare: (NSTimer*)b.obj];
-}
-
-static BOOL
-timerToTrim(GSIArrayItem item)
-{
-  return ((NSTimer*)(item.obj))->_invalidated;
-}
-
-#if 0
-static NSString *
-logTimers(GSIArray timers)
-{
-  NSMutableString	*s = [NSMutableString stringWithCapacity: 1000];
-  unsigned		count = GSIArrayCount(timers);
-  unsigned		index;
-
-  for (index = 0; index < count; index++)
-    {
-      [s appendFormat: @"    %@\n", GSIArrayItemAtIndex(timers, index).obj];
-    }
-  return s;
-}
-#endif
-
 
 /**
  * Adds a timer to the loop in the specified mode.<br />
@@ -1019,7 +953,6 @@ logTimers(GSIArray timers)
   const void	*loop = (const void*)self;
   GSRunLoopCtxt	*context;
   GSMinHeap	*timerHeap;
-  GSIArray      timers;
   uint64_t	modeBit;
   unsigned      i;
 
@@ -1055,55 +988,24 @@ logTimers(GSIArray timers)
     {
       return;	// Already present in this mode
     }
-  if (TS_MINHEAP == timerStyle)
-    {
-      timerHeap = context->timerHeap;
 
-      /* Timers can be scheduled in more than one mode, and if a timer fires
-       * and repeats it will have updated its fire date.  That will leave it
-       * incorrectly positioned in the min heap in other modes.  To handle
-       * that we must track whether it is scheduled in more than one mode to
-       * know if we need to check other modes for repositionng.
-       */
-      [timerHeap push: timer];
-      i = [timerHeap count];
-      if (i % 1000 == 0 && i > context->maxTimers)
-	{
-	  context->maxTimers = i;
-	  NSLog(@"WARNING ... there are %u timers scheduled in mode %@ of %@",
-	    i, mode, self);
-	}
-    }
-  else if (TS_SHAREDA == timerStyle)
+  timerHeap = context->timerHeap;
+
+  /* Timers can be scheduled in more than one mode, and if a timer fires
+   * and repeats it will have updated its fire date.  That will leave it
+   * incorrectly positioned in the min heap in other modes.  To handle
+   * that we must track whether it is scheduled in more than one mode to
+   * know if we need to check other modes for repositionng.
+   */
+  [timerHeap push: timer];
+  i = [timerHeap count];
+  if (i % 1000 == 0 && i > context->maxTimers)
     {
-      if (0 == timer->_modeMask)
-	{
-	  timers = myvars->timers;
-	  /* When the timer is first scheduled, we must add to the shared
-	   * sorted array.
-	   */
-	  GSIArrayInsertSorted(timers, (GSIArrayItem)((id)timer), sorter);
-	  i = GSIArrayCount(timers);
-	  if (i % 1000 == 0 && i > context->maxTimers)
-	    {
-	      context->maxTimers = i;
-	      NSLog(@"WARNING ... there are %u timers scheduled in %@",
-		i, self);
-	    }
-	}
+      context->maxTimers = i;
+      NSLog(@"WARNING ... there are %u timers scheduled in mode %@ of %@",
+	i, mode, self);
     }
-  else
-    {
-      timers = context->timers;
-      GSIArrayInsertSorted(timers, (GSIArrayItem)((id)timer), sorter);
-      i = GSIArrayCount(timers);
-      if (i % 1000 == 0 && i > context->maxTimers)
-	{
-	  context->maxTimers = i;
-	  NSLog(@"WARNING ... there are %u timers scheduled in mode %@ of %@",
-	    i, mode, self);
-	}
-    }
+
   timer->_modeMask |= modeBit;
 }
 
@@ -1178,8 +1080,6 @@ updateTimer(NSTimer *t, NSDate *d, NSTimeInterval now)
   NSAutoreleasePool     *arp = [NSAutoreleasePool new];
   uint64_t		contextModeMask = ~(UINT64_C(1)<<context->modeIndex);
   GSMinHeap		*timerHeap;
-  GSIArray		timers;
-  unsigned		count;
   NSTimeInterval	now;
   NSDate                *earliest;
   NSDate		*d;
@@ -1199,238 +1099,75 @@ updateTimer(NSTimer *t, NSDate *d, NSTimeInterval now)
   /* Fire the oldest/first valid timer whose fire date has passed
    * and fire it.
    */
-  if (TS_MINHEAP == timerStyle)
+  timerHeap = context->timerHeap;
+  timer = [timerHeap peek];
+  while (timer != nil)
     {
-      timerHeap = context->timerHeap;
-      timer = [timerHeap peek];
-      while (timer != nil)
+      if (timerInvalidated(timer))
 	{
-	  if (timerInvalidated(timer))
-	    {
-	      timer = [timerHeap next];
-	    }
-	  else
-	    {
-	      d = timerDate(timer);
-	      ti = [d timeIntervalSinceReferenceDate];
-	      if (ti < now)
-		{
-		  int		modeIndex;
-		  uint64_t	mask;
-		  uint64_t	save;
-		  GSRunLoopCtxt	*c;
-
-		  timer = [timerHeap popRetained];
-		  mask = timer->_modeMask;
-		  mask &= contextModeMask;
-		  save = mask;
-		  while (mask)
-		    {
-		      modeIndex = GET_INDEX_AND_CLEAR_BIT(mask);
-		      c = myvars->contexts[modeIndex];
-		      [c->timerHeap removeObjectIdenticalTo: timer];
-		    }
-		  [timer fire];
-		  GSPrivateNotifyASAP(_currentMode);
-		  IF_NO_ARC([arp emptyPool];)
-		  if (updateTimer(timer, d, now) == YES)
-		    {
-		      /* Updated ... replace in heap.
-		       */
-		      [timerHeap push: timer];
-		      mask = save;
-		      while (mask)
-			{
-			  modeIndex = GET_INDEX_AND_CLEAR_BIT(mask);
-			  c = myvars->contexts[modeIndex];
-			  [c->timerHeap push: timer];
-			}
-		    }
-		  RELEASE(timer);
-		}
-	      break;
-	    }
+	  timer = [timerHeap next];
 	}
-
-      /* Now, find the earliest remaining timer date while removing
-       * any invalidated timers.
-       */
-      earliest = nil;
-      timer = [timerHeap peek];
-      while (timer != nil)
+      else
 	{
-	  if (timerInvalidated(timer))
-	    {
-	      timer = [timerHeap next];
-	    }
-	  else
-	    {
-	      earliest = timerDate(timer);
-	      break;
-	    }
-	}
-    }
-  else if (TS_SHAREDA == timerStyle)
-    {
-      uint64_t		bit = (UINT64_C(1) << context->modeIndex);
-      unsigned		index;
-      GSIArrayItem	item;
-
-   
-      /* Find and remove blocks of invalidated timers
-       */ 
-      timers = myvars->timers;
-      GSIArrayTrim(timers, timerToTrim);
-
-      count = GSIArrayCount(timers);
-      for (index = 0; index < count; index++)
-	{
-	  item = GSIArrayItemAtIndex(timers, index);
-	  timer = (NSTimer*)item.obj;
-	  if (timer->_modeMask & bit)
-	    {
-	      break;	// First timer in current mode
-	    }
-	}
-      if (index < count)
-	{
-	  d = timerDate(timer);
-	  ti = [d timeIntervalSinceReferenceDate];
-	  if (ti < now)
-	    {
-	      GSIArrayRemoveItemAtIndexNoRelease(timers, 0);
-	      [timer fire];
-	      GSPrivateNotifyASAP(_currentMode);
-	      IF_NO_ARC([arp emptyPool];)
-	      if (updateTimer(timer, d, now) == YES)
-		{
-		  /* Updated ... replace in array.
-		   */
-		  GSIArrayInsertSortedNoRetain(timers, item, sorter);
-		}
-	      else
-		{
-		  RELEASE(timer);
-		}
-	    }
-	}
-
-      /* Now, find the earliest remaining timer date in this mode
-       */
-      earliest = nil;
-      count = GSIArrayCount(timers);
-      for (index = 0; index < count; index++)
-	{
-	  timer = (NSTimer*)GSIArrayItemAtIndex(timers, index).obj;
-	  if (timer->_modeMask & bit)
-	    {
-	      earliest = timerDate(timer);
-	      break;	// First timer in current mode
-	    }
-	}
-    }
-  else
-    {
-      GSIArrayItem	item;
-
-      timers = context->timers;
-
-      GSIArrayTrim(timers, timerToTrim);
-      if (GSIArrayCount(timers) > 0)
-	{
-	  item = GSIArrayItemAtIndex(timers, 0);
-	  timer = item.obj;
 	  d = timerDate(timer);
 	  ti = [d timeIntervalSinceReferenceDate];
 	  if (ti < now)
 	    {
 	      int		modeIndex;
-	      uint64_t		mask;
-	      uint64_t		save;
+	      uint64_t	mask;
+	      uint64_t	save;
 	      GSRunLoopCtxt	*c;
 
-	      GSIArrayRemoveItemAtIndexNoRelease(timers, 0);
+	      timer = [timerHeap popRetained];
 	      mask = timer->_modeMask;
 	      mask &= contextModeMask;
 	      save = mask;
-
-	      while (mask != 0)
+	      while (mask)
 		{
-		  unsigned	location;
-		  unsigned	length;
-
 		  modeIndex = GET_INDEX_AND_CLEAR_BIT(mask);
 		  c = myvars->contexts[modeIndex];
-
-		  /* Find the timers matching our fire date.
-		   */
-		  GSIArrayTrim(c->timers, timerToTrim);
-		  location = GSIArraySearchCount(c->timers,
-		    item, sorter, &length);
-
-		  /* Find our exact timer, and remove it.
-		   */
-		  while (length-- > 0)
-		    {
-		      if (GSIArrayItemAtIndex(c->timers,
-			location + length).obj == timer)
-			{
-			  GSIArrayRemoveItemAtIndex(
-			    c->timers, location + length);
-			  break;
-			}
-		    }
+		  [c->timerHeap removeObjectIdenticalTo: timer];
 		}
 	      [timer fire];
 	      GSPrivateNotifyASAP(_currentMode);
 	      IF_NO_ARC([arp emptyPool];)
 	      if (updateTimer(timer, d, now) == YES)
 		{
-		  /* Updated ... replace in array(s).
+		  /* Updated ... replace in heap.
 		   */
-		  GSIArrayInsertSortedNoRetain(timers, item, sorter);
+		  [timerHeap push: timer];
 		  mask = save;
 		  while (mask)
 		    {
 		      modeIndex = GET_INDEX_AND_CLEAR_BIT(mask);
 		      c = myvars->contexts[modeIndex];
-		      GSIArrayInsertSorted(c->timers, item, sorter);
+		      [c->timerHeap push: timer];
 		    }
 		}
-	      else
-		{
-		  RELEASE(timer);
-		}
+	      RELEASE(timer);
 	    }
-	}
-      /* Now, find the earliest remaining timer date while removing
-       * any invalidated timers.
-       */
-      earliest = nil;
-      count = GSIArrayCount(timers);
-      if (count > 0)
-	{
-	  unsigned	i;
-
-	  for (i = 0; i < count; i++)
-	    {
-	      timer = (NSTimer*)GSIArrayItemAtIndex(timers, i).obj;
-	      if (!timerInvalidated(timer))
-		{
-		  earliest = timerDate(timer);
-		  break;
-		}
-	    }
-	  if (nil == earliest)
-	    {
-	      GSIArrayRemoveAllItems(timers);	// all invalidated
-	    }
-	  else if (i > 0)
-	    {
-	      GSIArrayRemoveItems(timers, 0, i);
-	    }
+	  break;
 	}
     }
+
+  /* Now, find the earliest remaining timer date while removing
+   * any invalidated timers.
+   */
+  earliest = nil;
+  timer = [timerHeap peek];
+  while (timer != nil)
+    {
+      if (timerInvalidated(timer))
+	{
+	  timer = [timerHeap next];
+	}
+      else
+	{
+	  earliest = timerDate(timer);
+	  break;
+	}
+    }
+
   [arp drain];
 
   /* The earliest date of a valid timeout is retained in 'when'

--- a/Source/NSRunLoop.m
+++ b/Source/NSRunLoop.m
@@ -55,9 +55,6 @@
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
-#ifdef HAVE_POLL_F
-#include <poll.h>
-#endif
 #include <math.h>
 #include <time.h>
 
@@ -66,15 +63,19 @@
 #  import "GSDispatch.h"
 #endif
 
-
 NSRunLoopMode const NSDefaultRunLoopMode = @"NSDefaultRunLoopMode";
 NSRunLoopMode const NSRunLoopCommonModes = @"NSRunLoopCommonModes";
 
 static NSDate	*theFuture = nil;
 
-@interface NSObject (OptionalPortRunLoop)
-- (void) getFds: (NSInteger*)fds count: (NSInteger*)count;
-@end
+/* Allow the 'TimerStyle' environment variable to control alternative
+ * timer implementations for ease of testing.
+ */
+static enum {
+  TS_SORTARY,	// Use a sorted array of timers in each context
+  TS_MINHEAP,	// Use a minheap of timers in each context
+  TS_SHAREDA	// Use sorted array shared between contexts
+} timerStyle = TS_SORTARY;
 
 
 
@@ -436,6 +437,81 @@ static inline BOOL timerInvalidated(NSTimer *t)
 
 #endif
 
+
+typedef struct {
+  void                  *sharedContextInfo;
+  uint8_t		modeCount;		/* Number of known modes */
+  uint64_t		commonModeMask;		/* Common modes as mask */
+  NSMapTable		*contextMap;		/* Hash lookup by mode */
+  GSRunLoopCtxt		*contexts[64];		/* Context for each mode */
+  GSIArray		timers;			/* Timers not in contexts */
+} RunLoopInternal;
+                               
+#define myvars	((RunLoopInternal*)_internal)
+                                              
+/* Get the context for the mode name in the current run loop.
+ * Returns nil if it does not exist and was not created.
+ */
+static GSRunLoopCtxt*
+contextForMode(RunLoopInternal *loop, NSString *mode, BOOL shouldCreate)
+{
+  unsigned	limit = (loop->modeCount < 8) ? loop->modeCount : 8;
+  unsigned	index;
+  GSRunLoopCtxt	*c;
+
+  if (limit > 0)
+    {
+      BOOL	(*eq)(id, SEL, id);
+
+      /* The vast majority of applications almost exclusively use just a few
+       * modes and use standard constants (mostly NSRunLoopDefaultMode).
+       *
+       * For efficiency, try the first using direct pointer comparison.
+       * If that doesn't work, try more using the -isEqualtoString: method
+       * (we can cache the implementation of the mode we are looking for).
+       * Only when both strategies fail do we resort to a hash table lookup
+       * (which is more efficient when we have a lot of modes).
+       */
+      if (loop->contexts[0]->mode == mode)
+	{
+	  return loop->contexts[0];	// NSDefaultRunLoopMode
+	}
+
+      eq = (BOOL (*)(id, SEL, id))
+	[mode methodForSelector: @selector(isEqualToString:)];
+      for (index = 0; index < limit; index++)
+	{
+	  c = loop->contexts[index];
+	  if ((*eq)(mode, @selector(isEqualToString:), c->mode))
+	    {
+	      return c;
+	    }
+	}
+      if ((c = (GSRunLoopCtxt*)NSMapGet(loop->contextMap, (void*)mode)) != nil)
+	{
+	  return c;
+	}
+    }
+
+  if (NO == shouldCreate)
+    {
+      return nil;
+    }
+  if (loop->modeCount > 63)
+    {
+      [NSException raise: NSInvalidArgumentException
+		  format: @"Too many nodes added to run loop"];
+    }
+  c = [[GSRunLoopCtxt alloc] initWithMode: mode
+				    extra: &loop->sharedContextInfo];
+  c->modeIndex = loop->modeCount;
+  loop->contexts[loop->modeCount] = c;
+  loop->modeCount++;
+  NSMapInsert(loop->contextMap, c->mode, c);
+  RELEASE(c);
+  return c;
+}
+
 @interface NSRunLoop (Private)
 
 - (void) _addWatcher: (GSRunLoopWatcher*)item
@@ -461,13 +537,7 @@ static inline BOOL timerInvalidated(NSTimer *t)
   GSIArray	watchers;
   unsigned	i;
 
-  context = NSMapGet(_contextMap, mode);
-  if (context == nil)
-    {
-      context = [[GSRunLoopCtxt alloc] initWithMode: mode extra: _extra];
-      NSMapInsert(_contextMap, context->mode, context);
-      RELEASE(context);
-    }
+  context = contextForMode(myvars, mode, YES);
   watchers = context->watchers;
   GSIArrayAddItem(watchers, (GSIArrayItem)((id)item));
   i = GSIArrayCount(watchers);
@@ -481,7 +551,7 @@ static inline BOOL timerInvalidated(NSTimer *t)
 
 - (BOOL) _checkPerformers: (GSRunLoopCtxt*)context
 {
-  BOOL                  found = NO;
+  BOOL	found = NO;
 
   if (context != nil)
     {
@@ -492,9 +562,8 @@ static inline BOOL timerInvalidated(NSTimer *t)
 	{
           NSAutoreleasePool	*arp = [NSAutoreleasePool new];
 	  GSRunLoopPerformer	*array[count];
-	  NSMapEnumerator	enumerator;
 	  GSRunLoopCtxt		*original;
-	  void			*mode;
+	  unsigned		modeIndex;
 	  unsigned		i;
 
           found = YES;
@@ -513,10 +582,11 @@ static inline BOOL timerInvalidated(NSTimer *t)
 	  /* Remove the requests that we are about to fire from all modes.
 	   */
           original = context;
-	  enumerator = NSEnumerateMapTable(_contextMap);
-	  while (NSNextMapEnumeratorPair(&enumerator, &mode, (void**)&context))
+	  modeIndex = myvars->modeCount;
+	  while (modeIndex-- > 0)
 	    {
-	      if (context != nil && context != original)
+	      context = myvars->contexts[modeIndex];
+	      if (context != original)
 		{
 		  GSIArray	performers = context->performers;
 		  unsigned	tmpCount = GSIArrayCount(performers);
@@ -536,7 +606,6 @@ static inline BOOL timerInvalidated(NSTimer *t)
 		    }
 		}
 	    }
-	  NSEndMapTableEnumeration(&enumerator);
 
 	  /* Finally, fire the requests and release them.
 	   */
@@ -572,7 +641,7 @@ static inline BOOL timerInvalidated(NSTimer *t)
 	}
     }
 
-  context = NSMapGet(_contextMap, mode);
+  context = contextForMode(myvars, mode, NO);
   if (context != nil)
     {
       GSIArray	watchers = context->watchers;
@@ -592,19 +661,29 @@ static inline BOOL timerInvalidated(NSTimer *t)
   return nil;
 }
 
+/* Just for debugging ... get at internals
+ */
+- (RunLoopInternal*) internal
+{
+  return myvars;
+}
+
 - (id) _init
 {
-  self = [super init];
-  if (self != nil)
+  if (nil != (self = [super init]))
     {
+      NSZone	*z = NSDefaultMallocZone();
+
       _contextStack = [NSMutableArray new];
-      _contextMap = NSCreateMapTable (NSNonRetainedObjectMapKeyCallBacks,
-					 NSObjectMapValueCallBacks, 0);
       _timedPerformers = [[NSMutableArray alloc] initWithCapacity: 8];
-#ifdef	HAVE_POLL_F
-      _extra = NSZoneMalloc(NSDefaultMallocZone(), sizeof(pollextra));
-      memset(_extra, '\0', sizeof(pollextra));
-#endif
+      _internal = (RunLoopInternal*)NSZoneCalloc(z, 1, sizeof(RunLoopInternal));
+      myvars->contextMap = NSCreateMapTable(
+	NSNonRetainedObjectMapKeyCallBacks, NSObjectMapValueCallBacks, 0);
+      myvars->timers = NSZoneMalloc(z, sizeof(GSIArray_t));
+      GSIArrayInitWithZoneAndCapacity(myvars->timers, z, 8);
+      // The first mode must be NSDefaultRunLoopMode
+      contextForMode(myvars, NSDefaultRunLoopMode, YES);
+      myvars->commonModeMask |= UINT64_C(1);
     }
   return self;
 }
@@ -629,7 +708,7 @@ static inline BOOL timerInvalidated(NSTimer *t)
 	}
     }
 
-  context = NSMapGet(_contextMap, mode);
+  context = contextForMode(myvars, mode, NO);
   if (context != nil)
     {
       GSIArray	watchers = context->watchers;
@@ -755,6 +834,27 @@ static inline BOOL timerInvalidated(NSTimer *t)
 {
   if (self == [NSRunLoop class])
     {
+      NSString	*s;
+
+      s = [[[NSProcessInfo processInfo] environment]
+	objectForKey: @"TimerStyle"];
+      if (s && [s caseInsensitiveCompare: @"SortAry"] == NSOrderedSame)
+	{
+	  timerStyle = TS_SORTARY;
+	}
+      else if (s && [s caseInsensitiveCompare: @"MinHeap"] == NSOrderedSame)
+	{
+	  timerStyle = TS_MINHEAP;
+	}
+      else if (s && [s caseInsensitiveCompare: @"SharedA"] == NSOrderedSame)
+	{
+	  timerStyle = TS_SHAREDA;
+	}
+      else
+	{
+	  timerStyle = TS_MINHEAP;
+	}
+
       [self currentRunLoop];
       theFuture = RETAIN([NSDate distantFuture]);
       RELEASE([NSObject leakAt: &theFuture]);
@@ -850,22 +950,21 @@ static GSMainQueueDrainer 	*drainer = nil;
 
 - (void) dealloc
 {
-#ifdef	HAVE_POLL_F
-  if (_extra != 0)
-    {
-      pollextra	*e = (pollextra*)_extra;
-      if (e->index != 0)
-	NSZoneFree(NSDefaultMallocZone(), e->index);
-      NSZoneFree(NSDefaultMallocZone(), e);
-    }
-#endif
   RELEASE(_contextStack);
-  if (_contextMap != 0)
-    {
-      NSFreeMapTable(_contextMap);
-    }
   RELEASE(_timedPerformers);
-  [super dealloc];
+  if (myvars)
+    {
+      if (myvars->contextMap != 0)
+	{
+	  NSFreeMapTable(myvars->contextMap);
+	}
+      GSIArrayEmpty(myvars->timers);
+      NSZoneFree(myvars->timers->zone, (void*)myvars->timers);
+
+      NSZoneFree(NSDefaultMallocZone(), myvars);
+      _internal = NULL;
+    }
+  DEALLOC
 }
 
 /**
@@ -878,6 +977,38 @@ static GSMainQueueDrainer 	*drainer = nil;
 }
 
 
+
+/* Comparator for timers
+ */
+static NSComparisonResult
+sorter(GSIArrayItem a, GSIArrayItem b)
+{
+  return [(NSTimer*)a.obj compare: (NSTimer*)b.obj];
+}
+
+static BOOL
+timerToTrim(GSIArrayItem item)
+{
+  return ((NSTimer*)(item.obj))->_invalidated;
+}
+
+#if 0
+static NSString *
+logTimers(GSIArray timers)
+{
+  NSMutableString	*s = [NSMutableString stringWithCapacity: 1000];
+  unsigned		count = GSIArrayCount(timers);
+  unsigned		index;
+
+  for (index = 0; index < count; index++)
+    {
+      [s appendFormat: @"    %@\n", GSIArrayItemAtIndex(timers, index).obj];
+    }
+  return s;
+}
+#endif
+
+
 /**
  * Adds a timer to the loop in the specified mode.<br />
  * Timers are removed automatically when they are invalid.<br />
@@ -885,8 +1016,11 @@ static GSMainQueueDrainer 	*drainer = nil;
 - (void) addTimer: (NSTimer*)timer
 	  forMode: (NSString*)mode
 {
+  const void	*loop = (const void*)self;
   GSRunLoopCtxt	*context;
-  GSIArray	timers;
+  GSMinHeap	*timerHeap;
+  GSIArray      timers;
+  uint64_t	modeBit;
   unsigned      i;
 
   if ([timer isKindOfClass: [NSTimer class]] == NO
@@ -896,55 +1030,81 @@ static GSMainQueueDrainer 	*drainer = nil;
 		  format: @"[%@-%@] not a valid timer",
 	NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
     }
+  if (timer->_loop != loop && timer->_loop != nil)
+    {
+      [NSException raise: NSInvalidArgumentException
+		  format: @"[%@-%@] timer already scheduled in another runloop",
+	NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
+    }
   if ([mode isKindOfClass: [NSString class]] == NO)
     {
       [NSException raise: NSInvalidArgumentException
 		  format: @"[%@-%@] not a valid mode",
 	NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
     }
+  context = contextForMode(myvars, mode, YES);
 
   NSDebugMLLog(@"NSRunLoop", @"add timer for %f in %@",
     [[timer fireDate] timeIntervalSinceReferenceDate], mode);
 
-  context = NSMapGet(_contextMap, mode);
-  if (context == nil)
+  timer->_loop = loop;	// Not retained.
+
+  modeBit = (UINT64_C(1) << context->modeIndex);
+
+  if ((timer->_modeMask & modeBit) != 0)
     {
-      context = [[GSRunLoopCtxt alloc] initWithMode: mode extra: _extra];
-      NSMapInsert(_contextMap, context->mode, context);
-      RELEASE(context);
+      return;	// Already present in this mode
     }
-  timers = context->timers;
-  i = GSIArrayCount(timers);
-  while (i-- > 0)
+  if (TS_MINHEAP == timerStyle)
     {
-      if (timer == GSIArrayItemAtIndex(timers, i).obj)
-        {
-          return;       /* Timer already present */
-        }
+      timerHeap = context->timerHeap;
+
+      /* Timers can be scheduled in more than one mode, and if a timer fires
+       * and repeats it will have updated its fire date.  That will leave it
+       * incorrectly positioned in the min heap in other modes.  To handle
+       * that we must track whether it is scheduled in more than one mode to
+       * know if we need to check other modes for repositionng.
+       */
+      [timerHeap push: timer];
+      i = [timerHeap count];
+      if (i % 1000 == 0 && i > context->maxTimers)
+	{
+	  context->maxTimers = i;
+	  NSLog(@"WARNING ... there are %u timers scheduled in mode %@ of %@",
+	    i, mode, self);
+	}
     }
-  /*
-   * NB. A previous version of the timer code maintained an ordered
-   * array on the theory that we could improve performance by only
-   * checking the first few timers (up to the first one whose fire
-   * date is in the future) each time -limitDateForMode: is called.
-   * The problem with this was that it's possible for one timer to
-   * be added in multiple modes (or to different run loops) and for
-   * a repeated timer this could mean that the firing of the timer
-   * in one mode/loop adjusts its date ... without changing the
-   * ordering of the timers in the other modes/loops which contain
-   * the timer.  When the ordering of timers in an array was broken
-   * we could get delays in processing timeouts, so we reverted to
-   * simply having timers in an unordered array and checking them
-   * all each time -limitDateForMode: is called.
-   */
-  GSIArrayAddItem(timers, (GSIArrayItem)((id)timer));
-  i = GSIArrayCount(timers);
-  if (i % 1000 == 0 && i > context->maxTimers)
+  else if (TS_SHAREDA == timerStyle)
     {
-      context->maxTimers = i;
-      NSLog(@"WARNING ... there are %u timers scheduled in mode %@ of %@",
-	i, mode, self);
+      if (0 == timer->_modeMask)
+	{
+	  timers = myvars->timers;
+	  /* When the timer is first scheduled, we must add to the shared
+	   * sorted array.
+	   */
+	  GSIArrayInsertSorted(timers, (GSIArrayItem)((id)timer), sorter);
+	  i = GSIArrayCount(timers);
+	  if (i % 1000 == 0 && i > context->maxTimers)
+	    {
+	      context->maxTimers = i;
+	      NSLog(@"WARNING ... there are %u timers scheduled in %@",
+		i, self);
+	    }
+	}
     }
+  else
+    {
+      timers = context->timers;
+      GSIArrayInsertSorted(timers, (GSIArrayItem)((id)timer), sorter);
+      i = GSIArrayCount(timers);
+      if (i % 1000 == 0 && i > context->maxTimers)
+	{
+	  context->maxTimers = i;
+	  NSLog(@"WARNING ... there are %u timers scheduled in mode %@ of %@",
+	    i, mode, self);
+	}
+    }
+  timer->_modeMask |= modeBit;
 }
 
 
@@ -956,7 +1116,7 @@ static GSMainQueueDrainer 	*drainer = nil;
 static BOOL
 updateTimer(NSTimer *t, NSDate *d, NSTimeInterval now)
 {
-  if (timerInvalidated(t) == YES)
+  if (timerInvalidated(t))
     {
       return NO;
     }
@@ -1003,24 +1163,30 @@ updateTimer(NSTimer *t, NSDate *d, NSTimeInterval now)
   return YES;
 }
 
+/* Efficient code to find the indices of bits in a bitmask (which must
+ * not be zero), clearing the bits as they are processed.
+ */
+#define	GET_INDEX_AND_CLEAR_BIT(mask) ({\
+  int	index = __builtin_clzll((unsigned long long)mask); \
+  mask &= (mask - 1); \
+  index; \
+})
+
 - (NSDate*) _limitDateForContext: (GSRunLoopCtxt *)context
 {
   NSDate		*when = nil;
   NSAutoreleasePool     *arp = [NSAutoreleasePool new];
-  GSIArray		timers = context->timers;
+  uint64_t		contextModeMask = ~(UINT64_C(1)<<context->modeIndex);
+  GSMinHeap		*timerHeap;
+  GSIArray		timers;
+  unsigned		count;
   NSTimeInterval	now;
   NSDate                *earliest;
   NSDate		*d;
-  NSTimer		*t;
+  NSTimer		*timer;
   NSTimeInterval	ti;
-  NSTimeInterval	ei;
-  unsigned              c;
-  unsigned              i;
 
-  ei = 0.0;	// Only needed to avoid compiler warning
-
-  /*
-   * Save current time so we don't keep redoing system call to
+  /* Save current time so we don't keep redoing system call to
    * get it and so that we check timer fire dates against a known
    * value at the point when the method was called.
    * If we refetched the date after firing each timer, the time
@@ -1032,68 +1198,238 @@ updateTimer(NSTimer *t, NSDate *d, NSTimeInterval now)
 
   /* Fire the oldest/first valid timer whose fire date has passed
    * and fire it.
-   * We fire timers in the order in which they were added to the
-   * run loop rather than in date order.  This prevents code
-   * from blocking other timers by adding timers whose fire date
-   * is some time in the past... we guarantee fair handling.
    */
-  c = GSIArrayCount(timers);
-  for (i = 0; i < c; i++)
+  if (TS_MINHEAP == timerStyle)
     {
-      t = GSIArrayItemAtIndex(timers, i).obj;
-      if (timerInvalidated(t) == NO)
-        {
-          d = timerDate(t);
-          ti = [d timeIntervalSinceReferenceDate];
-          if (ti < now)
-            {
-              GSIArrayRemoveItemAtIndexNoRelease(timers, i);
-              [t fire];
-              GSPrivateNotifyASAP(_currentMode);
-              IF_NO_ARC([arp emptyPool];)
-              if (updateTimer(t, d, now) == YES)
-                {
-                  /* Updated ... replace in array.
-                   */
-                  GSIArrayAddItemNoRetain(timers,
-                    (GSIArrayItem)((id)t));
-                }
-              else
-                {
-                  /* The timer was invalidated, so we can
-                   * release it as we aren't putting it back
-                   * in the array.
-                   */
-                  RELEASE(t);
-                }
-              break;
-            }
-        }
-    }
+      timerHeap = context->timerHeap;
+      timer = [timerHeap peek];
+      while (timer != nil)
+	{
+	  if (timerInvalidated(timer))
+	    {
+	      timer = [timerHeap next];
+	    }
+	  else
+	    {
+	      d = timerDate(timer);
+	      ti = [d timeIntervalSinceReferenceDate];
+	      if (ti < now)
+		{
+		  int		modeIndex;
+		  uint64_t	mask;
+		  uint64_t	save;
+		  GSRunLoopCtxt	*c;
 
-  /* Now, find the earliest remaining timer date while removing
-   * any invalidated timers.  We iterate from the end of the
-   * array to minimise the amount of array alteration needed.
-   */
-  earliest = nil;
-  i = GSIArrayCount(timers);
-  while (i-- > 0)
+		  timer = [timerHeap popRetained];
+		  mask = timer->_modeMask;
+		  mask &= contextModeMask;
+		  save = mask;
+		  while (mask)
+		    {
+		      modeIndex = GET_INDEX_AND_CLEAR_BIT(mask);
+		      c = myvars->contexts[modeIndex];
+		      [c->timerHeap removeObjectIdenticalTo: timer];
+		    }
+		  [timer fire];
+		  GSPrivateNotifyASAP(_currentMode);
+		  IF_NO_ARC([arp emptyPool];)
+		  if (updateTimer(timer, d, now) == YES)
+		    {
+		      /* Updated ... replace in heap.
+		       */
+		      [timerHeap push: timer];
+		      mask = save;
+		      while (mask)
+			{
+			  modeIndex = GET_INDEX_AND_CLEAR_BIT(mask);
+			  c = myvars->contexts[modeIndex];
+			  [c->timerHeap push: timer];
+			}
+		    }
+		  RELEASE(timer);
+		}
+	      break;
+	    }
+	}
+
+      /* Now, find the earliest remaining timer date while removing
+       * any invalidated timers.
+       */
+      earliest = nil;
+      timer = [timerHeap peek];
+      while (timer != nil)
+	{
+	  if (timerInvalidated(timer))
+	    {
+	      timer = [timerHeap next];
+	    }
+	  else
+	    {
+	      earliest = timerDate(timer);
+	      break;
+	    }
+	}
+    }
+  else if (TS_SHAREDA == timerStyle)
     {
-      t = GSIArrayItemAtIndex(timers, i).obj;
-      if (timerInvalidated(t) == YES)
-        {
-          GSIArrayRemoveItemAtIndex(timers, i);
-        }
-      else
-        {
-          d = timerDate(t);
-          ti = [d timeIntervalSinceReferenceDate];
-          if (earliest == nil || ti < ei)
-            {
-              earliest = d;
-              ei = ti;
-            }
-        }
+      uint64_t		bit = (UINT64_C(1) << context->modeIndex);
+      unsigned		index;
+      GSIArrayItem	item;
+
+   
+      /* Find and remove blocks of invalidated timers
+       */ 
+      timers = myvars->timers;
+      GSIArrayTrim(timers, timerToTrim);
+
+      count = GSIArrayCount(timers);
+      for (index = 0; index < count; index++)
+	{
+	  item = GSIArrayItemAtIndex(timers, index);
+	  timer = (NSTimer*)item.obj;
+	  if (timer->_modeMask & bit)
+	    {
+	      break;	// First timer in current mode
+	    }
+	}
+      if (index < count)
+	{
+	  d = timerDate(timer);
+	  ti = [d timeIntervalSinceReferenceDate];
+	  if (ti < now)
+	    {
+	      GSIArrayRemoveItemAtIndexNoRelease(timers, 0);
+	      [timer fire];
+	      GSPrivateNotifyASAP(_currentMode);
+	      IF_NO_ARC([arp emptyPool];)
+	      if (updateTimer(timer, d, now) == YES)
+		{
+		  /* Updated ... replace in array.
+		   */
+		  GSIArrayInsertSortedNoRetain(timers, item, sorter);
+		}
+	      else
+		{
+		  RELEASE(timer);
+		}
+	    }
+	}
+
+      /* Now, find the earliest remaining timer date in this mode
+       */
+      earliest = nil;
+      count = GSIArrayCount(timers);
+      for (index = 0; index < count; index++)
+	{
+	  timer = (NSTimer*)GSIArrayItemAtIndex(timers, index).obj;
+	  if (timer->_modeMask & bit)
+	    {
+	      earliest = timerDate(timer);
+	      break;	// First timer in current mode
+	    }
+	}
+    }
+  else
+    {
+      GSIArrayItem	item;
+
+      timers = context->timers;
+
+      GSIArrayTrim(timers, timerToTrim);
+      if (GSIArrayCount(timers) > 0)
+	{
+	  item = GSIArrayItemAtIndex(timers, 0);
+	  timer = item.obj;
+	  d = timerDate(timer);
+	  ti = [d timeIntervalSinceReferenceDate];
+	  if (ti < now)
+	    {
+	      int		modeIndex;
+	      uint64_t		mask;
+	      uint64_t		save;
+	      GSRunLoopCtxt	*c;
+
+	      GSIArrayRemoveItemAtIndexNoRelease(timers, 0);
+	      mask = timer->_modeMask;
+	      mask &= contextModeMask;
+	      save = mask;
+
+	      while (mask != 0)
+		{
+		  unsigned	location;
+		  unsigned	length;
+
+		  modeIndex = GET_INDEX_AND_CLEAR_BIT(mask);
+		  c = myvars->contexts[modeIndex];
+
+		  /* Find the timers matching our fire date.
+		   */
+		  GSIArrayTrim(c->timers, timerToTrim);
+		  location = GSIArraySearchCount(c->timers,
+		    item, sorter, &length);
+
+		  /* Find our exact timer, and remove it.
+		   */
+		  while (length-- > 0)
+		    {
+		      if (GSIArrayItemAtIndex(c->timers,
+			location + length).obj == timer)
+			{
+			  GSIArrayRemoveItemAtIndex(
+			    c->timers, location + length);
+			  break;
+			}
+		    }
+		}
+	      [timer fire];
+	      GSPrivateNotifyASAP(_currentMode);
+	      IF_NO_ARC([arp emptyPool];)
+	      if (updateTimer(timer, d, now) == YES)
+		{
+		  /* Updated ... replace in array(s).
+		   */
+		  GSIArrayInsertSortedNoRetain(timers, item, sorter);
+		  mask = save;
+		  while (mask)
+		    {
+		      modeIndex = GET_INDEX_AND_CLEAR_BIT(mask);
+		      c = myvars->contexts[modeIndex];
+		      GSIArrayInsertSorted(c->timers, item, sorter);
+		    }
+		}
+	      else
+		{
+		  RELEASE(timer);
+		}
+	    }
+	}
+      /* Now, find the earliest remaining timer date while removing
+       * any invalidated timers.
+       */
+      earliest = nil;
+      count = GSIArrayCount(timers);
+      if (count > 0)
+	{
+	  unsigned	i;
+
+	  for (i = 0; i < count; i++)
+	    {
+	      timer = (NSTimer*)GSIArrayItemAtIndex(timers, i).obj;
+	      if (!timerInvalidated(timer))
+		{
+		  earliest = timerDate(timer);
+		  break;
+		}
+	    }
+	  if (nil == earliest)
+	    {
+	      GSIArrayRemoveAllItems(timers);	// all invalidated
+	    }
+	  else if (i > 0)
+	    {
+	      GSIArrayRemoveItems(timers, 0, i);
+	    }
+	}
     }
   [arp drain];
 
@@ -1140,7 +1476,7 @@ updateTimer(NSTimer *t, NSDate *d, NSTimeInterval now)
   GSRunLoopCtxt		*context;
   NSDate		*when = nil;
 
-  context = NSMapGet(_contextMap, mode);
+  context = contextForMode(myvars, mode, NO);
   if (context != nil)
     {
       NSString		*savedMode = _currentMode;
@@ -1187,7 +1523,7 @@ updateTimer(NSTimer *t, NSDate *d, NSTimeInterval now)
     {
       mode = NSDefaultRunLoopMode;
     }
-  context = NSMapGet(_contextMap, mode);
+  context = contextForMode(myvars, mode, NO);
   if (nil == context)
     {
       return;
@@ -1315,7 +1651,7 @@ updateTimer(NSTimer *t, NSDate *d, NSTimeInterval now)
    * another thread.
    */
   _currentMode = mode;
-  context = NSMapGet(_contextMap, mode);
+  context = contextForMode(myvars, mode, NO);
   [self _checkPerformers: context];
   _currentMode = savedMode;
 
@@ -1407,32 +1743,25 @@ updateTimer(NSTimer *t, NSDate *d, NSTimeInterval now)
  */
 - (void) cancelPerformSelectorsWithTarget: (id) target
 {
-  NSMapEnumerator	enumerator;
-  GSRunLoopCtxt		*context;
-  void			*mode;
+  unsigned	modeIndex = myvars->modeCount;
 
-  enumerator = NSEnumerateMapTable(_contextMap);
-
-  while (NSNextMapEnumeratorPair(&enumerator, &mode, (void**)&context))
+  while (modeIndex-- > 0)
     {
-      if (context != nil)
+      GSRunLoopCtxt	*context = myvars->contexts[modeIndex];
+      GSIArray		performers = context->performers;
+      unsigned		count = GSIArrayCount(performers);
+
+      while (count--)
 	{
-	  GSIArray	performers = context->performers;
-	  unsigned	count = GSIArrayCount(performers);
+	  GSRunLoopPerformer	*p;
 
-	  while (count--)
+	  p = GSIArrayItemAtIndex(performers, count).obj;
+	  if (p->target == target)
 	    {
-	      GSRunLoopPerformer	*p;
-
-	      p = GSIArrayItemAtIndex(performers, count).obj;
-	      if (p->target == target)
-		{
-		  GSIArrayRemoveItemAtIndex(performers, count);
-		}
+	      GSIArrayRemoveItemAtIndex(performers, count);
 	    }
 	}
     }
-  NSEndMapTableEnumeration(&enumerator);
 }
 
 /**
@@ -1446,33 +1775,26 @@ updateTimer(NSTimer *t, NSDate *d, NSTimeInterval now)
 			target: (id) target
 		      argument: (id) argument
 {
-  NSMapEnumerator	enumerator;
-  GSRunLoopCtxt		*context;
-  void			*mode;
+  unsigned	modeIndex = myvars->modeCount;
 
-  enumerator = NSEnumerateMapTable(_contextMap);
-
-  while (NSNextMapEnumeratorPair(&enumerator, &mode, (void**)&context))
+  while (modeIndex-- > 0)
     {
-      if (context != nil)
+      GSRunLoopCtxt	*context = myvars->contexts[modeIndex];
+      GSIArray		performers = context->performers;
+      unsigned		count = GSIArrayCount(performers);
+
+      while (count--)
 	{
-	  GSIArray	performers = context->performers;
-	  unsigned	count = GSIArrayCount(performers);
+	  GSRunLoopPerformer	*p;
 
-	  while (count--)
+	  p = GSIArrayItemAtIndex(performers, count).obj;
+	  if (p->target == target && sel_isEqual(p->selector, aSelector)
+	    && (p->argument == argument || [p->argument isEqual: argument]))
 	    {
-	      GSRunLoopPerformer	*p;
-
-	      p = GSIArrayItemAtIndex(performers, count).obj;
-	      if (p->target == target && sel_isEqual(p->selector, aSelector)
-		&& (p->argument == argument || [p->argument isEqual: argument]))
-		{
-		  GSIArrayRemoveItemAtIndex(performers, count);
-		}
+	      GSIArrayRemoveItemAtIndex(performers, count);
 	    }
 	}
     }
-  NSEndMapTableEnumeration(&enumerator);
 }
 
 /**
@@ -1533,14 +1855,7 @@ updateTimer(NSTimer *t, NSDate *d, NSTimeInterval now)
 	  GSRunLoopCtxt	*context;
 	  GSIArray	performers;
 
-	  context = NSMapGet(_contextMap, mode);
-	  if (context == nil)
-	    {
-	      context = [[GSRunLoopCtxt alloc] initWithMode: mode
-						      extra: _extra];
-	      NSMapInsert(_contextMap, context->mode, context);
-	      RELEASE(context);
-	    }
+	  context = contextForMode(myvars, mode, YES);
 	  performers = context->performers;
 
 	  end = GSIArrayCount(performers);

--- a/Source/NSTimer.m
+++ b/Source/NSTimer.m
@@ -66,21 +66,32 @@ static Class	NSDate_class;
 
   if ([self isValid])
     {
-      if (_selector == 0)
+      if (nil == _target)
+	{
+          s = [NSString stringWithFormat: @"%@ at %@ calls %@",
+            s, [self fireDate], _block];
+	}
+      else if (_selector == 0)
         {
-          return [NSString stringWithFormat: @"%@ at %@ invokes %@",
+          s = [NSString stringWithFormat: @"%@ at %@ invokes %@",
             s, [self fireDate], _target];
         }
       else
         {
-          return [NSString stringWithFormat: @"%@ at %@ sends %@ to (%@)",
+          s = [NSString stringWithFormat: @"%@ at %@ sends %@ to (%@)",
             s, [self fireDate], NSStringFromSelector(_selector), _target];
         }
+      if (_modeMask)
+	{
+	  s = [s stringByAppendingFormat: @", scheduled in modes: 0x%0"PRIx64,
+	    _modeMask];
+	}
     }
   else
     {
-      return [NSString stringWithFormat: @"%@ (invalidated)", s];
+      s = [NSString stringWithFormat: @"%@ (invalidated)", s];
     }
+  return s;
 }
 
 /* For MacOS-X compatibility, this returns nil.

--- a/Source/unix/GSRunLoopCtxt.m
+++ b/Source/unix/GSRunLoopCtxt.m
@@ -1,9 +1,6 @@
 /**
- * The GSRunLoopCtxt stores context information to handle polling for
- * events.  This information is associated with a particular runloop
- * mode, and persists throughout the life of the runloop instance.
- *
- *	NB.  This class is private to NSRunLoop and must not be subclassed.
+ * Unix/Linux subclasss of the GSRunLoopCtxt class.
+ * NB.  This class is private to NSRunLoop
  */
 
 #import "common.h"
@@ -27,51 +24,33 @@
 #include <poll.h>
 #endif
 
+#ifdef  HAVE_POLL
+typedef struct {
+  int   	limit;
+  short 	*index;
+  unsigned	refcount;
+} pollextra;
+#endif
+
 #define	FDCOUNT	1024
 
-static SEL	wRelSel;
-static SEL	wRetSel;
-static IMP	wRelImp;
-static IMP	wRetImp;
-
-static void
-wRelease(NSMapTable* t, void* w)
+@interface	GSRunLoopCtxtUnix: GSRunLoopCtxt
 {
-  (*wRelImp)((id)w, wRelSel);
+  NSMapTable    *_efdMap;
+  NSMapTable    *_rfdMap;
+  NSMapTable    *_wfdMap;
+#ifdef  HAVE_POLL_F
+  unsigned int  pollfds_capacity;
+  unsigned int  pollfds_count;
+  struct pollfd *pollfds;
+#endif
 }
+@end
 
-static void
-wRetain(NSMapTable* t, const void* w)
-{
-  (*wRetImp)((id)w, wRetSel);
-}
-
-static const NSMapTableValueCallBacks WatcherMapValueCallBacks = 
-{
-  wRetain,
-  wRelease,
-  0
-};
-
-@implementation	GSRunLoopCtxt
-
-+ (void) initialize
-{
-  wRelSel = @selector(release);
-  wRetSel = @selector(retain);
-  wRelImp = [[GSRunLoopWatcher class] instanceMethodForSelector: wRelSel];
-  wRetImp = [[GSRunLoopWatcher class] instanceMethodForSelector: wRetSel];
-}
+@implementation	GSRunLoopCtxtUnix
 
 - (void) dealloc
 {
-  RELEASE(mode);
-  GSIArrayEmpty(performers);
-  NSZoneFree(performers->zone, (void*)performers);
-  GSIArrayEmpty(timers);
-  NSZoneFree(timers->zone, (void*)timers);
-  GSIArrayEmpty(watchers);
-  NSZoneFree(watchers->zone, (void*)watchers);
   if (_efdMap != 0)
     {
       NSFreeMapTable(_efdMap);
@@ -84,15 +63,26 @@ static const NSMapTableValueCallBacks WatcherMapValueCallBacks =
     {
       NSFreeMapTable(_wfdMap);
     }
-  GSIArrayEmpty(_trigger);
-  NSZoneFree(_trigger->zone, (void*)_trigger);
-#ifdef	HAVE_POLL_F
+#ifdef  HAVE_POLL_F
   if (pollfds != 0)
     {
       NSZoneFree(NSDefaultMallocZone(), pollfds);
     }
+  if (extra)
+    {
+      pollextra	*pe = (pollextra*)extra;
+
+      if (--pe->refcount == 0)
+	{
+	  if (pe->index != 0)
+	    {
+	      NSZoneFree(NSDefaultMallocZone(), pe->index);
+	    }
+	  NSZoneFree(NSDefaultMallocZone(), pe);
+	}
+    }
 #endif
-  [super dealloc];
+  DEALLOC
 }
 
 /**
@@ -143,56 +133,31 @@ static const NSMapTableValueCallBacks WatcherMapValueCallBacks =
     }
 }
 
-/**
- * Mark this poll context as having completed, so that if we are
- * executing a re-entrant poll, the enclosing poll operations
- * know they can stop what they are doing because an inner
- * operation has done the job.
- */
-- (void) endPoll
+- (id) initWithMode: (NSString*)theMode extra: (void**)e
 {
-  completed = YES;
-}
-
-- (id) init
-{
-  [NSException raise: NSInternalInconsistencyException
-	      format: @"-init may not be called for GSRunLoopCtxt"];
-  return nil;
-}
-
-- (id) initWithMode: (NSString*)theMode extra: (void*)e
-{
-  self = [super init];
-  if (self != nil)
+  if (nil != (self = [super initWithMode: theMode extra: e]))
     {
-      NSZone	*z;
-
-      mode = [theMode copy];
-      extra = e;
-      z = [self zone];
-      performers = NSZoneMalloc(z, sizeof(GSIArray_t));
-      timers = NSZoneMalloc(z, sizeof(GSIArray_t));
-      watchers = NSZoneMalloc(z, sizeof(GSIArray_t));
-      _trigger = NSZoneMalloc(z, sizeof(GSIArray_t));
-      GSIArrayInitWithZoneAndCapacity(performers, z, 8);
-      GSIArrayInitWithZoneAndCapacity(timers, z, 8);
-      GSIArrayInitWithZoneAndCapacity(watchers, z, 8);
-      GSIArrayInitWithZoneAndCapacity(_trigger, z, 8);
-
       _efdMap = NSCreateMapTable (NSIntegerMapKeyCallBacks,
-				      WatcherMapValueCallBacks, 0);
+	[self watcherCallbacks], 0);
       _rfdMap = NSCreateMapTable (NSIntegerMapKeyCallBacks,
-				      WatcherMapValueCallBacks, 0);
+	[self watcherCallbacks], 0);
       _wfdMap = NSCreateMapTable (NSIntegerMapKeyCallBacks,
-				      WatcherMapValueCallBacks, 0);
+	[self watcherCallbacks], 0);
+#ifdef	HAVE_POLL_F
+      if (NULL == *e)
+	{
+          *e = extra
+	    = NSZoneCalloc(NSDefaultMallocZone(), 1, sizeof(pollextra));
+	}
+      ((pollextra*)extra)->refcount++;
+#endif
     }
   return self;
 }
 
 #ifdef	HAVE_POLL_F
 
-static void setPollfd(int fd, int event, GSRunLoopCtxt *ctxt)
+static void setPollfd(int fd, int event, GSRunLoopCtxtUnix *ctxt)
 {
   int		index;
   struct pollfd *pollfds = ctxt->pollfds;

--- a/Source/win32/GSRunLoopCtxt.m
+++ b/Source/win32/GSRunLoopCtxt.m
@@ -1,9 +1,6 @@
 /**
- * The GSRunLoopCtxt stores context information to handle polling for
- * events.  This information is associated with a particular runloop
- * mode, and persists throughout the life of the runloop instance.
- *
- *	NB.  This class is private to NSRunLoop and must not be subclassed.
+ * MS-Windows subclass of the GSRunLoopCtxt class.
+ * NB.  This class is private to NSRunLoop
  */
 
 #import "common.h"
@@ -19,49 +16,17 @@
 
 #define	FDCOUNT	1024
 
-static SEL	wRelSel;
-static SEL	wRetSel;
-static IMP	wRelImp;
-static IMP	wRetImp;
-
-static void
-wRelease(NSMapTable* t, void* w)
+@interface	GSRunLoopCtxtWin32: GSRunLoopCtxt
 {
-  (*wRelImp)((id)w, wRelSel);
+  NSMapTable    *handleMap;     
+  NSMapTable    *winMsgMap;
 }
+@end
 
-static void
-wRetain(NSMapTable* t, const void* w)
-{
-  (*wRetImp)((id)w, wRetSel);
-}
-
-static const NSMapTableValueCallBacks WatcherMapValueCallBacks = 
-{
-  wRetain,
-  wRelease,
-  0
-};
-
-@implementation	GSRunLoopCtxt
-
-+ (void) initialize
-{
-  wRelSel = @selector(release);
-  wRetSel = @selector(retain);
-  wRelImp = [[GSRunLoopWatcher class] instanceMethodForSelector: wRelSel];
-  wRetImp = [[GSRunLoopWatcher class] instanceMethodForSelector: wRetSel];
-}
+@implementation	GSRunLoopCtxtWin32
 
 - (void) dealloc
 {
-  RELEASE(mode);
-  GSIArrayEmpty(performers);
-  NSZoneFree(performers->zone, (void*)performers);
-  GSIArrayEmpty(timers);
-  NSZoneFree(timers->zone, (void*)timers);
-  GSIArrayEmpty(watchers);
-  NSZoneFree(watchers->zone, (void*)watchers);
   if (handleMap != 0)
     {
       NSFreeMapTable(handleMap);
@@ -70,9 +35,7 @@ static const NSMapTableValueCallBacks WatcherMapValueCallBacks =
     {
       NSFreeMapTable(winMsgMap);
     }
-  GSIArrayEmpty(_trigger);
-  NSZoneFree(_trigger->zone, (void*)_trigger);
-  [super dealloc];
+  DEALLOC
 }
 
 /**
@@ -88,17 +51,7 @@ static const NSMapTableValueCallBacks WatcherMapValueCallBacks =
 {
   if (completed == NO)
     {
-      unsigned i = GSIArrayCount(_trigger);
-
-      while (i-- > 0)
-	{
-	  GSIArrayItem	item = GSIArrayItemAtIndex(_trigger, i);
-
-	  if (item.obj == (id)watcher)
-	    {
-	      GSIArrayRemoveItemAtIndex(_trigger, i);
-	    }
-	}
+      [super endEvent: data for: watcher];
       switch (watcher->type)
 	{
 	  case ET_RPORT:
@@ -118,17 +71,6 @@ static const NSMapTableValueCallBacks WatcherMapValueCallBacks =
     }
 }
 
-/**
- * Mark this poll context as having completed, so that if we are
- * executing a re-entrant poll, the enclosing poll operations
- * know they can stop what they are doing because an inner
- * operation has done the job.
- */
-- (void) endPoll
-{
-  completed = YES;
-}
-
 - (id) init
 {
   [NSException raise: NSInternalInconsistencyException
@@ -136,29 +78,14 @@ static const NSMapTableValueCallBacks WatcherMapValueCallBacks =
   return nil;
 }
 
-- (id) initWithMode: (NSString*)theMode extra: (void*)e
+- (id) initWithMode: (NSString*)theMode extra: (void**)e
 {
-  self = [super init];
-  if (self != nil)
+  if (nil != (self = [super initWithMode: theMode extra: e]))
     {
-      NSZone	*z;
-
-      mode = [theMode copy];
-      extra = e;
-      z = [self zone];
-      performers = NSZoneMalloc(z, sizeof(GSIArray_t));
-      timers = NSZoneMalloc(z, sizeof(GSIArray_t));
-      watchers = NSZoneMalloc(z, sizeof(GSIArray_t));
-      _trigger = NSZoneMalloc(z, sizeof(GSIArray_t));
-      GSIArrayInitWithZoneAndCapacity(performers, z, 8);
-      GSIArrayInitWithZoneAndCapacity(timers, z, 8);
-      GSIArrayInitWithZoneAndCapacity(watchers, z, 8);
-      GSIArrayInitWithZoneAndCapacity(_trigger, z, 8);
-
       handleMap = NSCreateMapTable(NSIntegerMapKeyCallBacks,
-              WatcherMapValueCallBacks, 0);
+	[self watcherCallbacks], 0);
       winMsgMap = NSCreateMapTable(NSIntegerMapKeyCallBacks,
-              WatcherMapValueCallBacks, 0);
+	[self watcherCallbacks], 0);
     }
   return self;
 }


### PR DESCRIPTION
Changes from using an array of timers in each context to using a min heap for far better handling if a loop gets a huge number of timers.  Also, tracks which modes a timer is present in, so that on firing a repeating timer we avoid having to check all other modes to see if the timer is there too.
Also optimises lookup of the context for the mode that a loop is running in on each iteration.