### PR TITLE
CI: use actions that run on Node 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,7 +128,7 @@ jobs:
         working-directory: ${{ env.SRC_PATH }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           path: ${{ env.SRC_PATH }}
 
@@ -171,7 +171,7 @@ jobs:
           make check
 
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: Logs - ${{ matrix.name }}
@@ -257,7 +257,7 @@ jobs:
         working-directory: ${{ env.SRC_PATH }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           path: ${{ env.SRC_PATH }}
 
@@ -382,7 +382,7 @@ jobs:
           make check
 
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: Logs - ${{ matrix.name }}


### PR DESCRIPTION
main.yml pins actions/checkout@v3 and actions/upload-artifact@v4, so every job in it ends with a warning that the action targets Node.js 20 and is being forced onto Node.js 24. netbsd.yml already pins v7 of both and gcc-4.9.yml pins checkout v6, so main.yml now matches netbsd.yml.

v7 needs runner 2.327.1 or newer, and the runners here are 2.336.0. It also blocks checking out a fork under pull_request_target and workflow_run; main.yml runs on push, pull_request and workflow_dispatch, so that does not apply.

msys2/setup-msys2 already runs on node24. ilammy/msvc-dev-cmd is unchanged and will keep warning: its latest release, v1.13.0, is still node20 and the project has had no commit since March 2024.

Verified on the fork: 6 of the 8 jobs are green and no job logs the deprecation warning. The two GCC jobs fail to build Tests/base/NSUUID/extra.m at line 94, a C99 for loop declaration, and fail the same way on master.
