### PR TITLE
gcc-4.9

### DIFF
--- a/.github/workflows/gcc-4.9.yml
+++ b/.github/workflows/gcc-4.9.yml
@@ -37,7 +37,7 @@ jobs:
 
               git clone https://github.com/gnustep/tools-make.git
               cd tools-make
-              ./configure --prefix=/opt/GNUstep
+              ./configure --prefix=/opt/GNUstep --with-layout=gnustep
               make -j$(nproc)
               make install
               cd ..

--- a/.github/workflows/gcc-4.9.yml
+++ b/.github/workflows/gcc-4.9.yml
@@ -31,7 +31,7 @@ jobs:
             bash -c '
               export PATH=/opt/gcc-4.9.4/bin:$PATH
               export LD_LIBRARY_PATH=/opt/gcc-4.9.4/lib64:/opt/gcc-4.9.4/lib
-	      export GNUSTEP_INSTALLATION_DOMAIN=SYSTEM
+              export GNUSTEP_INSTALLATION_DOMAIN=SYSTEM
 
               which gcc
               gcc --version
@@ -46,6 +46,6 @@ jobs:
 
               ./configure
               make -j$(nproc)
-	      make install
+              make install
               make check
             '

--- a/.github/workflows/gcc-4.9.yml
+++ b/.github/workflows/gcc-4.9.yml
@@ -29,8 +29,8 @@ jobs:
             -w /src \
             ghcr.io/gnustep/gcc-4.9-gnustep:latest \
             bash -c '
-              export PATH=/opt/gcc4.9.4/bin:$PATH
-              export LD_LIBRARY_PATH=/opt/gcc4.9.4/lib64:/opt/gcc4.9.4/lib
+              export PATH=/opt/gcc-4.9.4/bin:$PATH
+              export LD_LIBRARY_PATH=/opt/gcc-4.9.4/lib64:/opt/gcc-4.9.4/lib
 
               which gcc
               gcc --version

--- a/.github/workflows/gcc-4.9.yml
+++ b/.github/workflows/gcc-4.9.yml
@@ -1,0 +1,60 @@
+name: GNUstep GCC 4.9
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/gnustep/gcc49-gobjc:latest
+
+    env:
+      PATH: /opt/gcc4.9.4/bin:/usr/local/bin:/usr/bin:/bin
+      LD_LIBRARY_PATH: /opt/gcc4.9.4/lib64:/opt/gcc4.9.4/lib
+      CC: gcc
+      CXX: g++
+      OBJC: gcc
+      GNUSTEP_INSTALLATION_DOMAIN: SYSTEM
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify compiler
+        run: |
+          which gcc
+          gcc --version
+
+      - name: Build gnustep-make
+        run: |
+          git clone https://github.com/gnustep/tools-make.git
+          cd tools-make
+          ./configure --prefix=/opt/GNUstep
+          make -j$(nproc)
+          make install
+
+      - name: Source GNUstep environment
+        run: |
+          . /opt/GNUstep/System/Library/Makefiles/GNUstep.sh
+          env | grep GNUSTEP
+
+      - name: Configure gnustep-base
+        shell: bash
+        run: |
+          . /opt/GNUstep/System/Library/Makefiles/GNUstep.sh
+          ./configure
+
+      - name: Build
+        shell: bash
+        run: |
+          . /opt/GNUstep/System/Library/Makefiles/GNUstep.sh
+          make -j$(nproc)
+
+      - name: Test
+        shell: bash
+        run: |
+          . /opt/GNUstep/System/Library/Makefiles/GNUstep.sh
+          make check
+

--- a/.github/workflows/gcc-4.9.yml
+++ b/.github/workflows/gcc-4.9.yml
@@ -31,6 +31,7 @@ jobs:
             bash -c '
               export PATH=/opt/gcc-4.9.4/bin:$PATH
               export LD_LIBRARY_PATH=/opt/gcc-4.9.4/lib64:/opt/gcc-4.9.4/lib
+	      export GNUSTEP_INSTALLATION_DOMAIN=SYSTEM
 
               which gcc
               gcc --version
@@ -38,7 +39,6 @@ jobs:
               git clone https://github.com/gnustep/tools-make.git
               cd tools-make
               ./configure --prefix=/opt/GNUstep --with-layout=gnustep
-              make -j$(nproc)
               make install
               cd ..
 
@@ -46,5 +46,6 @@ jobs:
 
               ./configure
               make -j$(nproc)
+	      make install
               make check
             '

--- a/.github/workflows/gcc-4.9.yml
+++ b/.github/workflows/gcc-4.9.yml
@@ -8,53 +8,32 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    container:
-      image: ghcr.io/gnustep/gcc-4.9-gnustep:latest
-
-    env:
-      PATH: /opt/gcc4.9.4/bin:/usr/local/bin:/usr/bin:/bin
-      LD_LIBRARY_PATH: /opt/gcc4.9.4/lib64:/opt/gcc4.9.4/lib
-      CC: gcc
-      CXX: g++
-      OBJC: gcc
-      GNUSTEP_INSTALLATION_DOMAIN: SYSTEM
-
     steps:
       - uses: actions/checkout@v4
 
-      - name: Verify compiler
-        run: |
-          which gcc
-          gcc --version
-
-      - name: Build gnustep-make
-        run: |
-          git clone https://github.com/gnustep/tools-make.git
-          cd tools-make
-          ./configure --prefix=/opt/GNUstep
-          make -j$(nproc)
-          make install
-
-      - name: Source GNUstep environment
-        run: |
-          . /opt/GNUstep/System/Library/Makefiles/GNUstep.sh
-          env | grep GNUSTEP
-
-      - name: Configure gnustep-base
-        shell: bash
-        run: |
-          . /opt/GNUstep/System/Library/Makefiles/GNUstep.sh
-          ./configure
-
       - name: Build
-        shell: bash
         run: |
-          . /opt/GNUstep/System/Library/Makefiles/GNUstep.sh
-          make -j$(nproc)
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/src" \
+            -w /src \
+            ghcr.io/gnustep/gcc-4.9-gnustep:latest \
+            bash -c '
+              export PATH=/opt/gcc4.9.4/bin:$PATH
+              export LD_LIBRARY_PATH=/opt/gcc4.9.4/lib64:/opt/gcc4.9.4/lib
 
-      - name: Test
-        shell: bash
-        run: |
-          . /opt/GNUstep/System/Library/Makefiles/GNUstep.sh
-          make check
+              which gcc
+              gcc --version
 
+              git clone https://github.com/gnustep/tools-make.git
+              cd tools-make
+              ./configure --prefix=/opt/GNUstep
+              make -j$(nproc)
+              make install
+              cd ..
+
+              . /opt/GNUstep/System/Library/Makefiles/GNUstep.sh
+
+              ./configure
+              make -j$(nproc)
+              make check
+            '

--- a/.github/workflows/gcc-4.9.yml
+++ b/.github/workflows/gcc-4.9.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/gnustep/gcc49-gobjc:latest
+      image: ghcr.io/gnustep/gcc-4.9-gnustep:latest
 
     env:
       PATH: /opt/gcc4.9.4/bin:/usr/local/bin:/usr/bin:/bin

--- a/.github/workflows/gcc-4.9.yml
+++ b/.github/workflows/gcc-4.9.yml
@@ -4,12 +4,23 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            docker login ghcr.io \
+              -u ${{ github.actor }} \
+              --password-stdin
 
       - name: Build
         run: |

--- a/.github/workflows/gcc-4.9.yml
+++ b/.github/workflows/gcc-4.9.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Login to GHCR
         run: |


### PR DESCRIPTION
Reference workflow for testing using the oldest compiler we support (gcc 4.9.4) on Debian Jessie