### PR TITLE
Fix: use an intermediate object's own observer registration in a key path

### DIFF
--- a/Source/NSKVOInternal.h
+++ b/Source/NSKVOInternal.h
@@ -68,11 +68,13 @@
   } while (false)
 
 @class _NSKVOKeypathObserver;
+@class _NSKVOForwardingRelay;
 
 @interface _NSKVOKeyObserver : NSObject
 {
   _NSKVOKeypathObserver	*_keypathObserver;
   _NSKVOKeyObserver     *_restOfKeypathObserver;
+  _NSKVOForwardingRelay *_restOfKeypathRelay;
   NSArray               *_dependentObservers;
   id                     _object;
   NSString              *_key;
@@ -90,6 +92,7 @@
               affectedObservers: (NSArray *)affectedObservers;
 @property (nonatomic, retain) _NSKVOKeypathObserver	*keypathObserver;
 @property (nonatomic, retain) _NSKVOKeyObserver     	*restOfKeypathObserver;
+@property (nonatomic, retain) _NSKVOForwardingRelay 	*restOfKeypathRelay;
 @property (nonatomic, retain) NSArray               	*dependentObservers;
 @property (nonatomic, assign) id                     	object;
 @property (nonatomic, copy) NSString                	*key;
@@ -121,6 +124,21 @@
 @property (nonatomic, assign) void                      *context;
 
 @property (retain) NSMutableDictionary *pendingChange;
+@end
+
+/* Observes on behalf of a key path whose intermediate object registers
+ * observations on the objects it holds.
+ */
+@interface _NSKVOForwardingRelay : NSObject
+{
+  id                     _object;
+  NSString              *_keypath;
+  _NSKVOKeypathObserver *_keypathObserver;
+}
+- (instancetype) initWithObject: (id)object
+                        keypath: (NSString *)keypath
+                keypathObserver: (_NSKVOKeypathObserver *)keypathObserver;
+- (void) stop;
 @end
 
 @interface _NSKVOObservationInfo : NSObject

--- a/Source/NSKVOSupport.m
+++ b/Source/NSKVOSupport.m
@@ -70,6 +70,7 @@ _NSKVCSplitKeypath(NSString *keyPath, NSString **pRemainder)
  * accessors are synthesized explicitly. */
 @synthesize keypathObserver = _keypathObserver;
 @synthesize restOfKeypathObserver = _restOfKeypathObserver;
+@synthesize restOfKeypathRelay = _restOfKeypathRelay;
 @synthesize dependentObservers = _dependentObservers;
 @synthesize object = _object;
 @synthesize key = _key;
@@ -101,6 +102,7 @@ _NSKVCSplitKeypath(NSString *keyPath, NSString **pRemainder)
   [_restOfKeypath release];
   [_dependentObservers release];
   [_restOfKeypathObserver release];
+  [_restOfKeypathRelay release];
   [_affectedObservers release];
   [super dealloc];
 }
@@ -159,6 +161,81 @@ _NSKVCSplitKeypath(NSString *keyPath, NSString **pRemainder)
 {
   return __atomic_fetch_sub(&_changeDepth, 1, __ATOMIC_SEQ_CST) == 1;
 }
+@end
+#pragma endregion
+
+#pragma region Forwarding Relay
+/* Stands between an object that registers observations on the objects it
+ * holds and the observer of the whole key path.  The change is reported for
+ * the key path being observed, on the object being observed, whichever of the
+ * held objects it came from.
+ */
+@implementation _NSKVOForwardingRelay
+
+- (instancetype) initWithObject: (id)object
+                        keypath: (NSString *)keypath
+                keypathObserver: (_NSKVOKeypathObserver *)keypathObserver
+{
+  if (nil != (self = [super init]))
+    {
+      _object = object;
+      _keypath = [keypath copy];
+      _keypathObserver = RETAIN(keypathObserver);
+
+      [object addObserver: self
+               forKeyPath: keypath
+                  options: 0
+                  context: NULL];
+    }
+  return self;
+}
+
+- (void) stop
+{
+  [_object removeObserver: self forKeyPath: _keypath];
+  _object = nil;
+}
+
+- (void) dealloc
+{
+  [_keypath release];
+  [_keypathObserver release];
+  [super dealloc];
+}
+
+- (void) observeValueForKeyPath: (NSString *)keyPath
+                       ofObject: (id)object
+                         change: (NSDictionary *)change
+                        context: (void *)context
+{
+  id                   observer = [_keypathObserver observer];
+  NSString            *keypath = [_keypathObserver keypath];
+  id                   rootObject = [_keypathObserver object];
+  NSMutableDictionary *relayed;
+
+  if (nil == observer)
+    {
+      return;
+    }
+
+  relayed = [NSMutableDictionary
+    dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:
+                                   NSKeyValueChangeSetting],
+                                 NSKeyValueChangeKindKey, nil];
+
+  if (([_keypathObserver options] & NSKeyValueObservingOptionNew))
+    {
+      id newValue = [rootObject valueForKeyPath: keypath] ?: [NSNull null];
+
+      [relayed setObject: newValue forKey: NSKeyValueChangeNewKey];
+    }
+
+  [observer observeValueForKeyPath: keypath
+                          ofObject: rootObject
+                            change: relayed
+                           context: [_keypathObserver context]];
+}
+
 @end
 #pragma endregion
 
@@ -373,6 +450,86 @@ _addKeypathObserver(id object, NSString *keypath,
 static void
 _removeKeyObserver(_NSKVOKeyObserver *keyObserver);
 
+/* An object may register observations on the objects it holds, by way of its
+ * own -addObserver:forKeyPath:options:context:.  That implementation has to be
+ * used or nothing it holds is ever observed.  A plain collection, which
+ * refuses the registration, and a proxy, which forwards the method and so
+ * would look like such an object, are both left to the ordinary path.
+ */
+static BOOL
+_registersObservationsItself(id object)
+{
+  SEL   selector = @selector(addObserver:forKeyPath:options:context:);
+  Class class;
+  Class root;
+  IMP   implementation;
+
+  if (nil == object)
+    {
+      return NO;
+    }
+
+  root = class = object_getClass(object);
+  while (class_getSuperclass(root) != Nil)
+    {
+      root = class_getSuperclass(root);
+    }
+  if (root != [NSObject class])
+    {
+      return NO;
+    }
+
+  implementation = class_getMethodImplementation(class, selector);
+
+  return implementation
+      != class_getMethodImplementation([NSObject class], selector)
+    && implementation
+      != class_getMethodImplementation([NSArray class], selector)
+    && implementation
+      != class_getMethodImplementation([NSSet class], selector);
+}
+
+/* Observe the rest of a key path on the value of its first key. */
+static void
+_attachRestOfKeypath(_NSKVOKeyObserver *keyObserver)
+{
+  id value = [keyObserver.object valueForKey: keyObserver.key];
+
+  if (_registersObservationsItself(value))
+    {
+      _NSKVOForwardingRelay *relay;
+
+      relay = [[_NSKVOForwardingRelay alloc]
+                initWithObject: value
+                       keypath: keyObserver.restOfKeypath
+               keypathObserver: keyObserver.keypathObserver];
+      keyObserver.restOfKeypathRelay = relay;
+      [relay release];
+    }
+  else
+    {
+      keyObserver.restOfKeypathObserver
+        = _addKeypathObserver(value, keyObserver.restOfKeypath,
+                              keyObserver.keypathObserver,
+                              keyObserver.affectedObservers);
+    }
+}
+
+static void
+_detachRestOfKeypath(_NSKVOKeyObserver *keyObserver)
+{
+  if (keyObserver.restOfKeypathRelay)
+    {
+      [keyObserver.restOfKeypathRelay stop];
+      keyObserver.restOfKeypathRelay = nil;
+    }
+  if (keyObserver.restOfKeypathObserver)
+    {
+      _removeKeyObserver(keyObserver.restOfKeypathObserver);
+      keyObserver.restOfKeypathObserver = nil;
+    }
+}
+
 // Add all observers with declared dependencies on this one:
 // * All keypaths that could trigger a change (keypaths for values affecting
 // us).
@@ -478,12 +635,10 @@ _addNestedObserversAndOptionallyDependents(_NSKVOKeyObserver *keyObserver,
     }
 
   // If restOfKeypath is non-nil, we have to chain on further observers.
-  if (keyObserver.restOfKeypath && !keyObserver.restOfKeypathObserver)
+  if (keyObserver.restOfKeypath && !keyObserver.restOfKeypathObserver
+      && !keyObserver.restOfKeypathRelay)
     {
-      keyObserver.restOfKeypathObserver
-        = _addKeypathObserver([object valueForKey:key],
-                              keyObserver.restOfKeypath, keypathObserver,
-                              keyObserver.affectedObservers);
+      _attachRestOfKeypath(keyObserver);
     }
 
   // Back-propagation of changes.
@@ -491,14 +646,10 @@ _addNestedObserversAndOptionallyDependents(_NSKVOKeyObserver *keyObserver,
   // be reconstructed.
   for (_NSKVOKeyObserver *affectedObserver in keyObserver.affectedObservers)
     {
-      if (!affectedObserver.restOfKeypathObserver)
+      if (!affectedObserver.restOfKeypathObserver
+          && !affectedObserver.restOfKeypathRelay)
         {
-          affectedObserver.restOfKeypathObserver
-            = _addKeypathObserver([affectedObserver.object
-                                    valueForKey:affectedObserver.key],
-                                  affectedObserver.restOfKeypath,
-                                  affectedObserver.keypathObserver,
-                                  affectedObserver.affectedObservers);
+          _attachRestOfKeypath(affectedObserver);
         }
     }
 }
@@ -556,18 +707,15 @@ _removeNestedObserversAndOptionallyDependents(_NSKVOKeyObserver *keyObserver,
   /* Fast path: a simple (non-keypath) observer with no dependents and no
    * affected observers has no nested work here. */
   if (!dependents && keyObserver.restOfKeypathObserver == nil
+      && keyObserver.restOfKeypathRelay == nil
       && keyObserver.dependentObservers == nil
       && keyObserver.affectedObservers == nil)
     {
       return;
     }
 
-  if (keyObserver.restOfKeypathObserver)
-    {
-      // Destroy the subpath observer recursively.
-      _removeKeyObserver(keyObserver.restOfKeypathObserver);
-      keyObserver.restOfKeypathObserver = nil;
-    }
+  // Destroy the subpath observer recursively.
+  _detachRestOfKeypath(keyObserver);
 
   if (dependents)
     {
@@ -597,8 +745,7 @@ _removeNestedObserversAndOptionallyDependents(_NSKVOKeyObserver *keyObserver,
       // (triggers in _addDependentAndNestedObservers).
       for (_NSKVOKeyObserver *affectedObserver in keyObserver.affectedObservers)
         {
-          _removeKeyObserver(affectedObserver.restOfKeypathObserver);
-          affectedObserver.restOfKeypathObserver = nil;
+          _detachRestOfKeypath(affectedObserver);
         }
     }
 }

--- a/Tests/base/NSKVOSupport/keypathRegistration.m
+++ b/Tests/base/NSKVOSupport/keypathRegistration.m
@@ -1,0 +1,197 @@
+/* An object in the middle of a key path may take charge of observer
+   registration, in order to pass it on to the objects it holds.  That is how
+   the gui library exposes an array controller's arranged objects.  Its
+   -addObserver:forKeyPath:options:context: has to be used, otherwise a change
+   to one of the held objects is never reported.
+*/
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSEnumerator.h>
+#import <Foundation/NSException.h>
+#import <Foundation/NSKeyValueObserving.h>
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+#import <GNUstepBase/GNUstep.h>
+
+#import "Testing.h"
+
+static int registrations = 0;
+
+@interface Element : NSObject
+{
+  NSString *_name;
+}
+- (NSString *) name;
+- (void) setName: (NSString *)aName;
+@end
+
+@implementation Element
+- (NSString *) name { return _name; }
+- (void) setName: (NSString *)aName { ASSIGN(_name, aName); }
+- (void) dealloc { RELEASE(_name); DEALLOC }
+@end
+
+/* Holds objects and passes registration on to them. */
+@interface Registrar : NSObject
+{
+  NSArray *_elements;
+}
+- (id) initWithElements: (NSArray *)elements;
+@end
+
+@implementation Registrar
+
+- (id) initWithElements: (NSArray *)elements
+{
+  if ((self = [super init]) != nil)
+    {
+      ASSIGN(_elements, elements);
+    }
+  return self;
+}
+
+- (void) dealloc
+{
+  RELEASE(_elements);
+  DEALLOC
+}
+
+- (id) valueForKey: (NSString *)key
+{
+  return [_elements valueForKey: key];
+}
+
+- (void) addObserver: (NSObject *)observer
+          forKeyPath: (NSString *)keyPath
+             options: (NSKeyValueObservingOptions)options
+             context: (void *)context
+{
+  NSEnumerator *e = [_elements objectEnumerator];
+  id element;
+
+  registrations++;
+  while ((element = [e nextObject]) != nil)
+    {
+      [element addObserver: observer
+                forKeyPath: keyPath
+                   options: options
+                   context: context];
+    }
+}
+
+- (void) removeObserver: (NSObject *)observer forKeyPath: (NSString *)keyPath
+{
+  NSEnumerator *e = [_elements objectEnumerator];
+  id element;
+
+  while ((element = [e nextObject]) != nil)
+    {
+      [element removeObserver: observer forKeyPath: keyPath];
+    }
+}
+
+@end
+
+@interface Holder : NSObject
+{
+  Registrar *_registrar;
+}
+- (Registrar *) registrar;
+- (void) setRegistrar: (Registrar *)aRegistrar;
+@end
+
+@implementation Holder
+- (Registrar *) registrar { return _registrar; }
+- (void) setRegistrar: (Registrar *)aRegistrar { ASSIGN(_registrar, aRegistrar); }
+- (void) dealloc { RELEASE(_registrar); DEALLOC }
+@end
+
+@interface Watcher : NSObject
+{
+@public
+  int       count;
+  NSString *lastKeyPath;
+  id        lastObject;
+}
+@end
+
+@implementation Watcher
+- (void) observeValueForKeyPath: (NSString *)keyPath
+                       ofObject: (id)object
+                         change: (NSDictionary *)change
+                        context: (void *)context
+{
+  count++;
+  ASSIGN(lastKeyPath, keyPath);
+  lastObject = object;
+}
+- (void) dealloc { RELEASE(lastKeyPath); DEALLOC }
+@end
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  Element *element = AUTORELEASE([[Element alloc] init]);
+  Registrar *registrar;
+  Holder *holder = AUTORELEASE([[Holder alloc] init]);
+  Watcher *watcher = AUTORELEASE([[Watcher alloc] init]);
+
+  [element setName: @"a"];
+  registrar = AUTORELEASE([[Registrar alloc]
+    initWithElements: [NSArray arrayWithObject: element]]);
+  [holder setRegistrar: registrar];
+
+  [holder addObserver: watcher
+           forKeyPath: @"registrar.name"
+              options: NSKeyValueObservingOptionNew
+              context: NULL];
+
+  PASS(registrations == 1,
+       "the object in the middle of the key path registers the observation");
+
+  [element setName: @"b"];
+
+  PASS(watcher->count == 1,
+       "changing a held object reports the key path");
+  PASS_EQUAL(watcher->lastKeyPath, @"registrar.name",
+             "the whole key path is reported");
+  PASS(watcher->lastObject == holder,
+       "the object of the notification is the one being observed");
+
+  [holder removeObserver: watcher forKeyPath: @"registrar.name"];
+  [element setName: @"c"];
+
+  PASS(watcher->count == 1,
+       "no notification arrives once the observer is removed");
+
+  /* A plain array refuses an observer, so a key path through one is left as
+     it was: the observation is registered, and no change is reported. */
+  {
+    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+    BOOL raised = NO;
+
+    [dict setObject: [NSArray arrayWithObject: element] forKey: @"list"];
+
+    NS_DURING
+      {
+        [dict addObserver: watcher
+               forKeyPath: @"list.name"
+                  options: NSKeyValueObservingOptionNew
+                  context: NULL];
+        [dict removeObserver: watcher forKeyPath: @"list.name"];
+      }
+    NS_HANDLER
+      {
+        raised = YES;
+      }
+    NS_ENDHANDLER
+
+    PASS(raised == NO,
+         "a key path through a plain array is still accepted");
+  }
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
An object in the middle of a key path may register observations on the objects it holds, through its own `-addObserver:forKeyPath:options:context:`. That implementation is never called. The observation is written into the observation info of the object itself, so nothing it holds is observed and a change to one of those objects is never reported. The gui library exposes an array controller's arranged objects that way, which is why a table column bound to `arrangedObjects.<key>` is never told that one of the objects changed, gnustep/libs-gui#99.

The rest of the key path is now registered through that implementation when the object has one, and a relay reports the change for the whole key path, on the object being observed.

A plain array or set refuses such a registration and is left as it was, so key paths that read through an array, such as the aggregate operators, keep working, and a key path to a property of the objects in a plain array still reports nothing. A proxy is left alone too.

Tests/base/NSKVOSupport/keypathRegistration.m. Six assertions fail before the change and pass after.

Refers to #707.

