### PR TITLE
Fix: compare expressions and predicates on what they describe

### DIFF
--- a/Source/NSPredicate.m
+++ b/Source/NSPredicate.m
@@ -433,6 +433,16 @@ extern void     GSPropertyListMake(id,NSDictionary*,BOOL,BOOL,unsigned,id*);
 
 @implementation GSTruePredicate
 
+- (BOOL) isEqual: (id)other
+{
+  return (self == other) || [other isKindOfClass: [GSTruePredicate class]];
+}
+
+- (NSUInteger) hash
+{
+  return 1;
+}
+
 - (id) copyWithZone: (NSZone *)z
 {
   return RETAIN(self);
@@ -452,6 +462,16 @@ extern void     GSPropertyListMake(id,NSDictionary*,BOOL,BOOL,unsigned,id*);
 
 @implementation GSFalsePredicate
 
+- (BOOL) isEqual: (id)other
+{
+  return (self == other) || [other isKindOfClass: [GSFalsePredicate class]];
+}
+
+- (NSUInteger) hash
+{
+  return 0;
+}
+
 - (id) copyWithZone: (NSZone *)z
 {
   return RETAIN(self);
@@ -470,6 +490,30 @@ extern void     GSPropertyListMake(id,NSDictionary*,BOOL,BOOL,unsigned,id*);
 @end
 
 @implementation NSCompoundPredicate
+
+- (BOOL) isEqual: (id)other
+{
+  NSCompoundPredicate	*o = other;
+
+  if (self == other)
+    {
+      return YES;
+    }
+  if (NO == [other isKindOfClass: [NSCompoundPredicate class]])
+    {
+      return NO;
+    }
+  if ([o compoundPredicateType] != [self compoundPredicateType])
+    {
+      return NO;
+    }
+  return [[o subpredicates] isEqual: [self subpredicates]];
+}
+
+- (NSUInteger) hash
+{
+  return [[self subpredicates] hash] ^ (NSUInteger)[self compoundPredicateType];
+}
 
 + (NSPredicate *) andPredicateWithSubpredicates: (NSArray *)list
 {
@@ -689,6 +733,39 @@ extern void     GSPropertyListMake(id,NSDictionary*,BOOL,BOOL,unsigned,id*);
 @end
 
 @implementation NSComparisonPredicate
+
+- (BOOL) isEqual: (id)other
+{
+  NSComparisonPredicate	*o = other;
+
+  if (self == other)
+    {
+      return YES;
+    }
+  if (NO == [other isKindOfClass: [NSComparisonPredicate class]])
+    {
+      return NO;
+    }
+  if ([o comparisonPredicateModifier] != [self comparisonPredicateModifier]
+    || [o predicateOperatorType] != [self predicateOperatorType]
+    || [o options] != [self options])
+    {
+      return NO;
+    }
+  if (NSCustomSelectorPredicateOperatorType == [self predicateOperatorType]
+    && NO == sel_isEqual([o customSelector], [self customSelector]))
+    {
+      return NO;
+    }
+  return [[o leftExpression] isEqual: [self leftExpression]]
+    && [[o rightExpression] isEqual: [self rightExpression]];
+}
+
+- (NSUInteger) hash
+{
+  return [[self leftExpression] hash] ^ [[self rightExpression] hash]
+    ^ (NSUInteger)[self predicateOperatorType];
+}
 
 + (NSPredicate *) predicateWithLeftExpression: (NSExpression *)left
                               rightExpression: (NSExpression *)right
@@ -1233,6 +1310,32 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
     }
 }
 
+/* Two expressions of a kind that holds nothing further, such as the one
+ * standing for the object being evaluated, are the same expression.  The
+ * kinds that do hold something compare it themselves.
+ */
+- (BOOL) isEqual: (id)other
+{
+  if (self == other)
+    {
+      return YES;
+    }
+  if (NO == [other isKindOfClass: [NSExpression class]])
+    {
+      return NO;
+    }
+  if ([other class] != [self class])
+    {
+      return NO;
+    }
+  return ([(NSExpression *)other expressionType] == [self expressionType]);
+}
+
+- (NSUInteger) hash
+{
+  return (NSUInteger)[self expressionType];
+}
+
 + (NSExpression *) expressionForConstantValue: (id)obj
 {
   GSConstantValueExpression *e;
@@ -1523,6 +1626,30 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
   return _obj;
 }
 
+- (BOOL) isEqual: (id)other
+{
+  GSConstantValueExpression	*o = other;
+
+  if (self == other)
+    {
+      return YES;
+    }
+  if (NO == [other isKindOfClass: [GSConstantValueExpression class]])
+    {
+      return NO;
+    }
+  if (_obj == o->_obj)
+    {
+      return YES;
+    }
+  return [_obj isEqual: o->_obj];
+}
+
+- (NSUInteger) hash
+{
+  return [_obj hash];
+}
+
 - (NSString *) description
 {
   if ([_obj isKindOfClass: [NSString class]])
@@ -1629,6 +1756,24 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
   return [NSString stringWithFormat: @"$%@", _variable];
 }
 
+- (BOOL) isEqual: (id)other
+{
+  if (self == other)
+    {
+      return YES;
+    }
+  if (NO == [other isKindOfClass: [GSVariableExpression class]])
+    {
+      return NO;
+    }
+  return [_variable isEqual: ((GSVariableExpression *)other)->_variable];
+}
+
+- (NSUInteger) hash
+{
+  return [_variable hash];
+}
+
 - (id) expressionValueWithObject: (id)object
 			 context: (NSMutableDictionary *)context
 {
@@ -1678,6 +1823,24 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
   return _keyPath;
 }
 
+- (BOOL) isEqual: (id)other
+{
+  if (self == other)
+    {
+      return YES;
+    }
+  if (NO == [other isKindOfClass: [GSKeyPathExpression class]])
+    {
+      return NO;
+    }
+  return [_keyPath isEqual: ((GSKeyPathExpression *)other)->_keyPath];
+}
+
+- (NSUInteger) hash
+{
+  return [_keyPath hash];
+}
+
 - (id) expressionValueWithObject: (id)object
 			 context: (NSMutableDictionary *)context
 {
@@ -1712,6 +1875,26 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 @end
 
 @implementation GSBinaryExpression
+
+- (BOOL) isEqual: (id)other
+{
+  GSBinaryExpression	*o = other;
+
+  if (self == other)
+    {
+      return YES;
+    }
+  if ([other class] != [self class])
+    {
+      return NO;
+    }
+  return [_left isEqual: o->_left] && [_right isEqual: o->_right];
+}
+
+- (NSUInteger) hash
+{
+  return [_left hash] ^ [_right hash];
+}
 
 - (id) copyWithZone: (NSZone*)zone
 {
@@ -1880,6 +2063,24 @@ do { \
 
 @implementation GSAggregateExpression
 
+- (BOOL) isEqual: (id)other
+{
+  if (self == other)
+    {
+      return YES;
+    }
+  if (NO == [other isKindOfClass: [GSAggregateExpression class]])
+    {
+      return NO;
+    }
+  return [_collection isEqual: ((GSAggregateExpression *)other)->_collection];
+}
+
+- (NSUInteger) hash
+{
+  return [_collection hash];
+}
+
 - (id) copyWithZone: (NSZone*)zone
 {
   GSAggregateExpression *copy;
@@ -1929,6 +2130,34 @@ do { \
 - (NSArray *) arguments
 {
   return _args;
+}
+
+- (BOOL) isEqual: (id)other
+{
+  GSFunctionExpression	*o = other;
+
+  if (self == other)
+    {
+      return YES;
+    }
+  if (NO == [other isKindOfClass: [GSFunctionExpression class]])
+    {
+      return NO;
+    }
+  if (NO == [_function isEqual: o->_function])
+    {
+      return NO;
+    }
+  if (_args == o->_args)
+    {
+      return YES;
+    }
+  return [_args isEqual: o->_args];
+}
+
+- (NSUInteger) hash
+{
+  return [_function hash] ^ [_args hash];
 }
 
 - (NSString *) description

--- a/Tests/base/NSPredicate/equality.m
+++ b/Tests/base/NSPredicate/equality.m
@@ -1,0 +1,84 @@
+/* Expressions and predicates that describe the same thing are equal, as they
+   are on OS X.  Without this an expression can only be found in a collection
+   by identity, which is what -[NSArray containsObject:] and
+   -[NSArray indexOfObject:] are given to work with.
+*/
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSExpression.h>
+#import <Foundation/NSPredicate.h>
+#import <Foundation/NSString.h>
+#import "ObjectTesting.h"
+
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSExpression *keyA = [NSExpression expressionForKeyPath: @"name"];
+  NSExpression *keyB = [NSExpression expressionForKeyPath: @"name"];
+  NSExpression *keyC = [NSExpression expressionForKeyPath: @"other"];
+  NSExpression *conA = [NSExpression expressionForConstantValue: @"x"];
+  NSExpression *conB = [NSExpression expressionForConstantValue: @"x"];
+  NSExpression *conC = [NSExpression expressionForConstantValue: @"y"];
+  NSExpression *varA = [NSExpression expressionForVariable: @"v"];
+  NSExpression *varB = [NSExpression expressionForVariable: @"v"];
+  NSExpression *funA = [NSExpression expressionForFunction: @"sum"
+                                                 arguments:
+                          [NSArray arrayWithObject: keyA]];
+  NSExpression *funB = [NSExpression expressionForFunction: @"sum"
+                                                 arguments:
+                          [NSArray arrayWithObject: keyB]];
+  NSExpression *selfA = [NSExpression expressionForEvaluatedObject];
+  NSExpression *selfB = [NSExpression expressionForEvaluatedObject];
+
+  PASS([keyA isEqual: keyB], "key path expressions of the same path are equal");
+  PASS(![keyA isEqual: keyC], "key path expressions of other paths differ");
+  PASS([keyA hash] == [keyB hash], "equal key path expressions hash alike");
+
+  PASS([conA isEqual: conB], "constant expressions of the same value are equal");
+  PASS(![conA isEqual: conC], "constant expressions of other values differ");
+  PASS([conA hash] == [conB hash], "equal constant expressions hash alike");
+
+  PASS(![keyA isEqual: conA], "a key path is not a constant");
+
+  PASS([varA isEqual: varB], "variable expressions of the same name are equal");
+  PASS([funA isEqual: funB], "function expressions of the same call are equal");
+  PASS([selfA isEqual: selfB], "the evaluated object expression is one thing");
+
+  PASS([[NSArray arrayWithObject: keyA] containsObject: keyB],
+       "an equal key path expression is found in an array");
+  PASS([[NSArray arrayWithObject: conA] indexOfObject: conB] == 0,
+       "an equal constant expression is found in an array");
+
+  {
+    NSPredicate *p1 = [NSPredicate predicateWithFormat: @"name == 'x'"];
+    NSPredicate *p2 = [NSPredicate predicateWithFormat: @"name == 'x'"];
+    NSPredicate *p3 = [NSPredicate predicateWithFormat: @"name == 'y'"];
+    NSPredicate *p4 = [NSPredicate predicateWithFormat: @"name ==[c] 'x'"];
+    NSPredicate *p5 = [NSPredicate predicateWithFormat: @"name CONTAINS 'x'"];
+    NSPredicate *c1 = [NSPredicate predicateWithFormat: @"a == 1 AND b == 2"];
+    NSPredicate *c2 = [NSPredicate predicateWithFormat: @"a == 1 AND b == 2"];
+    NSPredicate *c3 = [NSPredicate predicateWithFormat: @"a == 1 OR b == 2"];
+
+    PASS([p1 isEqual: p2], "comparison predicates of the same shape are equal");
+    PASS(![p1 isEqual: p3], "a different constant makes a different predicate");
+    PASS(![p1 isEqual: p4], "different options make a different predicate");
+    PASS(![p1 isEqual: p5], "a different operator makes a different predicate");
+    PASS([p1 hash] == [p2 hash], "equal comparison predicates hash alike");
+
+    PASS([c1 isEqual: c2], "compound predicates of the same shape are equal");
+    PASS(![c1 isEqual: c3], "a different compound type makes a different predicate");
+    PASS([c1 hash] == [c2 hash], "equal compound predicates hash alike");
+    PASS(![c1 isEqual: p1], "a compound predicate is not a comparison");
+
+    PASS([[NSPredicate predicateWithValue: YES]
+           isEqual: [NSPredicate predicateWithValue: YES]],
+         "the predicate that is always true is one thing");
+    PASS(![[NSPredicate predicateWithValue: YES]
+            isEqual: [NSPredicate predicateWithValue: NO]],
+         "the predicates that are always true and always false differ");
+  }
+
+  [arp release];
+  return 0;
+}


### PR DESCRIPTION
Expressions and predicates compared by identity only. Two expressions for the same key path, or two predicates of the same shape, were never equal, so neither could be found in a collection with `-containsObject:` or `-indexOfObject:`, and neither could be used as a dictionary key. On OS X they compare on what they describe, and their hashes agree.

`-isEqual:` and `-hash` are implemented for:

- the key path, constant, variable, function, aggregate and binary expressions, 
- for the expression kinds that hold nothing further,
-  for comparison and compound predicates 
- and the predicates that are always true or always false. 

A comparison predicate is equal to another of the same modifier, operator, options and operands, and to nothing else; a compound predicate to another of the same type holding equal subpredicates.

This is what a predicate editor needs to tell which of its row templates a predicate belongs to, since that is decided by looking for the predicate's expressions among the ones a template holds.

Tests/base/NSPredicate/equality.m. Thirteen assertions fail before the change and pass after. 
