### PR TITLE
Fix: archive an NSExpression the way OS X does

### DIFF
--- a/Source/NSKeyedArchiver.m
+++ b/Source/NSKeyedArchiver.m
@@ -331,7 +331,15 @@ static NSDictionary *makeReference(unsigned ref)
 	}
       else
 	{
-	  c = NSClassFromString(classname);
+	  Class	named = NSClassFromString(classname);
+
+	  /* The name may be one for which there is no class here, in which
+	   * case the class we already have is the one to describe.
+	   */
+	  if (named != 0)
+	    {
+	      c = named;
+	    }
 	}
 
       /*

--- a/Source/NSPredicate.m
+++ b/Source/NSPredicate.m
@@ -38,6 +38,7 @@
 
 #import "Foundation/NSArray.h"
 #import "Foundation/NSDate.h"
+#import "Foundation/NSKeyedArchiver.h"
 #import "Foundation/NSDictionary.h"
 #import "Foundation/NSEnumerator.h"
 #import "Foundation/NSException.h"
@@ -111,7 +112,11 @@ extern void     GSPropertyListMake(id,NSDictionary*,BOOL,BOOL,unsigned,id*);
 @interface GSConstantValueExpression : NSExpression
 {
   @public
-  id	_obj;
+  id		_obj;
+  /* A constant may stand for a class rather than for a value, and the class
+   * it stands for need not be one there is here, so it is kept by name.
+   */
+  NSString	*_className;
 }
 @end
 
@@ -126,6 +131,16 @@ extern void     GSPropertyListMake(id,NSDictionary*,BOOL,BOOL,unsigned,id*);
 @end
 
 @interface GSKeyPathExpression : NSExpression
+{
+  @public
+  NSString	*_keyPath;
+}
+@end
+
+/* Written inside the arguments of a key path expression, which is how OS X
+ * stores the key path itself.  It carries nothing else.
+ */
+@interface GSKeyPathSpecifierExpression : NSExpression
 {
   @public
   NSString	*_keyPath;
@@ -1364,6 +1379,39 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
   if (self == [NSExpression class] && nil == evaluatedObjectExpression)
     {
       evaluatedObjectExpression = [GSEvaluatedObjectExpression new];
+
+      /* An archive names the kinds of expression the way OS X does, so that
+       * one written here can be read there and the other way about.
+       */
+      [NSKeyedArchiver setClassName: @"NSConstantValueExpression"
+			   forClass: [GSConstantValueExpression class]];
+      [NSKeyedArchiver setClassName: @"NSSelfExpression"
+			   forClass: [GSEvaluatedObjectExpression class]];
+      [NSKeyedArchiver setClassName: @"NSVariableExpression"
+			   forClass: [GSVariableExpression class]];
+      [NSKeyedArchiver setClassName: @"NSKeyPathExpression"
+			   forClass: [GSKeyPathExpression class]];
+      [NSKeyedArchiver setClassName: @"NSKeyPathSpecifierExpression"
+			   forClass: [GSKeyPathSpecifierExpression class]];
+      [NSKeyedArchiver setClassName: @"NSFunctionExpression"
+			   forClass: [GSFunctionExpression class]];
+      [NSKeyedArchiver setClassName: @"NSAggregateExpression"
+			   forClass: [GSAggregateExpression class]];
+
+      [NSKeyedUnarchiver setClass: [GSConstantValueExpression class]
+		     forClassName: @"NSConstantValueExpression"];
+      [NSKeyedUnarchiver setClass: [GSEvaluatedObjectExpression class]
+		     forClassName: @"NSSelfExpression"];
+      [NSKeyedUnarchiver setClass: [GSVariableExpression class]
+		     forClassName: @"NSVariableExpression"];
+      [NSKeyedUnarchiver setClass: [GSKeyPathExpression class]
+		     forClassName: @"NSKeyPathExpression"];
+      [NSKeyedUnarchiver setClass: [GSKeyPathSpecifierExpression class]
+		     forClassName: @"NSKeyPathSpecifierExpression"];
+      [NSKeyedUnarchiver setClass: [GSFunctionExpression class]
+		     forClassName: @"NSFunctionExpression"];
+      [NSKeyedUnarchiver setClass: [GSAggregateExpression class]
+		     forClassName: @"NSAggregateExpression"];
     }
 }
 
@@ -1671,11 +1719,9 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
   return nil;
 }
 
-- (Class) classForCoder
-{
-  return [NSExpression class];
-}
-
+/* Each kind of expression is archived as itself, under the name OS X gives
+ * that kind, so the class is not collapsed to NSExpression here.
+ */
 - (void) encodeWithCoder: (NSCoder *)coder
 {
   // FIXME
@@ -1702,6 +1748,68 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 - (id) constantValue
 {
   return _obj;
+}
+
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+  if ([coder allowsKeyedCoding])
+    {
+      Class	c = object_getClass(_obj);
+
+      [coder encodeInt: NSConstantValueExpressionType
+		forKey: @"NSExpressionType"];
+      /* The operand of a function expression is a constant standing for the
+       * class the function belongs to, which is written by name.
+       */
+      if (_className != nil)
+	{
+	  [coder encodeObject: _className forKey: @"NSConstantValueClassName"];
+	}
+      else if (Nil != c && YES == class_isMetaClass(c))
+	{
+	  [coder encodeObject: NSStringFromClass((Class)_obj)
+		       forKey: @"NSConstantValueClassName"];
+	}
+      else
+	{
+	  [coder encodeObject: _obj forKey: @"NSConstantValue"];
+	}
+    }
+  else
+    {
+      [coder encodeObject: _obj];
+    }
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  self = [super initWithExpressionType: NSConstantValueExpressionType];
+  if (self == nil)
+    {
+      return nil;
+    }
+
+  if ([coder allowsKeyedCoding])
+    {
+      if ([coder containsValueForKey: @"NSConstantValueClassName"])
+	{
+	  NSString	*name;
+
+	  name = [coder decodeObjectForKey: @"NSConstantValueClassName"];
+	  ASSIGN(_className, name);
+	  ASSIGN(_obj, (id)NSClassFromString(name));
+	}
+      else
+	{
+	  ASSIGN(_obj, [coder decodeObjectForKey: @"NSConstantValue"]);
+	}
+    }
+  else
+    {
+      ASSIGN(_obj, [coder decodeObject]);
+    }
+
+  return self;
 }
 
 - (BOOL) isEqual: (id)other
@@ -1784,6 +1892,7 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 - (void) dealloc
 {
   RELEASE(_obj);
+  RELEASE(_className);
   DEALLOC
 }
 
@@ -1793,6 +1902,7 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 
   copy = (GSConstantValueExpression *)[super copyWithZone: zone];
   copy->_obj = [_obj copyWithZone: zone];
+  copy->_className = [_className copyWithZone: zone];
   return copy;
 }
 
@@ -1808,6 +1918,22 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 - (NSString *) description
 {
   return @"SELF";
+}
+
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+  if ([coder allowsKeyedCoding])
+    {
+      [coder encodeInt: NSEvaluatedObjectExpressionType
+		forKey: @"NSExpressionType"];
+    }
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  DESTROY(self);
+
+  return RETAIN([NSExpression expressionForEvaluatedObject]);
 }
 
 - (id) expressionValueWithObject: (id)object
@@ -1832,6 +1958,37 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 - (NSString *) description
 {
   return [NSString stringWithFormat: @"$%@", _variable];
+}
+
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+  if ([coder allowsKeyedCoding])
+    {
+      [coder encodeInt: NSVariableExpressionType forKey: @"NSExpressionType"];
+      [coder encodeObject: _variable forKey: @"NSVariable"];
+    }
+  else
+    {
+      [coder encodeObject: _variable];
+    }
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  self = [super initWithExpressionType: NSVariableExpressionType];
+  if (self != nil)
+    {
+      if ([coder allowsKeyedCoding])
+	{
+	  ASSIGN(_variable, [coder decodeObjectForKey: @"NSVariable"]);
+	}
+      else
+	{
+	  ASSIGN(_variable, [coder decodeObject]);
+	}
+    }
+
+  return self;
 }
 
 - (BOOL) isEqual: (id)other
@@ -1901,6 +2058,69 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
   return _keyPath;
 }
 
+/* OS X writes a key path as a function expression asking the object being
+ * evaluated for the key, with the key path itself held by a specifier in the
+ * arguments.
+ */
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+  if ([coder allowsKeyedCoding])
+    {
+      GSKeyPathSpecifierExpression	*specifier;
+      NSString				*selector;
+
+      selector = ([_keyPath rangeOfString: @"."].location == NSNotFound
+	? @"valueForKey:" : @"valueForKeyPath:");
+
+      specifier = [[GSKeyPathSpecifierExpression alloc]
+	initWithExpressionType: NSKeyPathExpressionType];
+      ASSIGN(specifier->_keyPath, _keyPath);
+
+      [coder encodeInt: NSKeyPathExpressionType forKey: @"NSExpressionType"];
+      [coder encodeObject: selector forKey: @"NSSelectorName"];
+      [coder encodeObject: [NSExpression expressionForEvaluatedObject]
+		   forKey: @"NSOperand"];
+      [coder encodeObject: [NSArray arrayWithObject: specifier]
+		   forKey: @"NSArguments"];
+      RELEASE(specifier);
+    }
+  else
+    {
+      [coder encodeObject: _keyPath];
+    }
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  self = [super initWithExpressionType: NSKeyPathExpressionType];
+  if (self == nil)
+    {
+      return nil;
+    }
+
+  if ([coder allowsKeyedCoding])
+    {
+      NSArray	*arguments = [coder decodeObjectForKey: @"NSArguments"];
+      id	first = ([arguments count] > 0
+	? [arguments objectAtIndex: 0] : nil);
+
+      if ([first isKindOfClass: [GSKeyPathSpecifierExpression class]])
+	{
+	  ASSIGN(_keyPath, ((GSKeyPathSpecifierExpression *)first)->_keyPath);
+	}
+      else if ([coder containsValueForKey: @"NSKeyPath"])
+	{
+	  ASSIGN(_keyPath, [coder decodeObjectForKey: @"NSKeyPath"]);
+	}
+    }
+  else
+    {
+      ASSIGN(_keyPath, [coder decodeObject]);
+    }
+
+  return self;
+}
+
 - (BOOL) isEqual: (id)other
 {
   if (self == other)
@@ -1947,6 +2167,60 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 
 - (id) _expressionWithSubstitutionVariables: (NSDictionary *)variables
 {
+  return self;
+}
+
+@end
+
+@implementation GSKeyPathSpecifierExpression
+
+- (void) dealloc
+{
+  RELEASE(_keyPath);
+  DEALLOC
+}
+
+- (NSString *) description
+{
+  return _keyPath;
+}
+
+- (NSString *) keyPath
+{
+  return _keyPath;
+}
+
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+  if ([coder allowsKeyedCoding])
+    {
+      /* The kind OS X gives a specifier, which is not one of the kinds an
+       * expression can be asked for.
+       */
+      [coder encodeInt: 10 forKey: @"NSExpressionType"];
+      [coder encodeObject: _keyPath forKey: @"NSKeyPath"];
+    }
+  else
+    {
+      [coder encodeObject: _keyPath];
+    }
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  self = [super initWithExpressionType: NSKeyPathExpressionType];
+  if (self != nil)
+    {
+      if ([coder allowsKeyedCoding])
+	{
+	  ASSIGN(_keyPath, [coder decodeObjectForKey: @"NSKeyPath"]);
+	}
+      else
+	{
+	  ASSIGN(_keyPath, [coder decodeObject]);
+	}
+    }
+
   return self;
 }
 
@@ -2141,6 +2415,37 @@ do { \
 
 @implementation GSAggregateExpression
 
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+  if ([coder allowsKeyedCoding])
+    {
+      [coder encodeInt: NSAggregateExpressionType forKey: @"NSExpressionType"];
+      [coder encodeObject: _collection forKey: @"NSCollection"];
+    }
+  else
+    {
+      [coder encodeObject: _collection];
+    }
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  self = [super initWithExpressionType: NSAggregateExpressionType];
+  if (self != nil)
+    {
+      if ([coder allowsKeyedCoding])
+	{
+	  ASSIGN(_collection, [coder decodeObjectForKey: @"NSCollection"]);
+	}
+      else
+	{
+	  ASSIGN(_collection, [coder decodeObject]);
+	}
+    }
+
+  return self;
+}
+
 - (BOOL) isEqual: (id)other
 {
   if (self == other)
@@ -2208,6 +2513,61 @@ do { \
 - (NSArray *) arguments
 {
   return _args;
+}
+
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+  if ([coder allowsKeyedCoding])
+    {
+      GSConstantValueExpression	*operand;
+      NSString			*selector = _function;
+
+      /* A function is named with its trailing colon in an archive. */
+      if (NO == [selector hasSuffix: @":"])
+	{
+	  selector = [selector stringByAppendingString: @":"];
+	}
+
+      /* The operand stands for the class the function belongs to, which OS X
+       * names _NSPredicateUtilities.  There is no such class here, so the
+       * constant carries the name alone.
+       */
+      operand = [[GSConstantValueExpression alloc]
+	initWithExpressionType: NSConstantValueExpressionType];
+      ASSIGN(operand->_className, @"_NSPredicateUtilities");
+
+      [coder encodeInt: NSFunctionExpressionType forKey: @"NSExpressionType"];
+      [coder encodeObject: selector forKey: @"NSSelectorName"];
+      [coder encodeObject: operand forKey: @"NSOperand"];
+      [coder encodeObject: _args forKey: @"NSArguments"];
+      RELEASE(operand);
+    }
+  else
+    {
+      [coder encodeObject: _function];
+      [coder encodeObject: _args];
+    }
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  NSString	*name;
+  NSArray	*args;
+
+  if ([coder allowsKeyedCoding])
+    {
+      name = [coder decodeObjectForKey: @"NSSelectorName"];
+      args = [coder decodeObjectForKey: @"NSArguments"];
+    }
+  else
+    {
+      name = [coder decodeObject];
+      args = [coder decodeObject];
+    }
+
+  DESTROY(self);
+
+  return RETAIN([NSExpression expressionForFunction: name arguments: args]);
 }
 
 - (BOOL) isEqual: (id)other

--- a/Source/NSPredicate.m
+++ b/Source/NSPredicate.m
@@ -1413,10 +1413,31 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 {
   GSFunctionExpression	*e;
   NSString		*s;
+  NSString		*implementation = name;
 
   e = AUTORELEASE([[GSFunctionExpression alloc]
     initWithExpressionType: NSFunctionExpressionType]);
-  s = [NSString stringWithFormat: @"_eval_%@:", name];
+
+  /* A function is named with its trailing colon on OS X, as in 'sum:', and
+   * without one here, as in 'sum'.  Take either.
+   */
+  if ([implementation hasSuffix: @":"])
+    {
+      implementation
+	= [implementation substringToIndex: [implementation length] - 1];
+    }
+
+  /* Two of them are implemented here under another name. */
+  if ([implementation isEqualToString: @"average"])
+    {
+      implementation = @"avg";
+    }
+  else if ([implementation isEqualToString: @"castObject:toType"])
+    {
+      implementation = @"CAST";
+    }
+
+  s = [NSString stringWithFormat: @"_eval_%@:", implementation];
   e->_selector = NSSelectorFromString(s);
   if (![e respondsToSelector: e->_selector])
     {

--- a/Tests/base/NSKeyedArchiver/classname.m
+++ b/Tests/base/NSKeyedArchiver/classname.m
@@ -1,0 +1,111 @@
+/* A class may be archived under a name for which there is no class here, as
+   OS X compatible archives require.  The description of the class still has
+   to be the one of the class being encoded.
+*/
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSKeyedArchiver.h>
+#import <Foundation/NSPropertyList.h>
+#import <Foundation/NSString.h>
+#import "Testing.h"
+#import "ObjectTesting.h"
+
+@interface GSRenamed : NSObject
+{
+  NSString	*_text;
+}
+- (id) initWithText: (NSString *)text;
+- (NSString *) text;
+@end
+
+@implementation GSRenamed
+
+- (id) initWithText: (NSString *)text
+{
+  if ((self = [super init]) != nil)
+    {
+      ASSIGN(_text, text);
+    }
+  return self;
+}
+
+- (void) dealloc
+{
+  RELEASE(_text);
+  [super dealloc];
+}
+
+- (NSString *) text
+{
+  return _text;
+}
+
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+  [coder encodeObject: _text forKey: @"Text"];
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  if ((self = [super init]) != nil)
+    {
+      ASSIGN(_text, [coder decodeObjectForKey: @"Text"]);
+    }
+  return self;
+}
+
+@end
+
+/* The class description an archive of the object holds. */
+static NSDictionary *
+classDescription(id object, NSString *name)
+{
+  NSData	*data = [NSKeyedArchiver archivedDataWithRootObject: object];
+  NSDictionary	*plist;
+  id		entry;
+
+  plist = [NSPropertyListSerialization propertyListWithData: data
+						    options: 0
+						     format: NULL
+						      error: NULL];
+  for (entry in [plist objectForKey: @"$objects"])
+    {
+      if ([entry isKindOfClass: [NSDictionary class]]
+	&& [[entry objectForKey: @"$classname"] isEqual: name])
+	{
+	  return entry;
+	}
+    }
+  return nil;
+}
+
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
+  GSRenamed		*object;
+  NSDictionary		*description;
+  id			decoded;
+
+  object = AUTORELEASE([[GSRenamed alloc] initWithText: @"text"]);
+  [NSKeyedArchiver setClassName: @"AbsentElsewhere" forClass: [GSRenamed class]];
+
+  description = classDescription(object, @"AbsentElsewhere");
+  PASS(description != nil, "an object is archived under the name given for it");
+  PASS([[description objectForKey: @"$classes"] count] > 0,
+       "a name with no class of its own still describes the class hierarchy");
+  PASS([[description objectForKey: @"$classes"] containsObject: @"NSObject"],
+       "and the hierarchy is the one of the class being encoded");
+
+  [NSKeyedUnarchiver setClass: [GSRenamed class] forClassName: @"AbsentElsewhere"];
+  decoded = [NSKeyedUnarchiver unarchiveObjectWithData:
+    [NSKeyedArchiver archivedDataWithRootObject: object]];
+  PASS([decoded isKindOfClass: [GSRenamed class]],
+       "and the object read back is of the class the name stands for");
+  PASS_EQUAL([decoded text], @"text", "carrying what it was given");
+
+  [arp release];
+  return 0;
+}

--- a/Tests/base/NSPredicate/expressionCoding.m
+++ b/Tests/base/NSPredicate/expressionCoding.m
@@ -1,0 +1,175 @@
+/* An expression can be archived and read back, which a predicate editor needs
+   since its row templates hold expressions and are stored in a nib.  The
+   archive is written the way OS X writes it, so that one written here can be
+   read there and the other way about.
+*/
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSException.h>
+#import <Foundation/NSExpression.h>
+#import <Foundation/NSKeyedArchiver.h>
+#import <Foundation/NSPropertyList.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSValue.h>
+#import "ObjectTesting.h"
+
+static id
+roundTrip(id object)
+{
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject: object];
+
+  return [NSKeyedUnarchiver unarchiveObjectWithData: data];
+}
+
+/* The class names an archive of the object holds. */
+static NSArray *
+classNames(id object)
+{
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject: object];
+  NSDictionary *plist;
+  NSMutableArray *names = [NSMutableArray array];
+
+  plist = [NSPropertyListSerialization propertyListWithData: data
+                                                    options: 0
+                                                     format: NULL
+                                                      error: NULL];
+  for (id entry in [plist objectForKey: @"$objects"])
+    {
+      if ([entry isKindOfClass: [NSDictionary class]]
+        && [entry objectForKey: @"$classname"] != nil)
+        {
+          [names addObject: [entry objectForKey: @"$classname"]];
+        }
+    }
+
+  return names;
+}
+
+/* Whether anything in an archive holds the given value under the given key. */
+static BOOL
+archiveHolds(id object, NSString *key, id value)
+{
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject: object];
+  NSDictionary *plist;
+
+  plist = [NSPropertyListSerialization propertyListWithData: data
+                                                    options: 0
+                                                     format: NULL
+                                                      error: NULL];
+  for (id entry in [plist objectForKey: @"$objects"])
+    {
+      if ([entry isKindOfClass: [NSDictionary class]])
+        {
+          id held = [entry objectForKey: key];
+
+          /* A value is written as a reference to the string holding it. */
+          if ([held isKindOfClass: [NSDictionary class]])
+            {
+              NSUInteger index;
+
+              index = [[held objectForKey: @"CF$UID"] unsignedIntegerValue];
+              held = [[plist objectForKey: @"$objects"] objectAtIndex: index];
+            }
+          if ([held isEqual: value])
+            {
+              return YES;
+            }
+        }
+    }
+
+  return NO;
+}
+
+/* The dictionary an archive holds for the object itself. */
+static NSDictionary *
+archivedObject(id object)
+{
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject: object];
+  NSDictionary *plist;
+
+  plist = [NSPropertyListSerialization propertyListWithData: data
+                                                    options: 0
+                                                     format: NULL
+                                                      error: NULL];
+  return [[plist objectForKey: @"$objects"] objectAtIndex: 1];
+}
+
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSExpression *e;
+
+  /* A constant. */
+  e = [NSExpression expressionForConstantValue: @"hello"];
+  PASS_EQUAL(roundTrip(e), e, "a constant expression survives being archived");
+  PASS([classNames(e) containsObject: @"NSConstantValueExpression"],
+       "and is named the way OS X names it");
+  PASS([[archivedObject(e) allKeys] containsObject: @"NSConstantValue"]
+       && [[archivedObject(e) allKeys] containsObject: @"NSExpressionType"],
+       "under the keys OS X writes");
+
+  e = [NSExpression expressionForConstantValue: [NSNumber numberWithInt: 42]];
+  PASS_EQUAL([roundTrip(e) constantValue], [NSNumber numberWithInt: 42],
+             "a constant number comes back as it went in");
+
+  /* The object being evaluated. */
+  e = [NSExpression expressionForEvaluatedObject];
+  PASS_EQUAL(roundTrip(e), e, "the evaluated object expression survives");
+  PASS([classNames(e) containsObject: @"NSSelfExpression"],
+       "and is named the way OS X names it");
+
+  /* A variable. */
+  e = [NSExpression expressionForVariable: @"v"];
+  PASS_EQUAL(roundTrip(e), e, "a variable expression survives");
+  PASS([classNames(e) containsObject: @"NSVariableExpression"],
+       "and is named the way OS X names it");
+
+  /* A key path, single and dotted. */
+  e = [NSExpression expressionForKeyPath: @"name"];
+  PASS_EQUAL(roundTrip(e), e, "a key path expression survives");
+  PASS_EQUAL([roundTrip(e) keyPath], @"name", "with its key path");
+  PASS([classNames(e) containsObject: @"NSKeyPathExpression"],
+       "and is named the way OS X names it");
+  PASS([classNames(e) containsObject: @"NSKeyPathSpecifierExpression"],
+       "with the key path held by a specifier, as OS X holds it");
+
+  e = [NSExpression expressionForKeyPath: @"a.b"];
+  PASS_EQUAL([roundTrip(e) keyPath], @"a.b", "a dotted key path survives");
+
+  /* A function. */
+  e = [NSExpression expressionForFunction: @"sum:"
+                                arguments: [NSArray arrayWithObject:
+                                  [NSExpression expressionForKeyPath: @"n"]]];
+  PASS_EQUAL(roundTrip(e), e, "a function expression survives");
+  PASS([classNames(e) containsObject: @"NSFunctionExpression"],
+       "and is named the way OS X names it");
+  PASS(archiveHolds(e, @"NSSelectorName", @"sum:"),
+       "under the name of the selector it calls");
+  PASS(archiveHolds(e, @"NSConstantValueClassName", @"_NSPredicateUtilities"),
+       "standing on the class OS X puts the functions on");
+
+  /* An aggregate. */
+  e = [NSExpression expressionForAggregate: ([NSArray arrayWithObjects:
+    [NSExpression expressionForConstantValue: [NSNumber numberWithInt: 1]],
+    [NSExpression expressionForConstantValue: [NSNumber numberWithInt: 2]],
+    nil])];
+  PASS_EQUAL(roundTrip(e), e, "an aggregate expression survives");
+  PASS([classNames(e) containsObject: @"NSAggregateExpression"],
+       "and is named the way OS X names it");
+
+  /* A collection of them, which is what a row template holds. */
+  {
+    NSArray *list = [NSArray arrayWithObjects:
+      [NSExpression expressionForKeyPath: @"name"],
+      [NSExpression expressionForKeyPath: @"size"], nil];
+
+    PASS_EQUAL(roundTrip(list), list,
+               "a list of expressions survives being archived");
+  }
+
+  [arp release];
+  return 0;
+}

--- a/Tests/base/NSPredicate/functionNames.m
+++ b/Tests/base/NSPredicate/functionNames.m
@@ -1,0 +1,80 @@
+/* A function expression is named with its trailing colon on OS X, as in
+   'sum:', and two of the functions are known there under names this library
+   implements under another one.  Code written against the documented names
+   could not build an expression here at all.
+*/
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSExpression.h>
+#import <Foundation/NSPredicate.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSValue.h>
+#import "ObjectTesting.h"
+
+static NSExpression *
+functionOf(NSString *name, NSArray *numbers)
+{
+  return [NSExpression expressionForFunction: name
+                                   arguments:
+    [NSArray arrayWithObject:
+      [NSExpression expressionForConstantValue: numbers]]];
+}
+
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSArray *numbers = [NSArray arrayWithObjects:
+    [NSNumber numberWithInt: 1], [NSNumber numberWithInt: 2],
+    [NSNumber numberWithInt: 3], nil];
+  NSExpression *e;
+
+  e = functionOf(@"sum:", numbers);
+  PASS(e != nil, "a function named with its colon builds an expression");
+  PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 6.0,
+       "and it adds the numbers up");
+  PASS_EQUAL([e function], @"sum:", "the name is kept as it was given");
+
+  e = functionOf(@"sum", numbers);
+  PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 6.0,
+       "the name without a colon is still taken");
+
+  e = functionOf(@"average:", numbers);
+  PASS(e != nil, "the name OS X gives the average builds an expression");
+  PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 2.0,
+       "and it averages the numbers");
+
+  e = functionOf(@"avg", numbers);
+  PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 2.0,
+       "the name it has always had here is still taken");
+
+  e = functionOf(@"count:", numbers);
+  PASS([[e expressionValueWithObject: nil context: nil] intValue] == 3,
+       "count takes its colon too");
+
+  e = functionOf(@"max:", numbers);
+  PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 3.0,
+       "so does max");
+
+  e = functionOf(@"min:", numbers);
+  PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 1.0,
+       "so does min");
+
+  {
+    BOOL raised = NO;
+
+    NS_DURING
+      {
+        functionOf(@"nosuchfunction:", numbers);
+      }
+    NS_HANDLER
+      {
+        raised = YES;
+      }
+    NS_ENDHANDLER
+    PASS(raised == YES, "a name that no function answers to still raises");
+  }
+
+  [arp release];
+  return 0;
+}


### PR DESCRIPTION
Archiving an NSExpression raises: both coder methods are left to a subclass with a FIXME and nothing implements them, so the row templates of a predicate editor can be neither written to a nib nor read back.

Each kind of expression now writes itself under the class name and keys OS X uses, so an archive written here can be read there. A constant writes NSConstantValue, or NSConstantValueClassName where it stands for a class. A key path writes NSSelectorName, NSOperand and NSArguments, with the path held by a specifier expression. A function writes the selector with its trailing colon, an aggregate NSCollection.

One change in NSKeyedArchiver is needed and is a commit of its own: a class encoded under a name for which there is no class here had an empty hierarchy written for it, which reading a nested expression back failed on. Predicates are unchanged and still raise. The branch also carries the commit in #715, which reading a function expression back needs.

Tests/base/NSPredicate/expressionCoding.m and Tests/base/NSKeyedArchiver/classname.m.

On master the first fails thirteen assertions then aborts and the second fails two of its five. With the change all twenty and all five pass, the rest of the suite unchanged.
