### PR TITLE
NSUnarchiver: decode an integer into a char destination

### DIFF
--- a/Source/NSUnarchiver.m
+++ b/Source/NSUnarchiver.m
@@ -250,6 +250,18 @@ typeCheck(char t1, char t2)
       if ((c == _C_FLT || c == _C_DBL) && (t1 == _C_FLT || t1 == _C_DBL))
 	return NO;
 
+/* Also allow an integer in the archive to be decoded into a char, as BOOL is
+ * a char on most platforms but an int with the libobjc2 runtime on Windows
+ * (unless that is built with STRICT_APPLE_COMPATIBILITY), so an archive (such
+ * as a gorm) written there has to decode its BOOL values into char
+ * destinations elsewhere.
+ */
+      if ((t1 == _C_CHR || t1 == _C_UCHR)
+	&& (c == _C_SHT || c == _C_USHT || c == _C_INT || c == _C_UINT
+	  || c == _C_LNG || c == _C_ULNG
+	  || c == _C_LNG_LNG || c == _C_ULNG_LNG))
+	return NO;
+
       [NSException raise: NSInternalInconsistencyException
 		  format: @"expected %s and got %s",
 		    typeToName1(t1), typeToName2(t2)];
@@ -679,7 +691,8 @@ static unsigned	encodingVersion;
 	  offset += size;
 	}
     }
-  else if (*type == _C_SHT
+  else if (*type == _C_CHR
+    || *type == _C_SHT
     || *type == _C_INT
     || *type == _C_LNG
     || *type == _C_LNG_LNG)
@@ -789,7 +802,7 @@ static unsigned	encodingVersion;
 	{
 	  void	*address = (void*)buf + offset;
 
-	  switch (info & _GSC_SIZE)
+	  switch (ainfo & _GSC_SIZE)
 	    {
 	      case _GSC_I16:	/* Encoded as 16-bit	*/
 		{
@@ -1372,7 +1385,8 @@ scalarSize(char type)
    *	First, we read the data and convert it to the largest size
    *	this system can support.
    */
-  if (*type == _C_SHT
+  if (*type == _C_CHR
+    || *type == _C_SHT
     || *type == _C_INT
     || *type == _C_LNG
     || *type == _C_LNG_LNG)

--- a/Tests/base/NSArchiver/charNarrowing.m
+++ b/Tests/base/NSArchiver/charNarrowing.m
@@ -1,0 +1,113 @@
+#import <Foundation/NSArchiver.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSException.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import "Testing.h"
+
+/* A value archived as an integer must decode into a char destination.
+   BOOL is a char on most platforms but an int with the libobjc2 runtime on
+   Windows, so a gorm written there archives its BOOL values as ints and has
+   to decode them into char slots everywhere else.  This is the reverse of the
+   char to int widening in charWidening.m.  (gnustep/libs-gui#318) */
+
+#define	ARCHIVE_AS(NAME, TYPE) \
+static NSData * \
+NAME (TYPE v) \
+{ \
+  NSMutableData *d = [NSMutableData data]; \
+  NSArchiver *a = [[NSArchiver alloc] initForWritingWithMutableData: d]; \
+  [a encodeValueOfObjCType: @encode(TYPE) at: &v]; \
+  [a release]; \
+  return d; \
+}
+
+ARCHIVE_AS(archiveShort, short)
+ARCHIVE_AS(archiveInt, int)
+ARCHIVE_AS(archiveUInt, unsigned int)
+ARCHIVE_AS(archiveLongLong, long long)
+
+/* Decode data as type, returning whether it succeeded without an exception. */
+static BOOL
+decodeAs(NSData *data, const char *type, void *out)
+{
+  NSUnarchiver *u = [[NSUnarchiver alloc] initForReadingWithData: data];
+  BOOL ok = YES;
+
+  NS_DURING
+    [u decodeValueOfObjCType: type at: out];
+  NS_HANDLER
+    ok = NO;
+  NS_ENDHANDLER
+  [u release];
+  return ok;
+}
+
+int
+main(void)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  char c = -1;
+  signed char sc = -1;
+  unsigned char uc = 1;
+  int i = -1;
+
+  PASS(decodeAs(archiveInt(1), @encode(char), &c) && c == 1,
+    "an int archived as 1 decodes into a char as 1");
+  PASS(decodeAs(archiveInt(0), @encode(char), &c) && c == 0,
+    "an int archived as 0 decodes into a char as 0");
+  PASS(decodeAs(archiveInt(1), @encode(unsigned char), &uc) && uc == 1,
+    "an int archived as 1 decodes into an unsigned char as 1");
+  PASS(decodeAs(archiveInt(-5), @encode(signed char), &sc) && sc == -5,
+    "an int archived as -5 decodes into a signed char as -5");
+  PASS(decodeAs(archiveUInt(200), @encode(unsigned char), &uc) && uc == 200,
+    "an unsigned int archived as 200 decodes into an unsigned char as 200");
+  PASS(decodeAs(archiveShort(7), @encode(char), &c) && c == 7,
+    "a short archived as 7 decodes into a char as 7");
+  PASS(decodeAs(archiveLongLong(1), @encode(char), &c) && c == 1,
+    "a long long archived as 1 decodes into a char as 1");
+
+  PASS(decodeAs(archiveInt(1234), @encode(int), &i) && i == 1234,
+    "an int still decodes into an int unchanged");
+
+  {
+    NSMutableData	*d = [NSMutableData data];
+    NSArchiver		*a;
+    NSUnarchiver	*u;
+    int			ints[4] = { 0, 1, 127, -5 };
+    unsigned int	uints[3] = { 0, 1, 200 };
+    char		chars[4] = { 9, 9, 9, 9 };
+    unsigned char	uchars[3] = { 9, 9, 9 };
+    BOOL		ok = YES;
+
+    a = [[NSArchiver alloc] initForWritingWithMutableData: d];
+    [a encodeArrayOfObjCType: @encode(int) count: 4 at: ints];
+    [a release];
+    u = [[NSUnarchiver alloc] initForReadingWithData: d];
+    NS_DURING
+      [u decodeArrayOfObjCType: @encode(char) count: 4 at: chars];
+    NS_HANDLER
+      ok = NO;
+    NS_ENDHANDLER
+    [u release];
+    PASS(ok && chars[0] == 0 && chars[1] == 1 && chars[2] == 127
+      && chars[3] == -5, "an array of ints decodes into an array of chars");
+
+    d = [NSMutableData data];
+    a = [[NSArchiver alloc] initForWritingWithMutableData: d];
+    [a encodeArrayOfObjCType: @encode(unsigned int) count: 3 at: uints];
+    [a release];
+    ok = YES;
+    u = [[NSUnarchiver alloc] initForReadingWithData: d];
+    NS_DURING
+      [u decodeArrayOfObjCType: @encode(unsigned char) count: 3 at: uchars];
+    NS_HANDLER
+      ok = NO;
+    NS_ENDHANDLER
+    [u release];
+    PASS(ok && uchars[0] == 0 && uchars[1] == 1 && uchars[2] == 200,
+      "an array of unsigned ints decodes into an array of unsigned chars");
+  }
+
+  [arp release]; arp = nil;
+  return 0;
+}

--- a/Tests/base/NSArchiver/charNarrowing.m
+++ b/Tests/base/NSArchiver/charNarrowing.m
@@ -21,6 +21,7 @@ NAME (TYPE v) \
   return d; \
 }
 
+ARCHIVE_AS(archiveUChar, unsigned char)
 ARCHIVE_AS(archiveShort, short)
 ARCHIVE_AS(archiveInt, int)
 ARCHIVE_AS(archiveUInt, unsigned int)
@@ -68,6 +69,18 @@ main(void)
 
   PASS(decodeAs(archiveInt(1234), @encode(int), &i) && i == 1234,
     "an int still decodes into an int unchanged");
+
+  /* BOOL is a char in some builds and an int in others, so one of these two
+     is a decode across widths whichever build this is. */
+  {
+    BOOL	b = NO;
+
+    PASS(decodeAs(archiveInt(1), @encode(BOOL), &b) && b,
+      "a BOOL archived as an int decodes as YES");
+    b = NO;
+    PASS(decodeAs(archiveUChar(1), @encode(BOOL), &b) && b,
+      "a BOOL archived as an unsigned char decodes as YES");
+  }
 
   {
     NSMutableData	*d = [NSMutableData data];


### PR DESCRIPTION
Follow up to #702, which let a char in an archive decode into a wider integer destination so that a gorm written where BOOL is a char loads on Windows, where the libobjc2 runtime makes BOOL an int.

This is the other direction. A gorm saved on Windows archives its BOOL values as ints, and every other platform decodes them into chars, which raised "expected unsigned char and got int".

The code that handles a value whose natural size is not the same as on the machine the archive was created on already reads the archived width and narrows it to the destination, and its size switch already covers one byte destinations, so the only thing needed was to let the type check fall through to it for a char destination. That also covers decodeArrayOfObjCType:count:at:. The unsigned branch of the array conversion read its size bits from the local type info rather than from the archive tag, which raised "invalid size in archive" once a char destination could reach it, so it reads the archive tag now.

Checked against a real gorm. Loading GSPrintPanel.gorm, re-archiving it through an NSArchiver subclass that writes every char as an int, which is what a Windows build produces, then reading it back raises "expected unsigned char and got int" without this change and returns the GSNibContainer with it.

Tests/base/NSArchiver/charNarrowing.m covers int, short and long long into char, signed and unsigned, plus the two array cases. 7 of its 10 assertions fail without the change and all 10 pass with it. NSArchiver, coding, NSKeyedArchiver and NSData all pass.

Relates to gnustep/libs-gui#318.
