### PR TITLE
Fix: NSFullUserName for an account with no name recorded

### DIFF
--- a/Source/NSPathUtilities.m
+++ b/Source/NSPathUtilities.m
@@ -2068,7 +2068,8 @@ NSFullUserName(void)
 {
   if (theFullUserName == nil)
     {
-      NSString	*userName = NSUserName();
+      NSString	*loginName = NSUserName();
+      NSString	*userName = loginName;
       int	length;
 #if defined(_WIN32)
       struct _USER_INFO_2	*userInfo;
@@ -2131,6 +2132,14 @@ NSFullUserName(void)
 	      userName = [userName substringToIndex: --length];
 	      userName = [userName stringByTrimmingSpaces];
 	    }
+	}
+      /* An account may hold no name at all, only the separators between the
+       * fields where one would be, in which case the name the user logs in
+       * under is the only name there is.
+       */
+      if ([userName length] == 0)
+	{
+	  userName = loginName;
 	}
       ASSIGN(theFullUserName, userName);
     }


### PR DESCRIPTION
NSFullUserName() returns an empty string for an account that was created without a name. The name comes from the gecos field, which for such an account holds only the separators between the fields where a name would go, and the trailing punctuation is then trimmed away, leaving nothing. Here the field reads ,,, and the function returns @"".

Where the trim leaves nothing, the login name is used instead, since that is the only name such an account has. An account that does record a name is unaffected.

The gecos field is not read on Windows, where the name comes from NetUserGetInfo, so this only affects the platforms that use it.

Tests/base/Functions/NSPathUtilities.m already asserts that a full user name has a length.

That assertion fails on an account with no name recorded and passes with the change, 227 to 228 in the directory. The rest of the suite is unchanged.
