### PR TITLE
Fix: keep the archiver whole when an object refuses to encode

### DIFF
--- a/Source/NSKeyedArchiver.m
+++ b/Source/NSKeyedArchiver.m
@@ -336,11 +336,23 @@ static NSDictionary *makeReference(unsigned ref)
 
       /*
        * At last, get the object to encode itself.  Save and restore the
-       * current object scope of course.
+       * current object scope of course.  The scope is borrowed from the
+       * array of objects, so it has to be given back even where the object
+       * refuses to encode itself, or it would be released twice.
        */
       _enc = m;
       _keyNum = 0;
-      [anObject encodeWithCoder: self];
+      NS_DURING
+	{
+	  [anObject encodeWithCoder: self];
+	}
+      NS_HANDLER
+	{
+	  _keyNum = savedKeyNum;
+	  _enc = savedEnc;
+	  [localException raise];
+	}
+      NS_ENDHANDLER
       _keyNum = savedKeyNum;
       _enc = savedEnc;
 

--- a/Tests/base/NSKeyedArchiver/encodeException.m
+++ b/Tests/base/NSKeyedArchiver/encodeException.m
@@ -1,0 +1,83 @@
+/* An object whose -encodeWithCoder: raises has to leave the archiver as it
+   was.  While an object encodes itself the archiver points its current scope
+   at a dictionary belonging to its array of objects; if that is not given
+   back when the object refuses, the archiver releases the dictionary a second
+   time on the way out, which corrupts the heap and takes the next allocation
+   with it.
+*/
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSException.h>
+#import <Foundation/NSKeyedArchiver.h>
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+#import "ObjectTesting.h"
+
+@interface Refuser : NSObject <NSCoding>
+@end
+
+@implementation Refuser
+
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+  [NSException raise: NSInternalInconsistencyException
+              format: @"this object refuses to be encoded"];
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  return self;
+}
+
+@end
+
+static BOOL
+archiveRaises(id object)
+{
+  BOOL raised = NO;
+
+  NS_DURING
+    {
+      [NSKeyedArchiver archivedDataWithRootObject: object];
+    }
+  NS_HANDLER
+    {
+      raised = YES;
+    }
+  NS_ENDHANDLER
+
+  return raised;
+}
+
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  Refuser *refuser = AUTORELEASE([Refuser new]);
+  NSArray *holder;
+  NSData *data;
+  id back;
+
+  holder = [NSArray arrayWithObjects: @"first", refuser, nil];
+
+  PASS(archiveRaises(refuser),
+       "archiving an object that refuses to encode raises");
+  PASS(archiveRaises(holder),
+       "archiving a collection holding one raises");
+
+  /* The archiver has to be left in one piece.  Before the archiver gave the
+     scope back this ran on a corrupted heap.
+  */
+  data = [NSKeyedArchiver archivedDataWithRootObject:
+    [NSArray arrayWithObjects: @"one", @"two", nil]];
+  PASS([data length] > 0, "an archive can still be written afterwards");
+
+  back = [NSKeyedUnarchiver unarchiveObjectWithData: data];
+  PASS_EQUAL(back, ([NSArray arrayWithObjects: @"one", @"two", nil]),
+             "and it reads back as what went in");
+
+  [arp release];
+  return 0;
+}


### PR DESCRIPTION
An object whose `-encodeWithCoder:` raises corrupts the archiver's heap. While an object encodes itself the archiver points `_enc`, its current scope, at a dictionary held by its array of objects, and puts the previous scope back afterwards. That only happened on the way out through the bottom of the method, so an object that raised left `_enc` pointing at the borrowed dictionary. The archiver's `-dealloc` then released it, though the array of objects still held it, and released the array in turn, which released the same dictionary again. The top level scope leaked along with it.

What that looks like is not a clean exception but a damaged heap: the exception is delivered, and the next allocation of any size aborts in malloc, often far from the archive that caused it.

The scope is now put back if the object raises, and the exception carries on.

Tests/base/NSKeyedArchiver/encodeException.m. Its four assertions cannot run before the change, since the process aborts partway through the file; they pass after.
