### PR TITLE
CI: add a NetBSD job running under vmactions/netbsd-vm

### DIFF
--- a/.github/scripts/dependencies.sh
+++ b/.github/scripts/dependencies.sh
@@ -2,6 +2,10 @@
 
 set -ex
 
+# NetBSD and the other BSDs ship a non-GNU make as /usr/bin/make, so allow the
+# caller to point us at GNU make. Defaults to plain "make" everywhere else.
+MAKE=${MAKE:-make}
+
 install_gnustep_make() {
     echo "::group::GNUstep Make"
     cd $DEPS_PATH
@@ -15,7 +19,7 @@ install_gnustep_make() {
       MAKE_OPTS="$MAKE_OPTS --with-runtime-abi=$RUNTIME_VERSION"
     fi
     ./configure --prefix=$INSTALL_PATH --with-library-combo=$LIBRARY_COMBO --with-libdir=$LIBDIR $MAKE_OPTS || cat config.log
-    make install
+    $MAKE install
 
     echo Objective-C build flags:
     $INSTALL_PATH/bin/gnustep-config --objc-flags
@@ -38,7 +42,7 @@ install_libobjc2() {
       -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_PATH \
       -DEMBEDDED_BLOCKS_RUNTIME=ON \
       ../
-    make install
+    $MAKE install
     echo "::endgroup::"
 }
 
@@ -54,7 +58,7 @@ install_libdispatch() {
       -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_PATH \
       -DINSTALL_PRIVATE_HEADERS=1 \
       ../
-    make install
+    $MAKE install
     echo "::endgroup::"
 }
 
@@ -64,7 +68,11 @@ mkdir -p $DEPS_PATH
 # the MSYS2 toolchain uses Pacman to install non-GNUstep dependencies.
 if [ "$LIBRARY_COMBO" = "ng-gnu-gnu" -a "$IS_WINDOWS_MSVC" != "true" -a "$IS_WINDOWS_MINGW" != "true" ]; then
     install_libobjc2
-    install_libdispatch
+    # libdispatch is optional for gnustep-base and does not support every
+    # platform we build on, so allow a workflow to opt out of it.
+    if [ "$INSTALL_LIBDISPATCH" != "false" ]; then
+        install_libdispatch
+    fi
 fi
 
 install_gnustep_make

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -1,0 +1,128 @@
+name: NetBSD
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  netbsd:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    # don't run pull requests from local branches twice
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: NetBSD 10.1 x86_64 Clang gnustep-2.2
+            release: "10.1"
+            library-combo: ng-gnu-gnu
+            runtime-version: gnustep-2.2
+            # Known NetBSD test failures, see the uploaded Tests/tests.log:
+            #   base/NSException/basic.m:54 - -callStackReturnAddresses is
+            #     empty. configure reports "checking for backtrace... no"
+            #     because on NetBSD backtrace() is in libexecinfo, not libc.
+            #   base/NSURL/basic.m - segmentation fault
+            #   base/NSURLSession/simpleTaskTests.m - aborts
+            #   base/NSTask/posix_spawn_multithread.m - aborts, intermittently
+            allow-test-failures: true
+
+    env:
+      LIBRARY_COMBO: ${{ matrix.library-combo }}
+      RUNTIME_VERSION: ${{ matrix.runtime-version }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          path: source
+
+      - name: Build and test in NetBSD ${{ matrix.release }}
+        uses: vmactions/netbsd-vm@v1
+        with:
+          release: ${{ matrix.release }}
+          usesh: true
+          cache-after-prepare: true
+          envs: 'LIBRARY_COMBO RUNTIME_VERSION'
+
+          # NetBSD is a minimal base install: everything below comes from
+          # pkgsrc. The package set mirrors the dependencies of pkgsrc's own
+          # devel/gnustep-base.
+          prepare: |
+            set -e
+            /usr/sbin/pkg_add \
+              bash \
+              clang \
+              cmake \
+              curl \
+              git-base \
+              gmake \
+              gmp \
+              gnutls \
+              icu \
+              libffi \
+              libunwind \
+              libxml2 \
+              libxslt \
+              pkgconf
+
+          # Building and installing must succeed for this step to pass. The
+          # result of "make check" is written to Tests/check-status and turned
+          # into a pass/fail by the "Check test results" step below, so that the
+          # logs are always copied back to the runner.
+          run: |
+            set -e
+            # The action runs this script with "set -eu"; gnustep-make's
+            # GNUstep.sh probes unset variables such as $ZSH_VERSION and so is
+            # not "set -u" clean.
+            set +u
+
+            export PATH="/usr/pkg/bin:/usr/pkg/sbin:$PATH"
+            export SRC_PATH="$GITHUB_WORKSPACE/source"
+            export DEPS_PATH="$HOME/dependencies"
+            export INSTALL_PATH="$HOME/build"
+            export LIBDIR=lib
+            export CC=clang
+            export CXX=clang++
+            # NetBSD's /usr/bin/make is bmake; the dependency builds need GNU make
+            export MAKE=gmake
+            # swift-corelibs-libdispatch has no NetBSD support, and gnustep-base
+            # treats libdispatch as optional
+            export INSTALL_LIBDISPATCH=false
+
+            cd "$SRC_PATH"
+            ./.github/scripts/dependencies.sh
+
+            . "$INSTALL_PATH/share/GNUstep/Makefiles/GNUstep.sh"
+            cd "$SRC_PATH"
+            # NetBSD's libc iconv has no //TRANSLIT, so lossy conversion is
+            # unavailable. pkgsrc builds devel/gnustep-base the same way.
+            ./configure --enable-limitediconv
+            gmake -j"$(sysctl -n hw.ncpu)"
+            gmake install
+
+            CHECK_STATUS=0
+            gmake check || CHECK_STATUS=$?
+            echo "$CHECK_STATUS" > "$SRC_PATH/Tests/check-status"
+
+            if [ "$CHECK_STATUS" != 0 ]; then
+              echo "===== crashes and failures in Tests/tests.log ====="
+              grep -n -B5 -A25 -iE "aborted|signal|Segmentation|Abort trap|Bus error" \
+                "$SRC_PATH/Tests/tests.log" | head -300 || true
+            fi
+
+      - name: Check test results
+        continue-on-error: ${{ matrix.allow-test-failures || false }}
+        run: |
+          tail -n 12 source/Tests/tests.log || true
+          exit "$(cat source/Tests/check-status)"
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: Logs - ${{ matrix.name }}
+          path: |
+            source/config.log
+            source/Tests/tests.log

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ GNUstep Base Library
 ====================
 
 [![CI](https://github.com/gnustep/libs-base/actions/workflows/main.yml/badge.svg)](https://github.com/gnustep/libs-base/actions/workflows/main.yml?query=branch%3Amaster)
+[![NetBSD](https://github.com/gnustep/libs-base/actions/workflows/netbsd.yml/badge.svg)](https://github.com/gnustep/libs-base/actions/workflows/netbsd.yml?query=branch%3Amaster)
 
 The GNUstep Base Library is a library of general-purpose, non-graphical
 Objective C objects.  For example, it includes classes for strings,


### PR DESCRIPTION
Closes #551.

GitHub hosts no NetBSD runner, so this builds and tests NetBSD 10.1 / x86_64 inside QEMU on an ordinary `ubuntu-latest` runner, using `vmactions/netbsd-vm` as suggested in the issue.

### What this adds

**`.github/workflows/netbsd.yml`** -- a separate workflow rather than another job in `main.yml`. The NetBSD job takes 11-18 min and has its own known-failure policy, so keeping it separate means it neither slows nor gates the existing matrix. Happy to fold it into `main.yml` if you prefer everything in one file.

**Two changes to `.github/scripts/dependencies.sh`**, both no-ops when the new variables are unset:

- `MAKE=${MAKE:-make}` -- `/usr/bin/make` on NetBSD is bmake, which cannot read the Makefiles CMake generates. The workflow sets `MAKE=gmake`.
- `install_libdispatch` is skipped when `INSTALL_LIBDISPATCH=false`. swift-corelibs-libdispatch has no NetBSD support, and `configure.ac` already treats libdispatch as optional ("just ignore libdispatch if it's not there").

**A README badge** for the new workflow.

### Toolchain

clang + libobjc2 (`ng-gnu-gnu`, `gnustep-2.2`) -- the combination pkgsrc uses for `devel/gnustep-base`, whose `gnustep.mk` sets `PKGSRC_COMPILER=clang` and `ONLY_FOR_COMPILER=clang`. clang 21.1 comes from pkgsrc; NetBSD base ships no Objective-C compiler. The `prepare` package set is modelled on the buildlinks of pkgsrc's own `devel/gnustep-base`.

Two NetBSD-specific settings, both for the same reason pkgsrc has them:

- `--enable-limitediconv` -- NetBSD's libc iconv has no `//TRANSLIT`.
- `set +u` before sourcing `GNUstep.sh` -- the action runs the script under `set -eu`, and `GNUstep.sh` probes `$ZSH_VERSION` unguarded.

### Results

[Run on the head of this branch](https://github.com/neilpang/libs-base/actions/runs/30372736063) -- 11 min, 273 files compiled, library built and installed, and:

```
13233 Passed tests
   45 Dashed hopes
    3 Skipped sets
    2 Failed files
    1 Failed test
```

`make check` is turned into a verdict by a separate step, so the logs are always copied back and uploaded as an artifact. That step carries `continue-on-error: ${{ matrix.allow-test-failures || false }}` -- the escape hatch the Windows jobs already have -- because of four pre-existing NetBSD failures:

| test | seen in | symptom |
|---|---|---|
| `base/NSException/basic.m:54` | 4/4 runs | `-callStackReturnAddresses` is empty |
| `base/NSURL/basic.m` | 4/4 runs | segmentation fault |
| `base/NSURLSession/simpleTaskTests.m` | 4/4 runs | aborts |
| `base/NSTask/posix_spawn_multithread.m` | 1/4 runs | aborts, intermittently |

Building and installing the library is still a hard gate -- only the test verdict is soft. Drop `allow-test-failures` from the matrix if you would rather the job go red on any test failure.

One root cause is already clear: configure reports `checking for execinfo.h... yes` but `checking for backtrace... no`, because on NetBSD `backtrace()` lives in `libexecinfo`, not libc, so `AC_CHECK_FUNCS(backtrace)` fails without `-lexecinfo`. That is a `configure.ac` change and I left it out of this PR; happy to send it separately.

### Notes

- `cache-after-prepare: true` caches the VM image after the pkgsrc install, so the package step is skipped on later runs with an unchanged `prepare`.
- The `551-netbsd-ci-runner` prototype pointed the way; it could not run as-is because `runs-on: netbsd-latest` is not a runner GitHub provides and the job body referenced `$PKGIN_PACKAGES` while the env defined `NETBSD_PACKAGES`.
