### PR TITLE
Fix: archive a predicate the way OS X does

### DIFF
--- a/Source/NSKeyedArchiver.m
+++ b/Source/NSKeyedArchiver.m
@@ -331,7 +331,15 @@ static NSDictionary *makeReference(unsigned ref)
 	}
       else
 	{
-	  c = NSClassFromString(classname);
+	  Class	named = NSClassFromString(classname);
+
+	  /* The name may be one for which there is no class here, in which
+	   * case the class we already have is the one to describe.
+	   */
+	  if (named != 0)
+	    {
+	      c = named;
+	    }
 	}
 
       /*

--- a/Source/NSPredicate.m
+++ b/Source/NSPredicate.m
@@ -105,6 +105,48 @@ extern void     GSPropertyListMake(id,NSDictionary*,BOOL,BOOL,unsigned,id*);
 @interface GSNotCompoundPredicate : NSCompoundPredicate
 @end
 
+/* The comparison a predicate makes is archived as an object of its own, as
+ * OS X archives it, with a class for each family of operators.  It exists
+ * for archiving alone and holds what the predicate holds.
+ */
+@interface GSPredicateOperator : NSObject
+{
+  @public
+  NSPredicateOperatorType	_type;
+  NSComparisonPredicateModifier	_modifier;
+  NSUInteger			_options;
+  SEL				_selector;
+}
++ (id) operatorForType: (NSPredicateOperatorType)type
+	      modifier: (NSComparisonPredicateModifier)modifier
+	       options: (NSUInteger)options
+	      selector: (SEL)selector;
+@end
+
+@interface GSComparisonPredicateOperator : GSPredicateOperator
+@end
+
+@interface GSEqualityPredicateOperator : GSPredicateOperator
+@end
+
+@interface GSMatchingPredicateOperator : GSPredicateOperator
+@end
+
+@interface GSLikePredicateOperator : GSPredicateOperator
+@end
+
+@interface GSSubstringPredicateOperator : GSPredicateOperator
+@end
+
+@interface GSInPredicateOperator : GSPredicateOperator
+@end
+
+@interface GSBetweenPredicateOperator : GSPredicateOperator
+@end
+
+@interface GSCustomPredicateOperator : GSPredicateOperator
+@end
+
 @interface NSExpression (Private)
 - (id) _expressionWithSubstitutionVariables: (NSDictionary *)variables;
 @end
@@ -214,6 +256,58 @@ extern void     GSPropertyListMake(id,NSDictionary*,BOOL,BOOL,unsigned,id*);
 #endif
 
 @implementation NSPredicate
+
++ (void) initialize
+{
+  if (self == [NSPredicate class])
+    {
+      /* An archive names a predicate and the comparison it makes the way
+       * OS X does, so that one written here can be read there and the other
+       * way about.
+       */
+      [NSKeyedArchiver setClassName: @"NSTruePredicate"
+			   forClass: [GSTruePredicate class]];
+      [NSKeyedArchiver setClassName: @"NSFalsePredicate"
+			   forClass: [GSFalsePredicate class]];
+      [NSKeyedArchiver setClassName: @"NSComparisonPredicateOperator"
+			   forClass: [GSComparisonPredicateOperator class]];
+      [NSKeyedArchiver setClassName: @"NSEqualityPredicateOperator"
+			   forClass: [GSEqualityPredicateOperator class]];
+      [NSKeyedArchiver setClassName: @"NSMatchingPredicateOperator"
+			   forClass: [GSMatchingPredicateOperator class]];
+      [NSKeyedArchiver setClassName: @"NSLikePredicateOperator"
+			   forClass: [GSLikePredicateOperator class]];
+      [NSKeyedArchiver setClassName: @"NSSubstringPredicateOperator"
+			   forClass: [GSSubstringPredicateOperator class]];
+      [NSKeyedArchiver setClassName: @"NSInPredicateOperator"
+			   forClass: [GSInPredicateOperator class]];
+      [NSKeyedArchiver setClassName: @"NSBetweenPredicateOperator"
+			   forClass: [GSBetweenPredicateOperator class]];
+      [NSKeyedArchiver setClassName: @"NSCustomPredicateOperator"
+			   forClass: [GSCustomPredicateOperator class]];
+
+      [NSKeyedUnarchiver setClass: [GSTruePredicate class]
+		     forClassName: @"NSTruePredicate"];
+      [NSKeyedUnarchiver setClass: [GSFalsePredicate class]
+		     forClassName: @"NSFalsePredicate"];
+      [NSKeyedUnarchiver setClass: [GSComparisonPredicateOperator class]
+		     forClassName: @"NSComparisonPredicateOperator"];
+      [NSKeyedUnarchiver setClass: [GSEqualityPredicateOperator class]
+		     forClassName: @"NSEqualityPredicateOperator"];
+      [NSKeyedUnarchiver setClass: [GSMatchingPredicateOperator class]
+		     forClassName: @"NSMatchingPredicateOperator"];
+      [NSKeyedUnarchiver setClass: [GSLikePredicateOperator class]
+		     forClassName: @"NSLikePredicateOperator"];
+      [NSKeyedUnarchiver setClass: [GSSubstringPredicateOperator class]
+		     forClassName: @"NSSubstringPredicateOperator"];
+      [NSKeyedUnarchiver setClass: [GSInPredicateOperator class]
+		     forClassName: @"NSInPredicateOperator"];
+      [NSKeyedUnarchiver setClass: [GSBetweenPredicateOperator class]
+		     forClassName: @"NSBetweenPredicateOperator"];
+      [NSKeyedUnarchiver setClass: [GSCustomPredicateOperator class]
+		     forClassName: @"NSCustomPredicateOperator"];
+    }
+}
 
 + (NSPredicate *) predicateWithFormat: (NSString *) format, ...
 {
@@ -473,6 +567,23 @@ extern void     GSPropertyListMake(id,NSDictionary*,BOOL,BOOL,unsigned,id*);
   return @"TRUEPREDICATE";
 }
 
+/* A predicate of a fixed value holds nothing, so the class it is archived
+ * under is all there is to write.
+ */
+- (Class) classForCoder
+{
+  return [self class];
+}
+
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  return self;
+}
+
 @end
 
 @implementation GSFalsePredicate
@@ -500,6 +611,20 @@ extern void     GSPropertyListMake(id,NSDictionary*,BOOL,BOOL,unsigned,id*);
 - (NSString *) predicateFormat
 {
   return @"FALSEPREDICATE";
+}
+
+- (Class) classForCoder
+{
+  return [self class];
+}
+
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  return self;
 }
 
 @end
@@ -636,15 +761,41 @@ extern void     GSPropertyListMake(id,NSDictionary*,BOOL,BOOL,unsigned,id*);
 
 - (void) encodeWithCoder: (NSCoder *)coder
 {
-  // FIXME
-  [self subclassResponsibility: _cmd];
+  if ([coder allowsKeyedCoding])
+    {
+      [coder encodeInt: (int)_type forKey: @"NSCompoundPredicateType"];
+      [coder encodeObject: _subs forKey: @"NSSubpredicates"];
+    }
+  else
+    {
+      int	type = (int)_type;
+
+      [coder encodeValueOfObjCType: @encode(int) at: &type];
+      [coder encodeObject: _subs];
+    }
 }
 
 - (id) initWithCoder: (NSCoder *)coder
 {
-  // FIXME
-  [self subclassResponsibility: _cmd];
-  return self;
+  NSCompoundPredicateType	type;
+  NSArray			*subs;
+
+  if ([coder allowsKeyedCoding])
+    {
+      type = (NSCompoundPredicateType)
+	[coder decodeIntForKey: @"NSCompoundPredicateType"];
+      subs = [coder decodeObjectForKey: @"NSSubpredicates"];
+    }
+  else
+    {
+      int	t;
+
+      [coder decodeValueOfObjCType: @encode(int) at: &t];
+      type = (NSCompoundPredicateType)t;
+      subs = [coder decodeObject];
+    }
+
+  return [self initWithType: type subpredicates: subs];
 }
 
 @end
@@ -774,6 +925,190 @@ extern void     GSPropertyListMake(id,NSDictionary*,BOOL,BOOL,unsigned,id*);
   return [NSString stringWithFormat: @"NOT %@", [sub predicateFormat]];
 }
 
+@end
+
+@implementation GSPredicateOperator
+
++ (id) operatorForType: (NSPredicateOperatorType)type
+	      modifier: (NSComparisonPredicateModifier)modifier
+	       options: (NSUInteger)options
+	      selector: (SEL)selector
+{
+  GSPredicateOperator	*op;
+  Class			c;
+
+  switch (type)
+    {
+      case NSLessThanPredicateOperatorType:
+      case NSLessThanOrEqualToPredicateOperatorType:
+      case NSGreaterThanPredicateOperatorType:
+      case NSGreaterThanOrEqualToPredicateOperatorType:
+	c = [GSComparisonPredicateOperator class];
+	break;
+      case NSEqualToPredicateOperatorType:
+      case NSNotEqualToPredicateOperatorType:
+	c = [GSEqualityPredicateOperator class];
+	break;
+      case NSMatchesPredicateOperatorType:
+	c = [GSMatchingPredicateOperator class];
+	break;
+      case NSLikePredicateOperatorType:
+	c = [GSLikePredicateOperator class];
+	break;
+      case NSBeginsWithPredicateOperatorType:
+      case NSEndsWithPredicateOperatorType:
+	c = [GSSubstringPredicateOperator class];
+	break;
+      case NSInPredicateOperatorType:
+      case NSContainsPredicateOperatorType:
+	c = [GSInPredicateOperator class];
+	break;
+      case NSBetweenPredicateOperatorType:
+	c = [GSBetweenPredicateOperator class];
+	break;
+      case NSCustomSelectorPredicateOperatorType:
+	c = [GSCustomPredicateOperator class];
+	break;
+      default:
+	c = [GSPredicateOperator class];
+	break;
+    }
+
+  op = [[c alloc] init];
+  op->_type = type;
+  op->_modifier = modifier;
+  op->_options = options;
+  op->_selector = selector;
+  return AUTORELEASE(op);
+}
+
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+  if (NO == [coder allowsKeyedCoding])
+    {
+      int	type = (int)_type;
+      int	modifier = (int)_modifier;
+      int	options = (int)_options;
+
+      [coder encodeValueOfObjCType: @encode(int) at: &type];
+      [coder encodeValueOfObjCType: @encode(int) at: &modifier];
+      [coder encodeValueOfObjCType: @encode(int) at: &options];
+      return;
+    }
+
+  [coder encodeInt: (int)_modifier forKey: @"NSModifier"];
+  [coder encodeInt: (int)_type forKey: @"NSOperatorType"];
+
+  /* What else is written depends on the family the operator belongs to,
+   * as it does on OS X.
+   */
+  switch (_type)
+    {
+      case NSLessThanPredicateOperatorType:
+      case NSLessThanOrEqualToPredicateOperatorType:
+      case NSGreaterThanPredicateOperatorType:
+      case NSGreaterThanOrEqualToPredicateOperatorType:
+	[coder encodeInt: (int)_options forKey: @"NSOptions"];
+	[coder encodeInt: 0 forKey: @"NSVariant"];
+	break;
+      case NSEqualToPredicateOperatorType:
+      case NSNotEqualToPredicateOperatorType:
+	[coder encodeInt:
+	  (NSNotEqualToPredicateOperatorType == _type) ? 1 : 0
+		  forKey: @"NSNegate"];
+	[coder encodeInt: (int)_options forKey: @"NSOptions"];
+	break;
+      case NSBeginsWithPredicateOperatorType:
+      case NSEndsWithPredicateOperatorType:
+	[coder encodeInt: (int)_options forKey: @"NSFlags"];
+	[coder encodeInt:
+	  (NSEndsWithPredicateOperatorType == _type) ? 1 : 0
+		  forKey: @"NSPosition"];
+	break;
+      case NSMatchesPredicateOperatorType:
+      case NSLikePredicateOperatorType:
+      case NSInPredicateOperatorType:
+      case NSContainsPredicateOperatorType:
+	[coder encodeInt: (int)_options forKey: @"NSFlags"];
+	break;
+      case NSCustomSelectorPredicateOperatorType:
+	[coder encodeObject: NSStringFromSelector(_selector)
+		     forKey: @"NSSelectorName"];
+	break;
+      default:
+	break;
+    }
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  if ((self = [super init]) == nil)
+    {
+      return nil;
+    }
+
+  if (NO == [coder allowsKeyedCoding])
+    {
+      int	type;
+      int	modifier;
+      int	options;
+
+      [coder decodeValueOfObjCType: @encode(int) at: &type];
+      [coder decodeValueOfObjCType: @encode(int) at: &modifier];
+      [coder decodeValueOfObjCType: @encode(int) at: &options];
+      _type = (NSPredicateOperatorType)type;
+      _modifier = (NSComparisonPredicateModifier)modifier;
+      _options = (NSUInteger)options;
+      return self;
+    }
+
+  _type = (NSPredicateOperatorType)[coder decodeIntForKey: @"NSOperatorType"];
+  _modifier
+    = (NSComparisonPredicateModifier)[coder decodeIntForKey: @"NSModifier"];
+  /* The options are written under one name or the other, depending on the
+   * family.
+   */
+  if ([coder containsValueForKey: @"NSOptions"])
+    {
+      _options = (NSUInteger)[coder decodeIntForKey: @"NSOptions"];
+    }
+  else
+    {
+      _options = (NSUInteger)[coder decodeIntForKey: @"NSFlags"];
+    }
+  if ([coder containsValueForKey: @"NSSelectorName"])
+    {
+      _selector
+	= NSSelectorFromString([coder decodeObjectForKey: @"NSSelectorName"]);
+    }
+
+  return self;
+}
+
+@end
+
+@implementation GSComparisonPredicateOperator
+@end
+
+@implementation GSEqualityPredicateOperator
+@end
+
+@implementation GSMatchingPredicateOperator
+@end
+
+@implementation GSLikePredicateOperator
+@end
+
+@implementation GSSubstringPredicateOperator
+@end
+
+@implementation GSInPredicateOperator
+@end
+
+@implementation GSBetweenPredicateOperator
+@end
+
+@implementation GSCustomPredicateOperator
 @end
 
 @implementation NSComparisonPredicate
@@ -1357,15 +1692,88 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 
 - (void) encodeWithCoder: (NSCoder *)coder
 {
-  // FIXME
-  [self subclassResponsibility: _cmd];
+  if ([coder allowsKeyedCoding])
+    {
+      [coder encodeObject: _left forKey: @"NSLeftExpression"];
+      [coder encodeObject: _right forKey: @"NSRightExpression"];
+      [coder encodeObject: [GSPredicateOperator operatorForType: _type
+						       modifier: _modifier
+							options: _options
+						       selector: _selector]
+		   forKey: @"NSPredicateOperator"];
+    }
+  else
+    {
+      int	type = (int)_type;
+      int	modifier = (int)_modifier;
+      int	options = (int)_options;
+
+      [coder encodeObject: _left];
+      [coder encodeObject: _right];
+      [coder encodeValueOfObjCType: @encode(int) at: &type];
+      [coder encodeValueOfObjCType: @encode(int) at: &modifier];
+      [coder encodeValueOfObjCType: @encode(int) at: &options];
+      [coder encodeObject: NSStringFromSelector(_selector)];
+    }
 }
 
 - (id) initWithCoder: (NSCoder *)coder
 {
-  // FIXME
-  [self subclassResponsibility: _cmd];
-  return self;
+  NSExpression			*left;
+  NSExpression			*right;
+  NSPredicateOperatorType	type;
+  NSComparisonPredicateModifier	modifier;
+  NSUInteger			options;
+  SEL				selector;
+
+  if ([coder allowsKeyedCoding])
+    {
+      GSPredicateOperator	*op;
+
+      left = [coder decodeObjectForKey: @"NSLeftExpression"];
+      right = [coder decodeObjectForKey: @"NSRightExpression"];
+      op = [coder decodeObjectForKey: @"NSPredicateOperator"];
+      if (NO == [op isKindOfClass: [GSPredicateOperator class]])
+	{
+	  DESTROY(self);
+	  [NSException raise: NSInvalidArgumentException
+		      format: @"decoding a comparison predicate without the"
+	    @" comparison it makes"];
+	  return nil;
+	}
+      type = op->_type;
+      modifier = op->_modifier;
+      options = op->_options;
+      selector = op->_selector;
+    }
+  else
+    {
+      int	t;
+      int	m;
+      int	o;
+
+      left = [coder decodeObject];
+      right = [coder decodeObject];
+      [coder decodeValueOfObjCType: @encode(int) at: &t];
+      [coder decodeValueOfObjCType: @encode(int) at: &m];
+      [coder decodeValueOfObjCType: @encode(int) at: &o];
+      type = (NSPredicateOperatorType)t;
+      modifier = (NSComparisonPredicateModifier)m;
+      options = (NSUInteger)o;
+      selector = NSSelectorFromString([coder decodeObject]);
+    }
+
+  if (NSCustomSelectorPredicateOperatorType == type)
+    {
+      return [self initWithLeftExpression: left
+			  rightExpression: right
+			   customSelector: selector];
+    }
+  return [self initWithLeftExpression: left
+		      rightExpression: right
+			     modifier: modifier
+				 type: type
+			      options: options];
 }
 
 @end

--- a/Source/NSPredicate.m
+++ b/Source/NSPredicate.m
@@ -38,6 +38,7 @@
 
 #import "Foundation/NSArray.h"
 #import "Foundation/NSDate.h"
+#import "Foundation/NSKeyedArchiver.h"
 #import "Foundation/NSDictionary.h"
 #import "Foundation/NSEnumerator.h"
 #import "Foundation/NSException.h"
@@ -111,7 +112,11 @@ extern void     GSPropertyListMake(id,NSDictionary*,BOOL,BOOL,unsigned,id*);
 @interface GSConstantValueExpression : NSExpression
 {
   @public
-  id	_obj;
+  id		_obj;
+  /* A constant may stand for a class rather than for a value, and the class
+   * it stands for need not be one there is here, so it is kept by name.
+   */
+  NSString	*_className;
 }
 @end
 
@@ -126,6 +131,16 @@ extern void     GSPropertyListMake(id,NSDictionary*,BOOL,BOOL,unsigned,id*);
 @end
 
 @interface GSKeyPathExpression : NSExpression
+{
+  @public
+  NSString	*_keyPath;
+}
+@end
+
+/* Written inside the arguments of a key path expression, which is how OS X
+ * stores the key path itself.  It carries nothing else.
+ */
+@interface GSKeyPathSpecifierExpression : NSExpression
 {
   @public
   NSString	*_keyPath;
@@ -1364,6 +1379,39 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
   if (self == [NSExpression class] && nil == evaluatedObjectExpression)
     {
       evaluatedObjectExpression = [GSEvaluatedObjectExpression new];
+
+      /* An archive names the kinds of expression the way OS X does, so that
+       * one written here can be read there and the other way about.
+       */
+      [NSKeyedArchiver setClassName: @"NSConstantValueExpression"
+			   forClass: [GSConstantValueExpression class]];
+      [NSKeyedArchiver setClassName: @"NSSelfExpression"
+			   forClass: [GSEvaluatedObjectExpression class]];
+      [NSKeyedArchiver setClassName: @"NSVariableExpression"
+			   forClass: [GSVariableExpression class]];
+      [NSKeyedArchiver setClassName: @"NSKeyPathExpression"
+			   forClass: [GSKeyPathExpression class]];
+      [NSKeyedArchiver setClassName: @"NSKeyPathSpecifierExpression"
+			   forClass: [GSKeyPathSpecifierExpression class]];
+      [NSKeyedArchiver setClassName: @"NSFunctionExpression"
+			   forClass: [GSFunctionExpression class]];
+      [NSKeyedArchiver setClassName: @"NSAggregateExpression"
+			   forClass: [GSAggregateExpression class]];
+
+      [NSKeyedUnarchiver setClass: [GSConstantValueExpression class]
+		     forClassName: @"NSConstantValueExpression"];
+      [NSKeyedUnarchiver setClass: [GSEvaluatedObjectExpression class]
+		     forClassName: @"NSSelfExpression"];
+      [NSKeyedUnarchiver setClass: [GSVariableExpression class]
+		     forClassName: @"NSVariableExpression"];
+      [NSKeyedUnarchiver setClass: [GSKeyPathExpression class]
+		     forClassName: @"NSKeyPathExpression"];
+      [NSKeyedUnarchiver setClass: [GSKeyPathSpecifierExpression class]
+		     forClassName: @"NSKeyPathSpecifierExpression"];
+      [NSKeyedUnarchiver setClass: [GSFunctionExpression class]
+		     forClassName: @"NSFunctionExpression"];
+      [NSKeyedUnarchiver setClass: [GSAggregateExpression class]
+		     forClassName: @"NSAggregateExpression"];
     }
 }
 
@@ -1671,11 +1719,9 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
   return nil;
 }
 
-- (Class) classForCoder
-{
-  return [NSExpression class];
-}
-
+/* Each kind of expression is archived as itself, under the name OS X gives
+ * that kind, so the class is not collapsed to NSExpression here.
+ */
 - (void) encodeWithCoder: (NSCoder *)coder
 {
   // FIXME
@@ -1702,6 +1748,68 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 - (id) constantValue
 {
   return _obj;
+}
+
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+  if ([coder allowsKeyedCoding])
+    {
+      Class	c = object_getClass(_obj);
+
+      [coder encodeInt: NSConstantValueExpressionType
+		forKey: @"NSExpressionType"];
+      /* The operand of a function expression is a constant standing for the
+       * class the function belongs to, which is written by name.
+       */
+      if (_className != nil)
+	{
+	  [coder encodeObject: _className forKey: @"NSConstantValueClassName"];
+	}
+      else if (Nil != c && YES == class_isMetaClass(c))
+	{
+	  [coder encodeObject: NSStringFromClass((Class)_obj)
+		       forKey: @"NSConstantValueClassName"];
+	}
+      else
+	{
+	  [coder encodeObject: _obj forKey: @"NSConstantValue"];
+	}
+    }
+  else
+    {
+      [coder encodeObject: _obj];
+    }
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  self = [super initWithExpressionType: NSConstantValueExpressionType];
+  if (self == nil)
+    {
+      return nil;
+    }
+
+  if ([coder allowsKeyedCoding])
+    {
+      if ([coder containsValueForKey: @"NSConstantValueClassName"])
+	{
+	  NSString	*name;
+
+	  name = [coder decodeObjectForKey: @"NSConstantValueClassName"];
+	  ASSIGN(_className, name);
+	  ASSIGN(_obj, (id)NSClassFromString(name));
+	}
+      else
+	{
+	  ASSIGN(_obj, [coder decodeObjectForKey: @"NSConstantValue"]);
+	}
+    }
+  else
+    {
+      ASSIGN(_obj, [coder decodeObject]);
+    }
+
+  return self;
 }
 
 - (BOOL) isEqual: (id)other
@@ -1784,6 +1892,7 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 - (void) dealloc
 {
   RELEASE(_obj);
+  RELEASE(_className);
   DEALLOC
 }
 
@@ -1793,6 +1902,7 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 
   copy = (GSConstantValueExpression *)[super copyWithZone: zone];
   copy->_obj = [_obj copyWithZone: zone];
+  copy->_className = [_className copyWithZone: zone];
   return copy;
 }
 
@@ -1808,6 +1918,22 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 - (NSString *) description
 {
   return @"SELF";
+}
+
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+  if ([coder allowsKeyedCoding])
+    {
+      [coder encodeInt: NSEvaluatedObjectExpressionType
+		forKey: @"NSExpressionType"];
+    }
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  DESTROY(self);
+
+  return RETAIN([NSExpression expressionForEvaluatedObject]);
 }
 
 - (id) expressionValueWithObject: (id)object
@@ -1832,6 +1958,37 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 - (NSString *) description
 {
   return [NSString stringWithFormat: @"$%@", _variable];
+}
+
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+  if ([coder allowsKeyedCoding])
+    {
+      [coder encodeInt: NSVariableExpressionType forKey: @"NSExpressionType"];
+      [coder encodeObject: _variable forKey: @"NSVariable"];
+    }
+  else
+    {
+      [coder encodeObject: _variable];
+    }
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  self = [super initWithExpressionType: NSVariableExpressionType];
+  if (self != nil)
+    {
+      if ([coder allowsKeyedCoding])
+	{
+	  ASSIGN(_variable, [coder decodeObjectForKey: @"NSVariable"]);
+	}
+      else
+	{
+	  ASSIGN(_variable, [coder decodeObject]);
+	}
+    }
+
+  return self;
 }
 
 - (BOOL) isEqual: (id)other
@@ -1901,6 +2058,69 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
   return _keyPath;
 }
 
+/* OS X writes a key path as a function expression asking the object being
+ * evaluated for the key, with the key path itself held by a specifier in the
+ * arguments.
+ */
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+  if ([coder allowsKeyedCoding])
+    {
+      GSKeyPathSpecifierExpression	*specifier;
+      NSString				*selector;
+
+      selector = ([_keyPath rangeOfString: @"."].location == NSNotFound
+	? @"valueForKey:" : @"valueForKeyPath:");
+
+      specifier = [[GSKeyPathSpecifierExpression alloc]
+	initWithExpressionType: NSKeyPathExpressionType];
+      ASSIGN(specifier->_keyPath, _keyPath);
+
+      [coder encodeInt: NSKeyPathExpressionType forKey: @"NSExpressionType"];
+      [coder encodeObject: selector forKey: @"NSSelectorName"];
+      [coder encodeObject: [NSExpression expressionForEvaluatedObject]
+		   forKey: @"NSOperand"];
+      [coder encodeObject: [NSArray arrayWithObject: specifier]
+		   forKey: @"NSArguments"];
+      RELEASE(specifier);
+    }
+  else
+    {
+      [coder encodeObject: _keyPath];
+    }
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  self = [super initWithExpressionType: NSKeyPathExpressionType];
+  if (self == nil)
+    {
+      return nil;
+    }
+
+  if ([coder allowsKeyedCoding])
+    {
+      NSArray	*arguments = [coder decodeObjectForKey: @"NSArguments"];
+      id	first = ([arguments count] > 0
+	? [arguments objectAtIndex: 0] : nil);
+
+      if ([first isKindOfClass: [GSKeyPathSpecifierExpression class]])
+	{
+	  ASSIGN(_keyPath, ((GSKeyPathSpecifierExpression *)first)->_keyPath);
+	}
+      else if ([coder containsValueForKey: @"NSKeyPath"])
+	{
+	  ASSIGN(_keyPath, [coder decodeObjectForKey: @"NSKeyPath"]);
+	}
+    }
+  else
+    {
+      ASSIGN(_keyPath, [coder decodeObject]);
+    }
+
+  return self;
+}
+
 - (BOOL) isEqual: (id)other
 {
   if (self == other)
@@ -1947,6 +2167,60 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 
 - (id) _expressionWithSubstitutionVariables: (NSDictionary *)variables
 {
+  return self;
+}
+
+@end
+
+@implementation GSKeyPathSpecifierExpression
+
+- (void) dealloc
+{
+  RELEASE(_keyPath);
+  DEALLOC
+}
+
+- (NSString *) description
+{
+  return _keyPath;
+}
+
+- (NSString *) keyPath
+{
+  return _keyPath;
+}
+
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+  if ([coder allowsKeyedCoding])
+    {
+      /* The kind OS X gives a specifier, which is not one of the kinds an
+       * expression can be asked for.
+       */
+      [coder encodeInt: 10 forKey: @"NSExpressionType"];
+      [coder encodeObject: _keyPath forKey: @"NSKeyPath"];
+    }
+  else
+    {
+      [coder encodeObject: _keyPath];
+    }
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  self = [super initWithExpressionType: NSKeyPathExpressionType];
+  if (self != nil)
+    {
+      if ([coder allowsKeyedCoding])
+	{
+	  ASSIGN(_keyPath, [coder decodeObjectForKey: @"NSKeyPath"]);
+	}
+      else
+	{
+	  ASSIGN(_keyPath, [coder decodeObject]);
+	}
+    }
+
   return self;
 }
 
@@ -2141,6 +2415,37 @@ do { \
 
 @implementation GSAggregateExpression
 
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+  if ([coder allowsKeyedCoding])
+    {
+      [coder encodeInt: NSAggregateExpressionType forKey: @"NSExpressionType"];
+      [coder encodeObject: _collection forKey: @"NSCollection"];
+    }
+  else
+    {
+      [coder encodeObject: _collection];
+    }
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  self = [super initWithExpressionType: NSAggregateExpressionType];
+  if (self != nil)
+    {
+      if ([coder allowsKeyedCoding])
+	{
+	  ASSIGN(_collection, [coder decodeObjectForKey: @"NSCollection"]);
+	}
+      else
+	{
+	  ASSIGN(_collection, [coder decodeObject]);
+	}
+    }
+
+  return self;
+}
+
 - (BOOL) isEqual: (id)other
 {
   if (self == other)
@@ -2208,6 +2513,61 @@ do { \
 - (NSArray *) arguments
 {
   return _args;
+}
+
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+  if ([coder allowsKeyedCoding])
+    {
+      GSConstantValueExpression	*operand;
+      NSString			*selector = _function;
+
+      /* A function is named with its trailing colon in an archive. */
+      if (NO == [selector hasSuffix: @":"])
+	{
+	  selector = [selector stringByAppendingString: @":"];
+	}
+
+      /* The operand stands for the class the function belongs to, which OS X
+       * names _NSPredicateUtilities.  There is no such class here, so the
+       * constant carries the name alone.
+       */
+      operand = [[GSConstantValueExpression alloc]
+	initWithExpressionType: NSConstantValueExpressionType];
+      ASSIGN(operand->_className, @"_NSPredicateUtilities");
+
+      [coder encodeInt: NSFunctionExpressionType forKey: @"NSExpressionType"];
+      [coder encodeObject: selector forKey: @"NSSelectorName"];
+      [coder encodeObject: operand forKey: @"NSOperand"];
+      [coder encodeObject: _args forKey: @"NSArguments"];
+      RELEASE(operand);
+    }
+  else
+    {
+      [coder encodeObject: _function];
+      [coder encodeObject: _args];
+    }
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  NSString	*name;
+  NSArray	*args;
+
+  if ([coder allowsKeyedCoding])
+    {
+      name = [coder decodeObjectForKey: @"NSSelectorName"];
+      args = [coder decodeObjectForKey: @"NSArguments"];
+    }
+  else
+    {
+      name = [coder decodeObject];
+      args = [coder decodeObject];
+    }
+
+  DESTROY(self);
+
+  return RETAIN([NSExpression expressionForFunction: name arguments: args]);
 }
 
 - (BOOL) isEqual: (id)other

--- a/Source/NSPredicate.m
+++ b/Source/NSPredicate.m
@@ -1413,10 +1413,31 @@ GSICUStringMatchesRegex(NSString *string, NSString *regex, NSStringCompareOption
 {
   GSFunctionExpression	*e;
   NSString		*s;
+  NSString		*implementation = name;
 
   e = AUTORELEASE([[GSFunctionExpression alloc]
     initWithExpressionType: NSFunctionExpressionType]);
-  s = [NSString stringWithFormat: @"_eval_%@:", name];
+
+  /* A function is named with its trailing colon on OS X, as in 'sum:', and
+   * without one here, as in 'sum'.  Take either.
+   */
+  if ([implementation hasSuffix: @":"])
+    {
+      implementation
+	= [implementation substringToIndex: [implementation length] - 1];
+    }
+
+  /* Two of them are implemented here under another name. */
+  if ([implementation isEqualToString: @"average"])
+    {
+      implementation = @"avg";
+    }
+  else if ([implementation isEqualToString: @"castObject:toType"])
+    {
+      implementation = @"CAST";
+    }
+
+  s = [NSString stringWithFormat: @"_eval_%@:", implementation];
   e->_selector = NSSelectorFromString(s);
   if (![e respondsToSelector: e->_selector])
     {

--- a/Tests/base/NSKeyedArchiver/classname.m
+++ b/Tests/base/NSKeyedArchiver/classname.m
@@ -1,0 +1,111 @@
+/* A class may be archived under a name for which there is no class here, as
+   OS X compatible archives require.  The description of the class still has
+   to be the one of the class being encoded.
+*/
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSKeyedArchiver.h>
+#import <Foundation/NSPropertyList.h>
+#import <Foundation/NSString.h>
+#import "Testing.h"
+#import "ObjectTesting.h"
+
+@interface GSRenamed : NSObject
+{
+  NSString	*_text;
+}
+- (id) initWithText: (NSString *)text;
+- (NSString *) text;
+@end
+
+@implementation GSRenamed
+
+- (id) initWithText: (NSString *)text
+{
+  if ((self = [super init]) != nil)
+    {
+      ASSIGN(_text, text);
+    }
+  return self;
+}
+
+- (void) dealloc
+{
+  RELEASE(_text);
+  [super dealloc];
+}
+
+- (NSString *) text
+{
+  return _text;
+}
+
+- (void) encodeWithCoder: (NSCoder *)coder
+{
+  [coder encodeObject: _text forKey: @"Text"];
+}
+
+- (id) initWithCoder: (NSCoder *)coder
+{
+  if ((self = [super init]) != nil)
+    {
+      ASSIGN(_text, [coder decodeObjectForKey: @"Text"]);
+    }
+  return self;
+}
+
+@end
+
+/* The class description an archive of the object holds. */
+static NSDictionary *
+classDescription(id object, NSString *name)
+{
+  NSData	*data = [NSKeyedArchiver archivedDataWithRootObject: object];
+  NSDictionary	*plist;
+  id		entry;
+
+  plist = [NSPropertyListSerialization propertyListWithData: data
+						    options: 0
+						     format: NULL
+						      error: NULL];
+  for (entry in [plist objectForKey: @"$objects"])
+    {
+      if ([entry isKindOfClass: [NSDictionary class]]
+	&& [[entry objectForKey: @"$classname"] isEqual: name])
+	{
+	  return entry;
+	}
+    }
+  return nil;
+}
+
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
+  GSRenamed		*object;
+  NSDictionary		*description;
+  id			decoded;
+
+  object = AUTORELEASE([[GSRenamed alloc] initWithText: @"text"]);
+  [NSKeyedArchiver setClassName: @"AbsentElsewhere" forClass: [GSRenamed class]];
+
+  description = classDescription(object, @"AbsentElsewhere");
+  PASS(description != nil, "an object is archived under the name given for it");
+  PASS([[description objectForKey: @"$classes"] count] > 0,
+       "a name with no class of its own still describes the class hierarchy");
+  PASS([[description objectForKey: @"$classes"] containsObject: @"NSObject"],
+       "and the hierarchy is the one of the class being encoded");
+
+  [NSKeyedUnarchiver setClass: [GSRenamed class] forClassName: @"AbsentElsewhere"];
+  decoded = [NSKeyedUnarchiver unarchiveObjectWithData:
+    [NSKeyedArchiver archivedDataWithRootObject: object]];
+  PASS([decoded isKindOfClass: [GSRenamed class]],
+       "and the object read back is of the class the name stands for");
+  PASS_EQUAL([decoded text], @"text", "carrying what it was given");
+
+  [arp release];
+  return 0;
+}

--- a/Tests/base/NSPredicate/expressionCoding.m
+++ b/Tests/base/NSPredicate/expressionCoding.m
@@ -1,0 +1,175 @@
+/* An expression can be archived and read back, which a predicate editor needs
+   since its row templates hold expressions and are stored in a nib.  The
+   archive is written the way OS X writes it, so that one written here can be
+   read there and the other way about.
+*/
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSException.h>
+#import <Foundation/NSExpression.h>
+#import <Foundation/NSKeyedArchiver.h>
+#import <Foundation/NSPropertyList.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSValue.h>
+#import "ObjectTesting.h"
+
+static id
+roundTrip(id object)
+{
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject: object];
+
+  return [NSKeyedUnarchiver unarchiveObjectWithData: data];
+}
+
+/* The class names an archive of the object holds. */
+static NSArray *
+classNames(id object)
+{
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject: object];
+  NSDictionary *plist;
+  NSMutableArray *names = [NSMutableArray array];
+
+  plist = [NSPropertyListSerialization propertyListWithData: data
+                                                    options: 0
+                                                     format: NULL
+                                                      error: NULL];
+  for (id entry in [plist objectForKey: @"$objects"])
+    {
+      if ([entry isKindOfClass: [NSDictionary class]]
+        && [entry objectForKey: @"$classname"] != nil)
+        {
+          [names addObject: [entry objectForKey: @"$classname"]];
+        }
+    }
+
+  return names;
+}
+
+/* Whether anything in an archive holds the given value under the given key. */
+static BOOL
+archiveHolds(id object, NSString *key, id value)
+{
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject: object];
+  NSDictionary *plist;
+
+  plist = [NSPropertyListSerialization propertyListWithData: data
+                                                    options: 0
+                                                     format: NULL
+                                                      error: NULL];
+  for (id entry in [plist objectForKey: @"$objects"])
+    {
+      if ([entry isKindOfClass: [NSDictionary class]])
+        {
+          id held = [entry objectForKey: key];
+
+          /* A value is written as a reference to the string holding it. */
+          if ([held isKindOfClass: [NSDictionary class]])
+            {
+              NSUInteger index;
+
+              index = [[held objectForKey: @"CF$UID"] unsignedIntegerValue];
+              held = [[plist objectForKey: @"$objects"] objectAtIndex: index];
+            }
+          if ([held isEqual: value])
+            {
+              return YES;
+            }
+        }
+    }
+
+  return NO;
+}
+
+/* The dictionary an archive holds for the object itself. */
+static NSDictionary *
+archivedObject(id object)
+{
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject: object];
+  NSDictionary *plist;
+
+  plist = [NSPropertyListSerialization propertyListWithData: data
+                                                    options: 0
+                                                     format: NULL
+                                                      error: NULL];
+  return [[plist objectForKey: @"$objects"] objectAtIndex: 1];
+}
+
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSExpression *e;
+
+  /* A constant. */
+  e = [NSExpression expressionForConstantValue: @"hello"];
+  PASS_EQUAL(roundTrip(e), e, "a constant expression survives being archived");
+  PASS([classNames(e) containsObject: @"NSConstantValueExpression"],
+       "and is named the way OS X names it");
+  PASS([[archivedObject(e) allKeys] containsObject: @"NSConstantValue"]
+       && [[archivedObject(e) allKeys] containsObject: @"NSExpressionType"],
+       "under the keys OS X writes");
+
+  e = [NSExpression expressionForConstantValue: [NSNumber numberWithInt: 42]];
+  PASS_EQUAL([roundTrip(e) constantValue], [NSNumber numberWithInt: 42],
+             "a constant number comes back as it went in");
+
+  /* The object being evaluated. */
+  e = [NSExpression expressionForEvaluatedObject];
+  PASS_EQUAL(roundTrip(e), e, "the evaluated object expression survives");
+  PASS([classNames(e) containsObject: @"NSSelfExpression"],
+       "and is named the way OS X names it");
+
+  /* A variable. */
+  e = [NSExpression expressionForVariable: @"v"];
+  PASS_EQUAL(roundTrip(e), e, "a variable expression survives");
+  PASS([classNames(e) containsObject: @"NSVariableExpression"],
+       "and is named the way OS X names it");
+
+  /* A key path, single and dotted. */
+  e = [NSExpression expressionForKeyPath: @"name"];
+  PASS_EQUAL(roundTrip(e), e, "a key path expression survives");
+  PASS_EQUAL([roundTrip(e) keyPath], @"name", "with its key path");
+  PASS([classNames(e) containsObject: @"NSKeyPathExpression"],
+       "and is named the way OS X names it");
+  PASS([classNames(e) containsObject: @"NSKeyPathSpecifierExpression"],
+       "with the key path held by a specifier, as OS X holds it");
+
+  e = [NSExpression expressionForKeyPath: @"a.b"];
+  PASS_EQUAL([roundTrip(e) keyPath], @"a.b", "a dotted key path survives");
+
+  /* A function. */
+  e = [NSExpression expressionForFunction: @"sum:"
+                                arguments: [NSArray arrayWithObject:
+                                  [NSExpression expressionForKeyPath: @"n"]]];
+  PASS_EQUAL(roundTrip(e), e, "a function expression survives");
+  PASS([classNames(e) containsObject: @"NSFunctionExpression"],
+       "and is named the way OS X names it");
+  PASS(archiveHolds(e, @"NSSelectorName", @"sum:"),
+       "under the name of the selector it calls");
+  PASS(archiveHolds(e, @"NSConstantValueClassName", @"_NSPredicateUtilities"),
+       "standing on the class OS X puts the functions on");
+
+  /* An aggregate. */
+  e = [NSExpression expressionForAggregate: ([NSArray arrayWithObjects:
+    [NSExpression expressionForConstantValue: [NSNumber numberWithInt: 1]],
+    [NSExpression expressionForConstantValue: [NSNumber numberWithInt: 2]],
+    nil])];
+  PASS_EQUAL(roundTrip(e), e, "an aggregate expression survives");
+  PASS([classNames(e) containsObject: @"NSAggregateExpression"],
+       "and is named the way OS X names it");
+
+  /* A collection of them, which is what a row template holds. */
+  {
+    NSArray *list = [NSArray arrayWithObjects:
+      [NSExpression expressionForKeyPath: @"name"],
+      [NSExpression expressionForKeyPath: @"size"], nil];
+
+    PASS_EQUAL(roundTrip(list), list,
+               "a list of expressions survives being archived");
+  }
+
+  [arp release];
+  return 0;
+}

--- a/Tests/base/NSPredicate/functionNames.m
+++ b/Tests/base/NSPredicate/functionNames.m
@@ -1,0 +1,80 @@
+/* A function expression is named with its trailing colon on OS X, as in
+   'sum:', and two of the functions are known there under names this library
+   implements under another one.  Code written against the documented names
+   could not build an expression here at all.
+*/
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSExpression.h>
+#import <Foundation/NSPredicate.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSValue.h>
+#import "ObjectTesting.h"
+
+static NSExpression *
+functionOf(NSString *name, NSArray *numbers)
+{
+  return [NSExpression expressionForFunction: name
+                                   arguments:
+    [NSArray arrayWithObject:
+      [NSExpression expressionForConstantValue: numbers]]];
+}
+
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSArray *numbers = [NSArray arrayWithObjects:
+    [NSNumber numberWithInt: 1], [NSNumber numberWithInt: 2],
+    [NSNumber numberWithInt: 3], nil];
+  NSExpression *e;
+
+  e = functionOf(@"sum:", numbers);
+  PASS(e != nil, "a function named with its colon builds an expression");
+  PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 6.0,
+       "and it adds the numbers up");
+  PASS_EQUAL([e function], @"sum:", "the name is kept as it was given");
+
+  e = functionOf(@"sum", numbers);
+  PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 6.0,
+       "the name without a colon is still taken");
+
+  e = functionOf(@"average:", numbers);
+  PASS(e != nil, "the name OS X gives the average builds an expression");
+  PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 2.0,
+       "and it averages the numbers");
+
+  e = functionOf(@"avg", numbers);
+  PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 2.0,
+       "the name it has always had here is still taken");
+
+  e = functionOf(@"count:", numbers);
+  PASS([[e expressionValueWithObject: nil context: nil] intValue] == 3,
+       "count takes its colon too");
+
+  e = functionOf(@"max:", numbers);
+  PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 3.0,
+       "so does max");
+
+  e = functionOf(@"min:", numbers);
+  PASS([[e expressionValueWithObject: nil context: nil] doubleValue] == 1.0,
+       "so does min");
+
+  {
+    BOOL raised = NO;
+
+    NS_DURING
+      {
+        functionOf(@"nosuchfunction:", numbers);
+      }
+    NS_HANDLER
+      {
+        raised = YES;
+      }
+    NS_ENDHANDLER
+    PASS(raised == YES, "a name that no function answers to still raises");
+  }
+
+  [arp release];
+  return 0;
+}

--- a/Tests/base/NSPredicate/predicateCoding.m
+++ b/Tests/base/NSPredicate/predicateCoding.m
@@ -1,0 +1,207 @@
+/* A predicate can be archived and read back, which a predicate editor needs
+   since a row template built from one is stored in a nib.  The archive is
+   written the way OS X writes it, so that one written here can be read there.
+*/
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSComparisonPredicate.h>
+#import <Foundation/NSCompoundPredicate.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSExpression.h>
+#import <Foundation/NSKeyedArchiver.h>
+#import <Foundation/NSPredicate.h>
+#import <Foundation/NSPropertyList.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSValue.h>
+#import "ObjectTesting.h"
+
+static id
+roundTrip(id object)
+{
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject: object];
+
+  return [NSKeyedUnarchiver unarchiveObjectWithData: data];
+}
+
+static NSArray *
+archiveObjects(id object)
+{
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject: object];
+  NSDictionary *plist;
+
+  plist = [NSPropertyListSerialization propertyListWithData: data
+                                                    options: 0
+                                                     format: NULL
+                                                      error: NULL];
+  return [plist objectForKey: @"$objects"];
+}
+
+/* The class names an archive of the object holds. */
+static NSArray *
+classNames(id object)
+{
+  NSMutableArray *names = [NSMutableArray array];
+
+  for (id entry in archiveObjects(object))
+    {
+      if ([entry isKindOfClass: [NSDictionary class]]
+        && [entry objectForKey: @"$classname"] != nil)
+        {
+          [names addObject: [entry objectForKey: @"$classname"]];
+        }
+    }
+
+  return names;
+}
+
+/* The dictionary an archive holds for the comparison a predicate makes. */
+static NSDictionary *
+operatorObject(id object)
+{
+  for (id entry in archiveObjects(object))
+    {
+      if ([entry isKindOfClass: [NSDictionary class]]
+        && [entry objectForKey: @"NSOperatorType"] != nil)
+        {
+          return entry;
+        }
+    }
+
+  return nil;
+}
+
+static NSPredicate *
+comparison(NSPredicateOperatorType type, NSUInteger options)
+{
+  return [NSComparisonPredicate
+    predicateWithLeftExpression: [NSExpression expressionForKeyPath: @"a"]
+                rightExpression: [NSExpression expressionForConstantValue: @"b"]
+                       modifier: NSDirectPredicateModifier
+                           type: type
+                        options: options];
+}
+
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSPredicate *p;
+  NSDictionary *op;
+
+  /* A comparison, and the three parts OS X writes it in. */
+  p = comparison(NSEqualToPredicateOperatorType, 0);
+  PASS_EQUAL(roundTrip(p), p, "a comparison predicate survives being archived");
+  PASS([classNames(p) containsObject: @"NSComparisonPredicate"],
+       "and is named the way OS X names it");
+  op = operatorObject(p);
+  PASS([[op allKeys] containsObject: @"NSOperatorType"]
+       && [[op allKeys] containsObject: @"NSModifier"],
+       "with the comparison it makes written as an object of its own");
+  PASS_EQUAL([op objectForKey: @"NSOperatorType"], [NSNumber numberWithInt: 4],
+             "under the operator type OS X writes");
+  PASS_EQUAL([op objectForKey: @"NSNegate"], [NSNumber numberWithInt: 0],
+             "and the negation OS X writes with it");
+  PASS([classNames(p) containsObject: @"NSEqualityPredicateOperator"],
+       "in the class OS X gives that family of operators");
+
+  /* The class of the operator object goes with the family it belongs to. */
+  PASS([classNames(comparison(NSLessThanPredicateOperatorType, 0))
+         containsObject: @"NSComparisonPredicateOperator"],
+       "an ordering comparison is written in its own class");
+  PASS([classNames(comparison(NSMatchesPredicateOperatorType, 0))
+         containsObject: @"NSMatchingPredicateOperator"],
+       "as is a match");
+  PASS([classNames(comparison(NSLikePredicateOperatorType, 0))
+         containsObject: @"NSLikePredicateOperator"],
+       "as is a like");
+  PASS([classNames(comparison(NSBeginsWithPredicateOperatorType, 0))
+         containsObject: @"NSSubstringPredicateOperator"],
+       "as is a substring comparison");
+  PASS([classNames(comparison(NSInPredicateOperatorType, 0))
+         containsObject: @"NSInPredicateOperator"],
+       "as is a membership test");
+  PASS([classNames(comparison(NSBetweenPredicateOperatorType, 0))
+         containsObject: @"NSBetweenPredicateOperator"],
+       "as is a range test");
+
+  /* Which name the options are written under goes with the family too. */
+  op = operatorObject(comparison(NSLessThanPredicateOperatorType,
+    NSCaseInsensitivePredicateOption | NSDiacriticInsensitivePredicateOption));
+  PASS_EQUAL([op objectForKey: @"NSOptions"], [NSNumber numberWithInt: 3],
+             "an ordering comparison writes its options under NSOptions");
+  op = operatorObject(comparison(NSMatchesPredicateOperatorType,
+    NSCaseInsensitivePredicateOption | NSDiacriticInsensitivePredicateOption));
+  PASS_EQUAL([op objectForKey: @"NSFlags"], [NSNumber numberWithInt: 3],
+             "a match writes them under NSFlags");
+  op = operatorObject(comparison(NSEndsWithPredicateOperatorType, 0));
+  PASS_EQUAL([op objectForKey: @"NSPosition"], [NSNumber numberWithInt: 1],
+             "and a substring comparison writes which end it looks at");
+
+  /* The options and the modifier come back. */
+  p = comparison(NSMatchesPredicateOperatorType,
+    NSCaseInsensitivePredicateOption);
+  PASS_EQUAL(roundTrip(p), p, "a comparison with options survives");
+  PASS([(NSComparisonPredicate *)roundTrip(p) options]
+       == NSCaseInsensitivePredicateOption, "with the options it was given");
+
+  p = [NSComparisonPredicate
+    predicateWithLeftExpression: [NSExpression expressionForKeyPath: @"a"]
+                rightExpression: [NSExpression expressionForConstantValue: @"b"]
+                       modifier: NSAnyPredicateModifier
+                           type: NSEqualToPredicateOperatorType
+                        options: 0];
+  PASS([(NSComparisonPredicate *)roundTrip(p) comparisonPredicateModifier]
+       == NSAnyPredicateModifier, "and a modifier comes back as it went in");
+
+  /* A custom selector is written by name, as OS X writes it. */
+  p = [NSComparisonPredicate
+    predicateWithLeftExpression: [NSExpression expressionForKeyPath: @"a"]
+                rightExpression: [NSExpression expressionForConstantValue: @"b"]
+                 customSelector: @selector(isEqual:)];
+  PASS([classNames(p) containsObject: @"NSCustomPredicateOperator"],
+       "a custom selector comparison is written in the class OS X gives it");
+  PASS(sel_isEqual([(NSComparisonPredicate *)roundTrip(p) customSelector],
+                   @selector(isEqual:)), "and the selector comes back");
+
+  /* A compound predicate, and the two keys OS X writes it under. */
+  p = [NSCompoundPredicate andPredicateWithSubpredicates:
+    [NSArray arrayWithObjects: comparison(NSEqualToPredicateOperatorType, 0),
+      comparison(NSLessThanPredicateOperatorType, 0), nil]];
+  PASS_EQUAL(roundTrip(p), p, "a compound predicate survives being archived");
+  PASS([classNames(p) containsObject: @"NSCompoundPredicate"],
+       "and is named the way OS X names it");
+  PASS([[[archiveObjects(p) objectAtIndex: 1] allKeys]
+         containsObject: @"NSCompoundPredicateType"]
+       && [[[archiveObjects(p) objectAtIndex: 1] allKeys]
+            containsObject: @"NSSubpredicates"],
+       "under the keys OS X writes");
+  PASS_EQUAL([[archiveObjects(p) objectAtIndex: 1]
+               objectForKey: @"NSCompoundPredicateType"],
+             [NSNumber numberWithInt: 1], "with the type of the compound");
+  PASS([[(NSCompoundPredicate *)roundTrip(p) subpredicates] count] == 2,
+       "and both of the predicates it holds");
+
+  p = [NSCompoundPredicate notPredicateWithSubpredicate:
+    comparison(NSEqualToPredicateOperatorType, 0)];
+  PASS_EQUAL(roundTrip(p), p, "a negated predicate survives");
+  PASS([(NSCompoundPredicate *)roundTrip(p) compoundPredicateType]
+       == NSNotPredicateType, "as the negation it was");
+
+  /* A predicate of a fixed value. */
+  p = [NSPredicate predicateWithValue: YES];
+  PASS_EQUAL(roundTrip(p), p, "a true predicate survives being archived");
+  PASS([classNames(p) containsObject: @"NSTruePredicate"],
+       "and is named the way OS X names it");
+  p = [NSPredicate predicateWithValue: NO];
+  PASS_EQUAL(roundTrip(p), p, "a false predicate survives being archived");
+  PASS([classNames(p) containsObject: @"NSFalsePredicate"],
+       "and is named the way OS X names it");
+
+  /* What a row template holds is a predicate parsed from a format. */
+  p = [NSPredicate predicateWithFormat: @"name CONTAINS[cd] %@", @"x"];
+  PASS_EQUAL(roundTrip(p), p, "a parsed predicate survives being archived");
+
+  [arp release];
+  return 0;
+}


### PR DESCRIPTION
Archiving a predicate raises. NSComparisonPredicate and NSCompoundPredicate both leave the coder methods to a subclass with a FIXME and nothing implements them, so a predicate can be neither written to a nib nor read back.

A comparison now writes NSLeftExpression, NSRightExpression and NSPredicateOperator, the last an object of its own as OS X writes it, in a class for each family of operator and holding the keys that family uses: NSOptions for an ordering or an equality, NSFlags for a match, a like, a substring or a membership test, NSNegate for a not equal, NSPosition for an ends with, and the selector name for a custom selector. A compound writes NSCompoundPredicateType and the predicates it holds under NSSubpredicates, and a predicate of a fixed value writes its class alone.

The operator classes exist for archiving and hold nothing the predicate does not. A range test drops its options, as on OS X. This sits on #716 and carries its commits, since a predicate archives the expressions it holds.

Tests/base/NSPredicate/predicateCoding.m.

On the branch it sits on, two assertions fail and the file then aborts. All thirty two pass with the change, and the rest of the suite is unchanged.
