### PR TITLE
Fix: take the function names OS X uses for an expression

### DIFF
--- a/Source/NSPredicate.m
+++ b/Source/NSPredicate.m
@@ -1384,10 +1384,31 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 {
   GSFunctionExpression	*e;
   NSString		*s;
+  NSString		*implementation = name;
 
   e = AUTORELEASE([[GSFunctionExpression alloc]
     initWithExpressionType: NSFunctionExpressionType]);
-  s = [NSString stringWithFormat: @"_eval_%@:", name];
+
+  /* A function is named with its trailing colon on OS X, as in 'sum:', and
+   * without one here, as in 'sum'.  Take either.
+   */
+  if ([implementation hasSuffix: @":"])
+    {
+      implementation
+	= [implementation substringToIndex: [implementation length] - 1];
+    }
+
+  /* Two of them are implemented here under another name. */
+  if ([implementation isEqualToString: @"average"])
+    {
+      implementation = @"avg";
+    }
+  else if ([implementation isEqualToString: @"castObject:toType"])
+    {
+      implementation = @"CAST";
+    }
+
+  s = [NSString stringWithFormat: @"_eval_%@:", implementation];
   e->_selector = NSSelectorFromString(s);
   if (![e respondsToSelector: e->_selector])
     {

--- a/Tests/base/NSPredicate/functionNames.m
+++ b/Tests/base/NSPredicate/functionNames.m
@@ -1,0 +1,80 @@
+/* A function expression is named with its trailing colon on OS X, as in
+   'sum:', and two of the functions are known there under names this library
+   implements under another one.  Code written against the documented names
+   could not build an expression here at all.
+*/
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSExpression.h>
+#import <Foundation/NSPredicate.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSValue.h>
+#import "ObjectTesting.h"
+
+static NSExpression *
+functionOf(NSString *name, NSArray *numbers)
+{
+  return [NSExpression expressionForFunction: name
+                                   arguments:
+    [NSArray arrayWithObject:
+      [NSExpression expressionForConstantValue: numbers]]];
+}
+
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSArray *numbers = [NSArray arrayWithObjects:
+    [NSNumber numberWithInt: 1], [NSNumber numberWithInt: 2],
+    [NSNumber numberWithInt: 3], nil];
+  NSExpression *e;
+
+  e = functionOf(@"sum:", numbers);
+  PASS(e != nil, "a function named with its colon builds an expression");
+  PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 6.0,
+       "and it adds the numbers up");
+  PASS_EQUAL([e function], @"sum:", "the name is kept as it was given");
+
+  e = functionOf(@"sum", numbers);
+  PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 6.0,
+       "the name without a colon is still taken");
+
+  e = functionOf(@"average:", numbers);
+  PASS(e != nil, "the name OS X gives the average builds an expression");
+  PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 2.0,
+       "and it averages the numbers");
+
+  e = functionOf(@"avg", numbers);
+  PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 2.0,
+       "the name it has always had here is still taken");
+
+  e = functionOf(@"count:", numbers);
+  PASS([[e expressionValueWithObject: nil context: nil] intValue] == 3,
+       "count takes its colon too");
+
+  e = functionOf(@"max:", numbers);
+  PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 3.0,
+       "so does max");
+
+  e = functionOf(@"min:", numbers);
+  PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 1.0,
+       "so does min");
+
+  {
+    BOOL raised = NO;
+
+    NS_DURING
+      {
+        functionOf(@"nosuchfunction:", numbers);
+      }
+    NS_HANDLER
+      {
+        raised = YES;
+      }
+    NS_ENDHANDLER
+    PASS(raised == YES, "a name that no function answers to still raises");
+  }
+
+  [arp release];
+  return 0;
+}


### PR DESCRIPTION
A function expression is named with its trailing colon on OS X, as in `[NSExpression expressionForFunction: @"sum:" arguments: ...]`, which is how the documented names read. Here the name was pasted straight into a selector, so only the form without a colon was taken and anything written against the documented names raised "Unknown function implementation". Two of the functions also answer to another name here: what OS X calls `average:` is implemented as `avg`, and `castObject:toType:` as `CAST`.

A trailing colon is now taken off the name before the implementation is looked up, and those two names are mapped to the implementations that carry them out. The name the caller gave is kept, so `-function` still reads back what was passed and the description of the expression is unchanged.

Nothing else about which functions exist changes: a name no function answers to still raises.

Tests/base/NSPredicate/functionNames.m. Its eleven assertions cannot run before the change, since the first of them raises and takes the file with it; they pass after.
