### PR TITLE
Fix: CONTAINS asks whether the left side holds the right

### DIFF
--- a/Source/NSPredicate.m
+++ b/Source/NSPredicate.m
@@ -1115,6 +1115,34 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 			      options: compareOptions
 				range: range] == NSOrderedSame ? YES : NO);
 	}
+      case NSContainsPredicateOperatorType:
+	/* The mirror of IN: the left hand side is the collection, or the
+	 * string, and the right hand side is what it has to hold.
+	 */
+	if (![leftResult isKindOfClass: [NSString class]])
+	  {
+	    NSEnumerator *e;
+	    id value;
+
+	    if (![leftResult respondsToSelector: @selector(objectEnumerator)])
+	      {
+		[NSException raise: NSInvalidArgumentException
+			    format: @"The left hand side for a CONTAINS "
+		  @"operator must be a collection"];
+	      }
+
+	    e = [leftResult objectEnumerator];
+	    while ((value = [e nextObject]))
+	      {
+		if ([value isEqual: rightResult])
+		  return YES;
+	      }
+
+	    return NO;
+	  }
+	return ([leftResult rangeOfString: rightResult
+				  options: compareOptions].location
+	  != NSNotFound ? YES : NO);
       case NSInPredicateOperatorType:
 	/* Handle special case where rightResult is a collection
 	 * and leftResult an element of it.
@@ -2535,7 +2563,6 @@ do { \
   NSExpression *right;
   NSPredicate *p;
   BOOL negate = NO;
-  BOOL swap = NO;
 
   if ([self scanPredicateKeyword: @"ANY"])
     {
@@ -2607,8 +2634,7 @@ do { \
     }
   else if ([self scanPredicateKeyword: @"CONTAINS"])
     {
-      type = NSInPredicateOperatorType;
-      swap = YES;
+      type = NSContainsPredicateOperatorType;
     }
   else if ([self scanPredicateKeyword: @"BETWEEN"])
     {
@@ -2665,15 +2691,8 @@ do { \
     }
 
   right = [self parseExpression];
-  if (swap == YES)
-    {
-      NSExpression      *tmp = left;
 
-      left = right;
-      right = tmp;
-    }
-
-  p = [NSComparisonPredicate predicateWithLeftExpression: left 
+  p = [NSComparisonPredicate predicateWithLeftExpression: left
                              rightExpression: right
                              modifier: modifier 
                              type: type 

--- a/Tests/base/NSPredicate/contains.m
+++ b/Tests/base/NSPredicate/contains.m
@@ -1,0 +1,90 @@
+/* CONTAINS asks whether the left hand side holds the right hand side, the
+   way OS X reports and evaluates it.  It used to be turned into IN with the
+   two sides exchanged, which left the predicate describing something else
+   than it was written as, and a CONTAINS predicate built by hand, rather than
+   parsed, was never true.
+*/
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSComparisonPredicate.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSExpression.h>
+#import <Foundation/NSPredicate.h>
+#import <Foundation/NSString.h>
+#import "ObjectTesting.h"
+
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSDictionary *object;
+  NSComparisonPredicate *parsed;
+  NSPredicate *built;
+
+  object = [NSDictionary dictionaryWithObjectsAndKeys:
+    @"xyz", @"name",
+    [NSArray arrayWithObjects: @"a", @"b", nil], @"list",
+    nil];
+
+  parsed = (NSComparisonPredicate *)
+    [NSPredicate predicateWithFormat: @"name CONTAINS 'y'"];
+
+  PASS([parsed predicateOperatorType] == NSContainsPredicateOperatorType,
+       "a parsed CONTAINS is a contains predicate");
+  PASS_EQUAL([[parsed leftExpression] keyPath], @"name",
+             "the left hand side is the one that was written first");
+  PASS_EQUAL([[parsed rightExpression] constantValue], @"y",
+             "the right hand side is the one that was written second");
+  PASS([parsed evaluateWithObject: object],
+       "a string that holds the substring passes");
+  PASS(![[NSPredicate predicateWithFormat: @"name CONTAINS 'q'"]
+          evaluateWithObject: object],
+       "a string that does not hold the substring fails");
+
+  /* Built rather than parsed, the way a predicate editor builds one. */
+  built = [NSComparisonPredicate
+    predicateWithLeftExpression: [NSExpression expressionForKeyPath: @"name"]
+                rightExpression: [NSExpression expressionForConstantValue: @"y"]
+                       modifier: NSDirectPredicateModifier
+                           type: NSContainsPredicateOperatorType
+                        options: 0];
+  PASS([built evaluateWithObject: object],
+       "a contains predicate built by hand is evaluated");
+  PASS_EQUAL([built predicateFormat], [parsed predicateFormat],
+             "a contains predicate built by hand reads as the parsed one");
+
+  /* The case insensitive form. */
+  PASS([[NSPredicate predicateWithFormat: @"name CONTAINS[c] 'Y'"]
+         evaluateWithObject: object],
+       "the case insensitive form ignores case");
+  PASS(![[NSPredicate predicateWithFormat: @"name CONTAINS 'Y'"]
+          evaluateWithObject: object],
+       "the plain form does not ignore case");
+
+  /* A collection on the left hand side. */
+  PASS([[NSPredicate predicateWithFormat: @"list CONTAINS 'a'"]
+         evaluateWithObject: object],
+       "a collection that holds the object passes");
+  PASS(![[NSPredicate predicateWithFormat: @"list CONTAINS 'z'"]
+          evaluateWithObject: object],
+       "a collection that does not hold the object fails");
+
+  /* IN is unchanged. */
+  {
+    NSComparisonPredicate *in = (NSComparisonPredicate *)
+      [NSPredicate predicateWithFormat: @"name IN 'wxyz'"];
+
+    PASS([in predicateOperatorType] == NSInPredicateOperatorType,
+         "IN is still IN");
+    PASS_EQUAL([[in leftExpression] keyPath], @"name",
+               "IN keeps the side that was written first");
+    PASS([in evaluateWithObject: object],
+         "a string held by the right hand side passes");
+    PASS([[NSPredicate predicateWithFormat: @"'a' IN list"]
+           evaluateWithObject: object],
+         "an object held by a collection passes");
+  }
+
+  [arp release];
+  return 0;
+}


### PR DESCRIPTION
CONTAINS was parsed as IN with the two sides exchanged, so the predicate stopped describing what had been written. `-predicateOperatorType` read back as IN rather than contains, `-leftExpression` gave the constant and `-rightExpression` the key path, and `name CONTAINS 'y'` read back as `y IN name`. A CONTAINS predicate built rather than parsed, which is how a predicate editor builds one, was never true: the evaluation had no case for that operator and fell through to false.

CONTAINS is now parsed as a contains predicate, keeping the side that was written first on the left, and evaluated as the mirror of IN: a string on the left is searched for the substring on the right, a collection on the left for the object on the right, honouring the case and diacritic options. IN is untouched, and the flag that exchanged the two sides is gone with its only user.

Predicates written with CONTAINS evaluate as before. Ones read back, or written out again, now read as they were written.

Tests/base/NSPredicate/contains.m. Ten assertions fail before the change and pass after.

