### PR TITLE
tests: import the headers posix_spawn_multithread.m uses

### DIFF
--- a/Tests/base/NSTask/posix_spawn_multithread.m
+++ b/Tests/base/NSTask/posix_spawn_multithread.m
@@ -1,6 +1,8 @@
 #import <Foundation/NSAutoreleasePool.h>
 #import <Foundation/NSTask.h>
+#import <Foundation/NSDate.h>
 #import <Foundation/NSFileManager.h>
+#import <Foundation/NSRunLoop.h>
 #import <Foundation/NSThread.h>
 #import <Foundation/NSArray.h>
 #import <Foundation/NSString.h>


### PR DESCRIPTION
Tests/base/NSTask/posix_spawn_multithread.m waits for its threads with `[[NSRunLoop currentRunLoop] runMode: beforeDate:]` but imports neither NSRunLoop.h nor NSDate.h. Where neither is reached through another header the file does not compile, `gnustep-tests` reports a failed build for it, and none of its assertions run. Here it fails with `use of undeclared identifier 'NSRunLoop'`.

The two headers are now imported, in the style of the other imports in the file.

The test itself is unchanged.

Tests/base/NSTask/posix_spawn_multithread.m.

The file does not build before the change, so none of its three assertions run. After it they run and pass.

