### PR TITLE
Fix: NSComparisonPredicate describes greater than as greater than or equal

### DIFF
--- a/Source/NSPredicate.m
+++ b/Source/NSPredicate.m
@@ -915,10 +915,10 @@ extern void     GSPropertyListMake(id,NSDictionary*,BOOL,BOOL,unsigned,id*);
         comp = @"<=";
         break;
       case NSGreaterThanPredicateOperatorType:
-        comp = @">=";
+        comp = @">";
         break;
       case NSGreaterThanOrEqualToPredicateOperatorType:
-        comp = @">";
+        comp = @">=";
         break;
       case NSEqualToPredicateOperatorType:
         comp = @"=";

--- a/Tests/base/NSPredicate/formatOperators.m
+++ b/Tests/base/NSPredicate/formatOperators.m
@@ -1,0 +1,43 @@
+/* The format a predicate describes itself with has to parse back to the same
+   predicate, since that is how a predicate is passed around as text.
+*/
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSComparisonPredicate.h>
+#import <Foundation/NSPredicate.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSValue.h>
+#import "ObjectTesting.h"
+
+static NSString *
+formatOf(NSString *format)
+{
+  return [[NSPredicate predicateWithFormat: format] predicateFormat];
+}
+
+int
+main(int argc, char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  NSPredicate *p;
+
+  PASS_EQUAL(formatOf(@"a < 1"), @"a < 1", "a less than describes itself");
+  PASS_EQUAL(formatOf(@"a <= 1"), @"a <= 1",
+             "a less than or equal describes itself");
+  PASS_EQUAL(formatOf(@"a > 1"), @"a > 1",
+             "a greater than describes itself");
+  PASS_EQUAL(formatOf(@"a >= 1"), @"a >= 1",
+             "a greater than or equal describes itself");
+  PASS_EQUAL(formatOf(@"a = 1"), @"a = 1", "an equal describes itself");
+  PASS_EQUAL(formatOf(@"a != 1"), @"a != 1", "a not equal describes itself");
+
+  /* The description has to mean what the predicate means. */
+  p = [NSPredicate predicateWithFormat: @"%@ > %@",
+    [NSNumber numberWithInt: 1], [NSNumber numberWithInt: 1]];
+  PASS([p evaluateWithObject: nil] == NO, "one is not greater than one");
+  PASS([[NSPredicate predicateWithFormat: [p predicateFormat]]
+         evaluateWithObject: nil] == NO,
+       "and neither is it read back from the description");
+
+  [arp release];
+  return 0;
+}


### PR DESCRIPTION
A predicate meaning greater than describes itself as greater than or equal, and one meaning greater than or equal describes itself as greater than. The two cases are the wrong way round in -predicateFormat. Parsing and evaluation are both right, so the fault is in the description alone, which makes it quiet: a predicate passed around as text comes back meaning something else. On a > 1 the format reads a >= 1, and reading that back gives a predicate that holds for 1.

The two cases are swapped back.

Nothing else reads those two strings, and the format of every other operator is unchanged.

Tests/base/NSPredicate/formatOperators.m, which checks that each comparison in a format string describes itself the same way, and that a predicate read back from its own description still means what it meant.

Three of its eight assertions fail before the change and all eight pass after. The rest of the suite is unchanged.
