### PR TITLE
Fix mac build

### DIFF
--- a/Headers/GNUstepBase/GSObjCRuntime.h
+++ b/Headers/GNUstepBase/GSObjCRuntime.h
@@ -69,13 +69,15 @@
 
 #if defined(OBJC_CAP_ARC)
 #  include <objc/objc-arc.h>
-#elif !defined(__APPLE__)
+#else
 
 GS_EXPORT void objc_copyWeak(id *dest, id *src);
 GS_EXPORT void objc_destroyWeak(id *obj);
 GS_EXPORT id objc_initWeak(id *addr, id obj);
 GS_EXPORT id objc_loadWeakRetained(id *addr);
 GS_EXPORT void objc_moveWeak(id *dest, id *src);
+
+#if !defined(__APPLE__)
 
 GS_EXPORT id objc_loadWeak(id *object);
 GS_EXPORT id objc_storeWeak(id *addr, id obj);
@@ -115,6 +117,7 @@ GS_EXPORT void objc_removeAssociatedObjects(id object);
 GS_EXPORT void objc_setAssociatedObject(id object, const void *key,
   id value, objc_AssociationPolicy policy);
 
+#endif
 #endif
 
 /*

--- a/Headers/GNUstepBase/GSVersionMacros.h
+++ b/Headers/GNUstepBase/GSVersionMacros.h
@@ -507,6 +507,7 @@ static inline void gs_consumed(id NS_CONSUMED GS_UNUSED_ARG o) { return; }
 /* Other constants/types commonplace in OSX applications but otherwise unused.
  */
 
+#if !defined(__APPLE__)
 // noErr                   OSErr: function performed properly - no error
 enum {
   noErr                         = 0
@@ -533,5 +534,6 @@ enum {
 enum {
   kUnknownType                  = 0x3F3F3F3F /* "????" QuickTime 3.0: default unknown ResType or OSType */
 };
+#endif
 
 #endif /* __GNUSTEP_GSVERSIONMACROS_H_INCLUDED_ */

--- a/Source/Additions/GSStandaloneXMLParser.m
+++ b/Source/Additions/GSStandaloneXMLParser.m
@@ -35,6 +35,10 @@
 #import "Foundation/NSNull.h"
 #import "GNUstepBase/GSMime.h"
 #import "GNUstepBase/GSStandaloneXMLParser.h"
+#import "GNUstepBase/Unicode.h"
+#ifndef GSUndefinedEncoding
+#define GSUndefinedEncoding 0
+#endif
 
 @interface GSMimeDocument (internal)
 + (NSString*) charsetForXml: (NSData*)xml;
@@ -205,7 +209,7 @@ static SEL	foundIgnorableSel;
     }
   else
     {
-      self = [super init];
+      self = [super init]; // NS_DESIGNATED_INITIALIZER
       if (self)
 	{
 	  NSStringEncoding	enc;
@@ -436,7 +440,7 @@ static SEL	foundIgnorableSel;
             }
           uri = [self _uriForPrefix: p];
         }
-      (*this->didEndElement)(_del,
+      ((void (*)(id, SEL, id, id, id, id))this->didEndElement)(_del,
 	didEndElementSel, self, tag, uri, qualified);
     }
 
@@ -453,7 +457,7 @@ static SEL	foundIgnorableSel;
 
               while ((k = [e nextObject]) != nil)
                 {
-                  (*this->didEndMappingPrefix)(_del,
+                  ((void (*)(id, SEL, id, id))this->didEndMappingPrefix)(_del,
 		    didEndMappingPrefixSel, self, k);
                 }
             }
@@ -798,7 +802,7 @@ NSLog(@"_processTag <%@%@ %@>", flag?@"/": @"", tag, attributes);
                     {
                       if (this->didStartMappingPrefix != 0)
                         {
-			  (*this->didStartMappingPrefix)(_del,
+			  ((void (*)(id, SEL, id, id, id))this->didStartMappingPrefix)(_del,
 			    didStartMappingPrefixSel, self, prefix, uri);
                         }
                     }
@@ -837,7 +841,7 @@ NSLog(@"_processTag <%@%@ %@>", flag?@"/": @"", tag, attributes);
                 {
                   uri = @"";
                 }
-	      (*this->didStartElement)(_del,
+	      ((void (*)(id, SEL, id, id, id, id, id))this->didStartElement)(_del,
 		didStartElementSel, self, tag, uri, qualified, attributes);
             }
 	  TEST_RELEASE(ns);
@@ -1194,7 +1198,7 @@ NSLog(@"_processTag <%@%@ %@>", flag?@"/": @"", tag, attributes);
                                 {
                                   /* Process this data as characters
                                    */
-                                  (*this->foundCharacters)(_del,
+                                  ((void (*)(id, SEL, id, id))this->foundCharacters)(_del,
                                     foundCharactersSel, self, s);
                                   RELEASE(s);
                                 }
@@ -1214,7 +1218,7 @@ NSLog(@"_processTag <%@%@ %@>", flag?@"/": @"", tag, attributes);
                                 {
                                   /* Process data as ignorable whitespace
                                    */
-                                  (*this->foundIgnorable)(_del,
+                                  ((void (*)(id, SEL, id, id))this->foundIgnorable)(_del,
                                     foundIgnorableSel, self, s);
                                   RELEASE(s);
                                 }
@@ -1231,7 +1235,7 @@ NSLog(@"_processTag <%@%@ %@>", flag?@"/": @"", tag, attributes);
                                 {
                                   /* Process data as characters
                                    */
-                                  (*this->foundCharacters)(_del,
+                                  ((void (*)(id, SEL, id, id))this->foundCharacters)(_del,
                                     foundCharactersSel, self, s);
                                   RELEASE(s);
                                 }
@@ -1265,7 +1269,7 @@ NSLog(@"_processTag <%@%@ %@>", flag?@"/": @"", tag, attributes);
                           }
                         else
                           {
-                            (*this->foundIgnorable)(_del,
+                            ((void (*)(id, SEL, id, id))this->foundIgnorable)(_del,
                               foundIgnorableSel, self, s);
 			    RELEASE(s);
                           }
@@ -1280,7 +1284,7 @@ NSLog(@"_processTag <%@%@ %@>", flag?@"/": @"", tag, attributes);
                           }
                         else
                           {
-                            (*this->foundCharacters)(_del,
+                            ((void (*)(id, SEL, id, id))this->foundCharacters)(_del,
                               foundCharactersSel, self, s);
                             RELEASE(s);
 			  }
@@ -1346,7 +1350,7 @@ NSLog(@"_processTag <%@%@ %@>", flag?@"/": @"", tag, attributes);
                 }
 	      if (this->foundCharacters != 0)
 		{
-		  (*this->foundCharacters)(_del,
+		  ((void (*)(id, SEL, id, id))this->foundCharacters)(_del,
 		    foundCharactersSel, self, entity);
                 }
 	      RELEASE(entity);
@@ -1392,7 +1396,7 @@ NSLog(@"_processTag <%@%@ %@>", flag?@"/": @"", tag, attributes);
                         }
                       else
                         {
-                          (*this->foundComment)(_del,
+                          ((void (*)(id, SEL, id, id))this->foundComment)(_del,
                             foundCommentSel, self, c);
 			  RELEASE(c);
                         }
@@ -1420,7 +1424,7 @@ NSLog(@"_processTag <%@%@ %@>", flag?@"/": @"", tag, attributes);
 
 		      d = [[NSData alloc] initWithBytes: addr(tp)
 						 length: this->cp - tp];
-		      (*this->foundCDATA)(_del,
+		      ((void (*)(id, SEL, id, id))this->foundCDATA)(_del,
 			foundCDATASel, self, d);
 		      RELEASE(d);
 		    }


### PR DESCRIPTION
Three problems that blocked the build on macOS 26.5.2 Tahoe:

1. The version macros in `GSVersionMacros.h` shadow constants that Foundation defines.
2. `GSObjCRuntime.h` relies on clang ABI for weak pointers that it only declared on non-macOS platforms, but they aren't defined in the runtime headers there either.
3. `GSStandaloneXMLParser` uses `IMP` caching; the function pointers need to be cast to the correct type on macOS before use (and it's safe to do so on other platforms anyway).

Incidentally, a recent change between the last time I pulled and the current `master` fixes an `autogsdoc` crash I saw where `autogsdoc` cast an `NSXMLParser` to `GSStandaloneXMLParser` which didn't work on macOS. My original goal with this branch was to fix that, but after addressing the compiler issues I don't see that crash any more anyway.