### PR TITLE
Fix: do not chain -[GSInlineArray initWithObjects:count:] to super

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-08-06 Todd White <todd.white@thalion.global>
+
+	* Source/GSArray.m (-[GSInlineArray initWithObjects:count:]): Do not
+	chain to [super init].  GSArray -init calls -initWithObjects:count:
+	on self, so it re-enters this method and recurses until the stack is
+	exhausted.
+
 2026-08-06 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Headers/GNUstepBase/NSData+GNUstepBase.h:

--- a/Source/GSArray.m
+++ b/Source/GSArray.m
@@ -434,27 +434,28 @@ static int (*lsanCheck)(void) = __lsan_do_recoverable_leak_check;
 }
 - (id) initWithObjects: (const id[])objects count: (NSUInteger)count
 {
-  if (nil != (self = [super init]))
+  /* GSArray -init calls -initWithObjects:count: on self, so this method
+   * must not chain to it.  The inline contents follow the instance and
+   * are not the superclass's to set up.
+   */
+  _contents_array
+    = (id*)(((void*)self) + class_getInstanceSize([self class]));
+
+  if (count > 0)
     {
-      _contents_array
-	= (id*)(((void*)self) + class_getInstanceSize([self class]));
+      NSUInteger	i;
 
-      if (count > 0)
+      for (i = 0; i < count; i++)
 	{
-	  NSUInteger	i;
-
-	  for (i = 0; i < count; i++)
+	  if ((_contents_array[i] = RETAIN(objects[i])) == nil)
 	    {
-	      if ((_contents_array[i] = RETAIN(objects[i])) == nil)
-		{
-		  _count = i;
-		  DESTROY(self);
-		  [NSException raise: NSInvalidArgumentException
-			      format: @"Tried to init array with nil object"];
-		}
+	      _count = i;
+	      DESTROY(self);
+	      [NSException raise: NSInvalidArgumentException
+			  format: @"Tried to init array with nil object"];
 	    }
-	  _count = count;
 	}
+      _count = count;
     }
   return self;
 }


### PR DESCRIPTION
-[GSInlineArray initWithObjects:count:] chains to [super init]. GSArray -init is `return [self initWithObjects: 0 count: 0];`, so on a GSInlineArray that dispatches back into the override, which chains again. Every [[NSArray alloc] initWithObjects:count:] recurses until the stack is exhausted.

This drops the chain from that one method, leaving it as it stood before d84adab6 with a comment recording why it cannot call super. The inline contents live in storage that follows the instance, which GSArray does not set up.

The rest of d84adab6 is untouched. -[GSMutableArray initWithCapacity:], -[GSDictionary initWithObjects:forKeys:count:] and -[GSMutableDictionary initWithCapacity:] were measured either side of that commit and behave the same, so they are not affected; GSMutableArray descends from NSMutableArray and its [super init] does not reach GSArray -init.

Run gnustep-tests base/NSArray from Tests. Against master it aborts. With this it reports 139 passed, 0 failed, and base/NSDictionary 143 passed, 0 failed.

Closes #723
