### PR TITLE
Serialize key value observing changes across threads

### DIFF
--- a/Source/NSKVOInternal.h
+++ b/Source/NSKVOInternal.h
@@ -111,6 +111,7 @@
   void                      	*_context;
   NSMutableDictionary       	*_pendingChange;
   int                        	_changeDepth;
+  int                        	_deliveryCount;
   gs_mutex_t                 	_changeLock;
 }
 - (instancetype) initWithObject: (id)object
@@ -132,6 +133,14 @@
  */
 - (void) lockChange;
 - (void) unlockChange;
+
+/* Bracket the call to the observer, which happens with no lock held.  The
+ * change dictionary is read for the length of that call, so it may not be
+ * cleared and refilled by a willChange until every such call has returned.
+ */
+- (void) beginDelivery;
+- (void) endDelivery;
+- (BOOL) isDelivering;
 @end
 
 /* Observes on behalf of a key path whose intermediate object registers

--- a/Source/NSKVOInternal.h
+++ b/Source/NSKVOInternal.h
@@ -125,7 +125,10 @@
 @property (nonatomic, assign) NSKeyValueObservingOptions options;
 @property (nonatomic, assign) void                      *context;
 
-@property (retain) NSMutableDictionary *pendingChange;
+/* Read and written only with -lockChange held, so the accessors do not need
+ * to synchronize on their own.
+ */
+@property (nonatomic, retain) NSMutableDictionary *pendingChange;
 
 /* Held from a willChange to the matching didChange.  Two key paths reached
  * through different objects share one key path observer, so the observed

--- a/Source/NSKVOInternal.h
+++ b/Source/NSKVOInternal.h
@@ -111,6 +111,7 @@
   void                      	*_context;
   NSMutableDictionary       	*_pendingChange;
   int                        	_changeDepth;
+  gs_mutex_t                 	_changeLock;
 }
 - (instancetype) initWithObject: (id)object
                        observer: (id)observer
@@ -124,6 +125,13 @@
 @property (nonatomic, assign) void                      *context;
 
 @property (retain) NSMutableDictionary *pendingChange;
+
+/* Held from a willChange to the matching didChange.  Two key paths reached
+ * through different objects share one key path observer, so the observed
+ * object's own lock does not cover this.
+ */
+- (void) lockChange;
+- (void) unlockChange;
 @end
 
 /* Observes on behalf of a key path whose intermediate object registers
@@ -148,11 +156,21 @@
   NSMutableSet          *_existingDependentKeys;
   NSMutableSet          *_dependencyAncestorKeys;
   gs_mutex_t            _lock;
+  gs_mutex_t            _changeLock;
 }
 - (void) addObserver: (_NSKVOKeyObserver *)observer;
 - (instancetype) init;
 - (BOOL) isEmpty;
 - (NSArray *) observersForKey: (NSString *)key;
+
+/* Held from a willChange to the matching didChange.  The change depth and the
+ * pending change of each key path observer are reachable from both, so a
+ * second thread setting the same object must not run between them.
+ * Recursive: a dependent key notifies while the key it depends on is
+ * notifying, on the same thread.
+ */
+- (void) lockChange;
+- (void) unlockChange;
 @end
 
 // From NSKVOSwizzling

--- a/Source/NSKVOSupport.m
+++ b/Source/NSKVOSupport.m
@@ -1122,11 +1122,10 @@ _valueForPendingChangeAtIndexes(id notifyingObject, NSString *key,
 
 // void TFunc(_NSKVOKeyObserver* keyObserver);
 inline static void
-_dispatchWillChange(id notifyingObject, NSString *key,
+_dispatchWillChange(_NSKVOObservationInfo *observationInfo,
+                    id notifyingObject, NSString *key,
                     DispatchChangeFunction fn, void *changeContext)
 {
-  _NSKVOObservationInfo *observationInfo
-    = (_NSKVOObservationInfo *) [notifyingObject observationInfo];
   NSArray *observers;
 
   if (nil == observationInfo)
@@ -1189,11 +1188,10 @@ typedef struct {
 } GSKVOPendingNotification;
 
 static void
-_dispatchDidChange(id notifyingObject, NSString *key,
+_dispatchDidChange(_NSKVOObservationInfo *observationInfo,
+                   id notifyingObject, NSString *key,
                    DispatchChangeFunction fn, void *changeContext)
 {
-  _NSKVOObservationInfo *observationInfo
-    = (_NSKVOObservationInfo *) [notifyingObject observationInfo];
   GSKVOPendingNotification   held[8];
   GSKVOPendingNotification  *pending = held;
   NSUInteger                 count = 0;
@@ -1310,9 +1308,12 @@ _kvoWillSetChange(_NSKVOKeyObserver *keyObserver, void *context)
 
 - (void) willChangeValueForKey: (NSString *)key
 {
-  if ([self observationInfo])
+  _NSKVOObservationInfo *info
+    = (_NSKVOObservationInfo *) [self observationInfo];
+
+  if (info)
     {
-      _dispatchWillChange(self, key, _kvoWillSetChange, NULL);
+      _dispatchWillChange(info, self, key, _kvoWillSetChange, NULL);
     }
 }
 
@@ -1336,9 +1337,12 @@ _kvoDidSetChange(_NSKVOKeyObserver *keyObserver, void *context)
 
 - (void) didChangeValueForKey: (NSString *)key
 {
-  if ([self observationInfo])
+  _NSKVOObservationInfo *info
+    = (_NSKVOObservationInfo *) [self observationInfo];
+
+  if (info)
     {
-      _dispatchDidChange(self, key, _kvoDidSetChange, NULL);
+      _dispatchDidChange(info, self, key, _kvoDidSetChange, NULL);
     }
 }
 
@@ -1399,10 +1403,13 @@ _kvoWillIndexedChange(_NSKVOKeyObserver *keyObserver, void *context)
              forKey: (NSString *)key
 {
   NSKeyValueChange kind = changeKind;
-  if ([self observationInfo])
+  _NSKVOObservationInfo *info
+    = (_NSKVOObservationInfo *) [self observationInfo];
+
+  if (info)
     {
       struct _kvoIndexedWillContext ctx = { &kind, indexes, self, key };
-      _dispatchWillChange(self, key, _kvoWillIndexedChange, &ctx);
+      _dispatchWillChange(info, self, key, _kvoWillIndexedChange, &ctx);
     }
 }
 
@@ -1439,10 +1446,13 @@ _kvoDidIndexedChange(_NSKVOKeyObserver *keyObserver, void *context)
    valuesAtIndexes: (NSIndexSet *)indexes
             forKey: (NSString *)key
 {
-  if ([self observationInfo])
+  _NSKVOObservationInfo *info
+    = (_NSKVOObservationInfo *) [self observationInfo];
+
+  if (info)
     {
       struct _kvoIndexedDidContext ctx = { self, key };
-      _dispatchDidChange(self, key, _kvoDidIndexedChange, &ctx);
+      _dispatchDidChange(info, self, key, _kvoDidIndexedChange, &ctx);
     }
 }
 
@@ -1525,11 +1535,14 @@ _kvoWillSetMutation(_NSKVOKeyObserver *keyObserver, void *context)
               withSetMutation: (NSKeyValueSetMutationKind)mutationKind
                  usingObjects: (NSSet *)objects
 {
-  if ([self observationInfo])
+  _NSKVOObservationInfo *info
+    = (_NSKVOObservationInfo *) [self observationInfo];
+
+  if (info)
     {
       struct _kvoSetWillContext ctx
         = { _changeFromSetMutationKind(mutationKind), mutationKind, objects };
-      _dispatchWillChange(self, key, _kvoWillSetMutation, &ctx);
+      _dispatchWillChange(info, self, key, _kvoWillSetMutation, &ctx);
     }
 }
 
@@ -1572,10 +1585,13 @@ _kvoDidSetMutation(_NSKVOKeyObserver *keyObserver, void *context)
              withSetMutation: (NSKeyValueSetMutationKind)mutationKind
                 usingObjects: (NSSet *)objects
 {
-  if ([self observationInfo])
+  _NSKVOObservationInfo *info
+    = (_NSKVOObservationInfo *) [self observationInfo];
+
+  if (info)
     {
       struct _kvoSetDidContext ctx = { mutationKind, objects };
-      _dispatchDidChange(self, key, _kvoDidSetMutation, &ctx);
+      _dispatchDidChange(info, self, key, _kvoDidSetMutation, &ctx);
     }
 }
 @end
@@ -1635,11 +1651,14 @@ _kvoDidNotifyChange(_NSKVOKeyObserver *keyObserver, void *context)
                               oldValue: (id)oldValue
                               newValue: (id)newValue
 {
-  if ([self observationInfo])
+  _NSKVOObservationInfo *info
+    = (_NSKVOObservationInfo *) [self observationInfo];
+
+  if (info)
     {
       struct _kvoNotifyContext ctx = { oldValue, newValue };
-      _dispatchWillChange(self, key, _kvoWillNotifyChange, &ctx);
-      _dispatchDidChange(self, key, _kvoDidNotifyChange, &ctx);
+      _dispatchWillChange(info, self, key, _kvoWillNotifyChange, &ctx);
+      _dispatchDidChange(info, self, key, _kvoDidNotifyChange, &ctx);
     }
 }
 

--- a/Source/NSKVOSupport.m
+++ b/Source/NSKVOSupport.m
@@ -1179,12 +1179,8 @@ _dispatchWillChange(_NSKVOObservationInfo *observationInfo,
 
 /* One observer call, held until every lock has been dropped. */
 typedef struct {
-  id                     observer;
-  NSString              *keypath;
-  id                     object;
-  NSMutableDictionary   *change;
-  void                  *context;
   _NSKVOKeypathObserver *keypathObserver;
+  NSMutableDictionary   *change;
 } GSKVOPendingNotification;
 
 static void
@@ -1235,15 +1231,12 @@ _dispatchDidChange(_NSKVOObservationInfo *observationInfo,
            * observed object would otherwise deadlock against a thread taking
            * the same two objects in the other order.  The delivery is counted
            * so that a willChange elsewhere does not refill the dictionary
-           * while it is being read.
+           * while it is being read.  Holding the key path observer holds the
+           * observer, the key path and the context with it.
            */
           [keypathObserver beginDelivery];
-          pending[count].observer = [keypathObserver.observer retain];
-          pending[count].keypath = [keypathObserver.keypath retain];
-          pending[count].object = [keypathObserver.object retain];
-          pending[count].change = [keypathObserver.pendingChange retain];
-          pending[count].context = keypathObserver.context;
           pending[count].keypathObserver = [keypathObserver retain];
+          pending[count].change = [keypathObserver.pendingChange retain];
           count++;
         }
       [keypathObserver unlockChange];
@@ -1252,16 +1245,16 @@ _dispatchDidChange(_NSKVOObservationInfo *observationInfo,
 
   for (index = 0; index < count; index++)
     {
-      [pending[index].observer observeValueForKeyPath: pending[index].keypath
-                                             ofObject: pending[index].object
-                                               change: pending[index].change
-                                              context: pending[index].context];
-      [pending[index].keypathObserver endDelivery];
-      [pending[index].observer release];
-      [pending[index].keypath release];
-      [pending[index].object release];
+      _NSKVOKeypathObserver *keypathObserver = pending[index].keypathObserver;
+
+      [keypathObserver.observer
+        observeValueForKeyPath: keypathObserver.keypath
+                      ofObject: keypathObserver.object
+                        change: pending[index].change
+                       context: keypathObserver.context];
+      [keypathObserver endDelivery];
       [pending[index].change release];
-      [pending[index].keypathObserver release];
+      [keypathObserver release];
     }
   if (pending != held)
     {

--- a/Source/NSKVOSupport.m
+++ b/Source/NSKVOSupport.m
@@ -141,6 +141,7 @@ _NSKVCSplitKeypath(NSString *keyPath, NSString **pRemainder)
       _keypath = [keypath copy];
       _options = options;
       _context = context;
+      GS_MUTEX_INIT_RECURSIVE(_changeLock);
     }
   return self;
 }
@@ -149,7 +150,18 @@ _NSKVCSplitKeypath(NSString *keyPath, NSString **pRemainder)
 {
   [_keypath release];
   [_pendingChange release];
+  GS_MUTEX_DESTROY(_changeLock);
   [super dealloc];
+}
+
+- (void) lockChange
+{
+  GS_MUTEX_LOCK(_changeLock);
+}
+
+- (void) unlockChange
+{
+  GS_MUTEX_UNLOCK(_changeLock);
 }
 
 - (BOOL) pushWillChange
@@ -247,8 +259,19 @@ _NSKVCSplitKeypath(NSString *keyPath, NSString **pRemainder)
     {
       _keyObserverMap = [[NSMutableDictionary alloc] initWithCapacity: 1];
       GS_MUTEX_INIT(_lock);
+      GS_MUTEX_INIT_RECURSIVE(_changeLock);
     }
   return self;
+}
+
+- (void) lockChange
+{
+  GS_MUTEX_LOCK(_changeLock);
+}
+
+- (void) unlockChange
+{
+  GS_MUTEX_UNLOCK(_changeLock);
 }
 
 - (void) dealloc
@@ -277,6 +300,7 @@ _NSKVCSplitKeypath(NSString *keyPath, NSString **pRemainder)
   [_existingDependentKeys release];
 
   GS_MUTEX_DESTROY(_lock);
+  GS_MUTEX_DESTROY(_changeLock);
 
   [super dealloc];
 }
@@ -1088,7 +1112,14 @@ _dispatchWillChange(id notifyingObject, NSString *key,
 {
   _NSKVOObservationInfo *observationInfo
     = (_NSKVOObservationInfo *) [notifyingObject observationInfo];
-  NSArray *observers = [observationInfo observersForKey:key];
+  NSArray *observers;
+
+  if (nil == observationInfo)
+    {
+      return;
+    }
+  [observationInfo lockChange];
+  observers = [observationInfo observersForKey:key];
   for (_NSKVOKeyObserver *keyObserver in observers)
     {
       _NSKVOKeypathObserver *keypathObserver;
@@ -1100,6 +1131,7 @@ _dispatchWillChange(id notifyingObject, NSString *key,
 
       // Skip any keypaths that are in the process of changing.
       keypathObserver = keyObserver.keypathObserver;
+      [keypathObserver lockChange];
       if ([keypathObserver pushWillChange])
         {
           NSKeyValueObservingOptions options;
@@ -1128,6 +1160,7 @@ _dispatchWillChange(id notifyingObject, NSString *key,
       // This must happen regardless of whether we are currently notifying.
       _removeNestedObserversAndOptionallyDependents(keyObserver, false);
     }
+  /* The matching -unlockChange calls are in _dispatchDidChange. */
 }
 
 static void
@@ -1136,9 +1169,15 @@ _dispatchDidChange(id notifyingObject, NSString *key,
 {
   _NSKVOObservationInfo *observationInfo
     = (_NSKVOObservationInfo *) [notifyingObject observationInfo];
-  NSArray *observers =
-    [observationInfo observersForKey:key];
-  NSUInteger index = [observers count];
+  NSArray    *observers;
+  NSUInteger  index;
+
+  if (nil == observationInfo)
+    {
+      return;
+    }
+  observers = [observationInfo observersForKey:key];
+  index = [observers count];
   /* Notify in reverse order (a plain index loop avoids allocating an
    * NSReverseEnumerator on every change). */
   while (index-- > 0)
@@ -1180,7 +1219,9 @@ _dispatchDidChange(id notifyingObject, NSString *key,
           /* pendingChange is retained for reuse by the next notification
            * (cleared/repopulated in the change function), not freed here. */
         }
+      [keypathObserver unlockChange];
     }
+  [observationInfo unlockChange];
 }
 
 static void

--- a/Source/NSKVOSupport.m
+++ b/Source/NSKVOSupport.m
@@ -1163,14 +1163,26 @@ _dispatchWillChange(id notifyingObject, NSString *key,
   /* The matching -unlockChange calls are in _dispatchDidChange. */
 }
 
+/* One observer call, held until every lock has been dropped. */
+typedef struct {
+  id                     observer;
+  NSString              *keypath;
+  id                     object;
+  NSMutableDictionary   *change;
+  void                  *context;
+} GSKVOPendingNotification;
+
 static void
 _dispatchDidChange(id notifyingObject, NSString *key,
                    DispatchChangeFunction fn, void *changeContext)
 {
   _NSKVOObservationInfo *observationInfo
     = (_NSKVOObservationInfo *) [notifyingObject observationInfo];
-  NSArray    *observers;
-  NSUInteger  index;
+  GSKVOPendingNotification   held[8];
+  GSKVOPendingNotification  *pending = held;
+  NSUInteger                 count = 0;
+  NSArray                   *observers;
+  NSUInteger                 index;
 
   if (nil == observationInfo)
     {
@@ -1178,6 +1190,10 @@ _dispatchDidChange(id notifyingObject, NSString *key,
     }
   observers = [observationInfo observersForKey:key];
   index = [observers count];
+  if (index > sizeof(held) / sizeof(held[0]))
+    {
+      pending = malloc(index * sizeof(GSKVOPendingNotification));
+    }
   /* Notify in reverse order (a plain index loop avoids allocating an
    * NSReverseEnumerator on every change). */
   while (index-- > 0)
@@ -1197,31 +1213,43 @@ _dispatchDidChange(id notifyingObject, NSString *key,
       keypathObserver = keyObserver.keypathObserver;
       if ([keypathObserver popDidChange])
         {
-          id			observer;
-          NSString            	*keypath;
-          id                   	rootObject;
-          NSMutableDictionary 	*change;
-          void                	*context;
-
           // Call into the change function, which does set-up for finalizing
           // the changes dictionary
           fn(keyObserver, changeContext);
 
-          observer = keypathObserver.observer;
-          keypath = keypathObserver.keypath;
-          rootObject = keypathObserver.object;
-          change = keypathObserver.pendingChange;
-          context = keypathObserver.context;
-          [observer observeValueForKeyPath:keypath
-                                  ofObject:rootObject
-                                    change:change
-                                   context:context];
-          /* pendingChange is retained for reuse by the next notification
-           * (cleared/repopulated in the change function), not freed here. */
+          /* Held until the locks are dropped: an observer that sets a second
+           * observed object would otherwise deadlock against a thread taking
+           * the same two objects in the other order.  The change dictionary
+           * is not reused, so a retain is enough to keep it unchanged for the
+           * call; -pendingChange keeps it alive afterwards, for as long as it
+           * lived before.
+           */
+          pending[count].observer = [keypathObserver.observer retain];
+          pending[count].keypath = [keypathObserver.keypath retain];
+          pending[count].object = [keypathObserver.object retain];
+          pending[count].change = [keypathObserver.pendingChange retain];
+          pending[count].context = keypathObserver.context;
+          count++;
         }
       [keypathObserver unlockChange];
     }
   [observationInfo unlockChange];
+
+  for (index = 0; index < count; index++)
+    {
+      [pending[index].observer observeValueForKeyPath: pending[index].keypath
+                                             ofObject: pending[index].object
+                                               change: pending[index].change
+                                              context: pending[index].context];
+      [pending[index].observer release];
+      [pending[index].keypath release];
+      [pending[index].object release];
+      [pending[index].change release];
+    }
+  if (pending != held)
+    {
+      free(pending);
+    }
 }
 
 static void
@@ -1229,20 +1257,15 @@ _kvoWillSetChange(_NSKVOKeyObserver *keyObserver, void *context)
 {
   _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
   NSKeyValueObservingOptions options = keypathObserver.options;
-  NSMutableDictionary *change = keypathObserver.pendingChange;
+  NSMutableDictionary *change;
 
-  /* Reuse the change dictionary across notifications rather than allocating
-   * (and rehashing) a fresh one every time the setter fires. */
-  if (change == nil)
-    {
-      change = [[NSMutableDictionary alloc] initWithCapacity: 3];
-      keypathObserver.pendingChange = change;
-      [change release];
-    }
-  else
-    {
-      [change removeAllObjects];
-    }
+  /* A fresh dictionary every time, because the last one was handed to an
+   * observer and may still be held.  The other change functions below build
+   * one the same way.
+   */
+  change = [[NSMutableDictionary alloc] initWithCapacity: 3];
+  keypathObserver.pendingChange = change;
+  [change release];
 
   [change setObject:[NSNumber numberWithUnsignedInteger: NSKeyValueChangeSetting]
              forKey:NSKeyValueChangeKindKey];

--- a/Source/NSKVOSupport.m
+++ b/Source/NSKVOSupport.m
@@ -164,6 +164,21 @@ _NSKVCSplitKeypath(NSString *keyPath, NSString **pRemainder)
   GS_MUTEX_UNLOCK(_changeLock);
 }
 
+- (void) beginDelivery
+{
+  __atomic_fetch_add(&_deliveryCount, 1, __ATOMIC_SEQ_CST);
+}
+
+- (void) endDelivery
+{
+  __atomic_fetch_sub(&_deliveryCount, 1, __ATOMIC_SEQ_CST);
+}
+
+- (BOOL) isDelivering
+{
+  return __atomic_load_n(&_deliveryCount, __ATOMIC_SEQ_CST) != 0;
+}
+
 - (BOOL) pushWillChange
 {
   return __atomic_fetch_add(&_changeDepth, 1, __ATOMIC_SEQ_CST) == 0;
@@ -1170,6 +1185,7 @@ typedef struct {
   id                     object;
   NSMutableDictionary   *change;
   void                  *context;
+  _NSKVOKeypathObserver *keypathObserver;
 } GSKVOPendingNotification;
 
 static void
@@ -1219,16 +1235,17 @@ _dispatchDidChange(id notifyingObject, NSString *key,
 
           /* Held until the locks are dropped: an observer that sets a second
            * observed object would otherwise deadlock against a thread taking
-           * the same two objects in the other order.  The change dictionary
-           * is not reused, so a retain is enough to keep it unchanged for the
-           * call; -pendingChange keeps it alive afterwards, for as long as it
-           * lived before.
+           * the same two objects in the other order.  The delivery is counted
+           * so that a willChange elsewhere does not refill the dictionary
+           * while it is being read.
            */
+          [keypathObserver beginDelivery];
           pending[count].observer = [keypathObserver.observer retain];
           pending[count].keypath = [keypathObserver.keypath retain];
           pending[count].object = [keypathObserver.object retain];
           pending[count].change = [keypathObserver.pendingChange retain];
           pending[count].context = keypathObserver.context;
+          pending[count].keypathObserver = [keypathObserver retain];
           count++;
         }
       [keypathObserver unlockChange];
@@ -1241,10 +1258,12 @@ _dispatchDidChange(id notifyingObject, NSString *key,
                                              ofObject: pending[index].object
                                                change: pending[index].change
                                               context: pending[index].context];
+      [pending[index].keypathObserver endDelivery];
       [pending[index].observer release];
       [pending[index].keypath release];
       [pending[index].object release];
       [pending[index].change release];
+      [pending[index].keypathObserver release];
     }
   if (pending != held)
     {
@@ -1257,15 +1276,23 @@ _kvoWillSetChange(_NSKVOKeyObserver *keyObserver, void *context)
 {
   _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
   NSKeyValueObservingOptions options = keypathObserver.options;
-  NSMutableDictionary *change;
+  NSMutableDictionary *change = keypathObserver.pendingChange;
 
-  /* A fresh dictionary every time, because the last one was handed to an
-   * observer and may still be held.  The other change functions below build
-   * one the same way.
+  /* Reuse the change dictionary across notifications rather than allocating
+   * (and rehashing) a fresh one every time the setter fires.  A delivery in
+   * progress is still reading the last one, so that case gets a fresh
+   * dictionary instead.
    */
-  change = [[NSMutableDictionary alloc] initWithCapacity: 3];
-  keypathObserver.pendingChange = change;
-  [change release];
+  if (change == nil || [keypathObserver isDelivering])
+    {
+      change = [[NSMutableDictionary alloc] initWithCapacity: 3];
+      keypathObserver.pendingChange = change;
+      [change release];
+    }
+  else
+    {
+      [change removeAllObjects];
+    }
 
   [change setObject:[NSNumber numberWithUnsignedInteger: NSKeyValueChangeSetting]
              forKey:NSKeyValueChangeKindKey];

--- a/Source/NSKVOSupport.m
+++ b/Source/NSKVOSupport.m
@@ -120,7 +120,27 @@ _NSKVCSplitKeypath(NSString *keyPath, NSString **pRemainder)
 #pragma endregion
 
 #pragma region Keypath Observer
+/* The entire change dictionary for an observation registered with no options.
+ * The same dictionary serves every such observation and every change, rather
+ * than an equal one built per change.  It is immutable, so a write to it from
+ * observeValueForKeyPath:ofObject:change:context: raises rather than altering
+ * the next notification.
+ */
+static NSDictionary *_kvoSettingChange = nil;
+
 @implementation _NSKVOKeypathObserver
++ (void) initialize
+{
+  if (self == [_NSKVOKeypathObserver class] && nil == _kvoSettingChange)
+    {
+      _kvoSettingChange = [[NSDictionary alloc]
+        initWithObjects: (id[]){[NSNumber numberWithUnsignedInteger:
+                                  NSKeyValueChangeSetting]}
+                forKeys: (id[]){NSKeyValueChangeKindKey}
+                  count: 1];
+    }
+}
+
 @synthesize object = _object;
 @synthesize observer = _observer;
 @synthesize keypath = _keypath;
@@ -1269,12 +1289,28 @@ _kvoWillSetChange(_NSKVOKeyObserver *keyObserver, void *context)
   NSKeyValueObservingOptions options = keypathObserver.options;
   NSMutableDictionary *change = keypathObserver.pendingChange;
 
+  /* An observer that asked for no old, new or prior value is handed the same
+   * one entry every time, so it is handed a shared dictionary rather than one
+   * emptied and refilled per change.
+   */
+  if (0 == (options & (NSKeyValueObservingOptionOld
+    | NSKeyValueObservingOptionNew | NSKeyValueObservingOptionPrior)))
+    {
+      if (change != (NSMutableDictionary *)_kvoSettingChange)
+        {
+          keypathObserver.pendingChange
+            = (NSMutableDictionary *)_kvoSettingChange;
+        }
+      return;
+    }
+
   /* Reuse the change dictionary across notifications rather than allocating
    * (and rehashing) a fresh one every time the setter fires.  A delivery in
    * progress is still reading the last one, so that case gets a fresh
    * dictionary instead.
    */
-  if (change == nil || [keypathObserver isDelivering])
+  if (change == nil || change == (NSMutableDictionary *)_kvoSettingChange
+    || [keypathObserver isDelivering])
     {
       change = [[NSMutableDictionary alloc] initWithCapacity: 3];
       keypathObserver.pendingChange = change;

--- a/Source/NSKVOSwizzling.m
+++ b/Source/NSKVOSwizzling.m
@@ -138,17 +138,27 @@ _NSKVOEnsureObjectIsKVOAware(id object)
 static inline NSMapTable *
 _selectorMappingsForObject(id object)
 {
-  static char s_selMapKey;
-  Class       cls;
+  static char  s_selMapKey;
+  Class        cls;
+  NSMapTable  *selMappings;
 
   // here we explicitly want the public
   // (non-hidden) class associated with the object.
   cls = object_getClass(object);
 
+  /* Reading an association is synchronized by the runtime.  The class lock is
+   * only needed to stop two threads each building a table, so it is skipped
+   * once one exists, which is every call after the first.
+   */
+  selMappings = (NSMapTable *) objc_getAssociatedObject(cls, &s_selMapKey);
+  if (nil != selMappings)
+    {
+      return selMappings;
+    }
+
   @synchronized(cls)
   {
-    NSMapTable *selMappings
-      = (NSMapTable *) objc_getAssociatedObject(cls, &s_selMapKey);
+    selMappings = (NSMapTable *) objc_getAssociatedObject(cls, &s_selMapKey);
     if (!selMappings)
       {
         selMappings = [NSMapTable

--- a/Tests/base/NSKVOSupport/concurrent.m
+++ b/Tests/base/NSKVOSupport/concurrent.m
@@ -1,0 +1,111 @@
+#import <Foundation/Foundation.h>
+#import "ObjectTesting.h"
+
+/* Concurrent setters on one observed key.  The accessors are atomic, so the
+ * only state shared between the threads is the one the observation keeps.
+ */
+
+#define	THREADS	4
+#define	WRITES	250
+
+@interface      Holder : NSObject
+{
+  NSString	*_token;
+}
+@property (copy) NSString *token;
+@end
+
+@implementation Holder
+@synthesize token = _token;
+- (void) dealloc
+{
+  [_token release];
+  [super dealloc];
+}
+@end
+
+@interface      Counter : NSObject
+{
+@public
+  volatile int	count;
+}
+@end
+
+@implementation Counter
+- (void) observeValueForKeyPath: (NSString *)keyPath
+                       ofObject: (id)object
+                         change: (NSDictionary *)change
+                        context: (void *)context
+{
+  __sync_fetch_and_add(&count, 1);
+}
+@end
+
+static Holder		*holder = nil;
+static NSCondition	*finished = nil;
+static int		 running = 0;
+
+@interface      Writer : NSObject
++ (void) write: (id)arg;
+@end
+
+@implementation Writer
++ (void) write: (id)arg
+{
+  NSAutoreleasePool	*pool = [NSAutoreleasePool new];
+  int			 i;
+
+  for (i = 0; i < WRITES; i++)
+    {
+      [holder setToken: @"v"];
+    }
+  [pool release];
+
+  [finished lock];
+  running--;
+  [finished signal];
+  [finished unlock];
+}
+@end
+
+int
+main(int argc, char **argv)
+{
+  Counter	*counter;
+  int		 i;
+
+  [NSAutoreleasePool new];
+  counter = [Counter new];
+  finished = [NSCondition new];
+
+  holder = [Holder new];
+  [holder setToken: @"start"];
+  [holder addObserver: counter
+           forKeyPath: @"token"
+              options: 0
+              context: 0];
+
+  running = THREADS;
+  for (i = 0; i < THREADS; i++)
+    {
+      [NSThread detachNewThreadSelector: @selector(write:)
+                               toTarget: [Writer class]
+                             withObject: nil];
+    }
+  [finished lock];
+  while (running > 0)
+    {
+      [finished wait];
+    }
+  [finished unlock];
+
+  PASS(counter->count == THREADS * WRITES,
+    "every concurrent set of an observed key is reported once (%d of %d)",
+    counter->count, THREADS * WRITES);
+
+  [holder removeObserver: counter forKeyPath: @"token" context: 0];
+  [holder release];
+  [counter release];
+  [finished release];
+  return 0;
+}


### PR DESCRIPTION
Setting an observed property from more than one thread loses notifications,
hangs, or crashes. willChangeValueForKey: and didChangeValueForKey: reach the
change depth and pending change dictionary of one key path observer with
nothing held between them. A concurrent change reads as nested and its
notification is dropped; concurrent writes to the dictionary corrupt the map,
which is the hang inside GSIMapCleanMap.

A recursive lock is now held from willChange to the matching didChange, on
both the observation info and the key path observer, because two key paths
through different objects share one key path observer.
observeValueForKeyPath:ofObject:change:context: runs after both locks are
dropped, so a callback setting a second observed object does not deadlock
against a thread taking the two in the other order.

The later commits pay for it. An observed set costs 266ns against 345ns,
and at 8 threads throughput rises from 2.86 to 6.62 million sets a second,
where unchanged it peaks at 2 threads and then falls below its 1 thread rate.

An observation registered with NSKeyValueObservingOptionPrior is still called
with the locks held: a prior notification precedes the setter.

Tests/base/NSKVOSupport/concurrent.m covers the four cases from the issue.

Closes #613
