### PR TITLE
Raise for a key path that continues through a collection

### DIFF
--- a/Source/NSKVOSupport.m
+++ b/Source/NSKVOSupport.m
@@ -489,11 +489,52 @@ _registersObservationsItself(id object)
       != class_getMethodImplementation([NSSet class], selector);
 }
 
+/* Whether the value refuses observer registration, which is what a plain
+ * collection does.  A key path cannot continue through one: the collection
+ * reports no change for a property of the objects it holds.
+ */
+static BOOL
+_refusesObservation(id object)
+{
+  SEL   selector = @selector(addObserver:forKeyPath:options:context:);
+  IMP   implementation;
+
+  if (nil == object)
+    {
+      return NO;
+    }
+  implementation
+    = class_getMethodImplementation(object_getClass(object), selector);
+
+  return implementation
+      == class_getMethodImplementation([NSArray class], selector)
+    || implementation
+      == class_getMethodImplementation([NSSet class], selector);
+}
+
 /* Observe the rest of a key path on the value of its first key. */
 static void
 _attachRestOfKeypath(_NSKVOKeyObserver *keyObserver)
 {
   id value = [keyObserver.object valueForKey: keyObserver.key];
+
+  /* An operator reads through the collection and reports the result for the
+   * whole key path, so it is registered as any other key is.  Any other key
+   * names a property of the objects the collection holds, and the collection
+   * raises for it, as it does when the same key path is registered on it
+   * directly.
+   */
+  if (_refusesObservation(value)
+    && NO == [keyObserver.restOfKeypath hasPrefix: @"@"])
+    {
+      _NSKVOKeypathObserver *keypathObserver = keyObserver.keypathObserver;
+
+      [value addObserver: keypathObserver.observer
+              forKeyPath: keyObserver.restOfKeypath
+                 options: keypathObserver.options
+                 context: keypathObserver.context];
+      return;
+    }
 
   if (_registersObservationsItself(value))
     {

--- a/Tests/base/NSKVOSupport/keypathRegistration.m
+++ b/Tests/base/NSKVOSupport/keypathRegistration.m
@@ -166,8 +166,23 @@ main(int argc, char **argv)
   PASS(watcher->count == 1,
        "no notification arrives once the observer is removed");
 
-  /* A plain array refuses an observer, so a key path through one is left as
-     it was: the observation is registered, and no change is reported. */
+  /* A plain array refuses an observer, and a key path through one reaches the
+     array with the rest of the key path, so that registration raises too. */
+  {
+    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+
+    [dict setObject: [NSArray arrayWithObject: element] forKey: @"list"];
+
+    PASS_EXCEPTION([dict addObserver: watcher
+                          forKeyPath: @"list.name"
+                             options: NSKeyValueObservingOptionNew
+                             context: NULL];,
+      NSInvalidArgumentException,
+      "a key path through a plain array raises");
+  }
+
+  /* An operator reads through the array rather than naming a property of the
+     objects it holds, so it is accepted. */
   {
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
     BOOL raised = NO;
@@ -177,10 +192,10 @@ main(int argc, char **argv)
     NS_DURING
       {
         [dict addObserver: watcher
-               forKeyPath: @"list.name"
+               forKeyPath: @"list.@count"
                   options: NSKeyValueObservingOptionNew
                   context: NULL];
-        [dict removeObserver: watcher forKeyPath: @"list.name"];
+        [dict removeObserver: watcher forKeyPath: @"list.@count"];
       }
     NS_HANDLER
       {
@@ -189,7 +204,7 @@ main(int argc, char **argv)
     NS_ENDHANDLER
 
     PASS(raised == NO,
-         "a key path through a plain array is still accepted");
+      "a key path through an array to an operator is accepted");
   }
 
   DESTROY(arp);

--- a/Tests/base/NSKVOSupport/kvoToMany.m
+++ b/Tests/base/NSKVOSupport/kvoToMany.m
@@ -831,68 +831,30 @@ ToMany_KVCMediatedArrayWithHelpers_AggregateFunction()
 }
 
 static void
-toOne_insertCallbackPost(NSString *keyPath, id object, NSDictionary *change,
-                         void *context)
+ToMany_ToOne_KeyPathThroughACollectionRaises()
 {
-  (void)keyPath;
-  (void)object;
-  (void)context;
+  START_SET("ToMany_ToOne_KeyPathThroughACollectionRaises");
 
-  PASS([change objectForKey: NSKeyValueChangeNotificationIsPriorKey] == nil, "Post change");
-  PASS_EQUAL(BOXI(NSKeyValueChangeSetting), [change objectForKey: NSKeyValueChangeKindKey],
-             "Change is a setting");
-  NSArray *expectedOld = [NSArray arrayWithObjects: @"Value", nil];
-  PASS_EQUAL(expectedOld, [change objectForKey: NSKeyValueChangeOldKey],
-             "Old value is correct");
-  NSArray *expectedNew = [NSArray arrayWithObjects: @"Value", @"Value", nil];
-  PASS_EQUAL(expectedNew, [change objectForKey: NSKeyValueChangeNewKey],
-             "New value is correct");
-  NSIndexSet *indexes = [change objectForKey: NSKeyValueChangeIndexesKey];
-  PASS(indexes == nil, "Indexes are nil");
-}
+  Observee     *observee = [Observee new];
+  TestObserver *observer = [TestObserver new];
 
-static void
-toOne_illegalChangeNotification(NSString *keyPath, id object,
-                                NSDictionary *change, void *context)
-{
-  (void)keyPath;
-  (void)object;
-  (void)change;
-  (void)context;
-  PASS(NO, "illegalChangeNotification");
-}
-
-static void
-toOne_insertMutation(Observee *observee)
-{
-  // This array is assisted by setter functions, and should also
-  // dispatch one notification per change.
-  [observee insertObject:[DummyObject makeDummy]
-    inArrayWithHelpersAtIndex:0];
-}
-
-static void
-ToMany_ToOne_ShouldDowngradeForOrderedObservation()
-{
-  START_SET("ToMany_ToOne_ShouldDowngradeForOrderedObservation");
-
-  Observee *observee = [Observee new];
   [observee insertObject:[DummyObject makeDummy] inArrayWithHelpersAtIndex:0];
 
-  TestFacade *facade = [TestFacade newWithObservee:observee];
-  [facade observeKeyPath:@"arrayWithHelpers.name"
-             withOptions:NSKeyValueObservingOptionOld
-                         | NSKeyValueObservingOptionNew
-            performingFn:toOne_insertMutation
-    andExpectChangeCallbacks:(ChangeCallback[]){
-      toOne_insertCallbackPost, toOne_illegalChangeNotification}
-                       count:2];
-  PASS([facade hits] == 1, "One notification was sent");
+  /* The key path names a property of the objects the collection holds, which
+   * the collection reports no change for.  Mutation helpers on the property
+   * make the collection itself observable, not the objects in it.
+   */
+  PASS_EXCEPTION([observee addObserver:observer
+                            forKeyPath:@"arrayWithHelpers.name"
+                               options:NSKeyValueObservingOptionNew
+                               context:nil],
+    NSInvalidArgumentException,
+    "a key path through an ordered to-many property raises");
 
-  [facade release];
+  [observer release];
   [observee release];
 
-  END_SET("ToMany_ToOne_ShouldDowngradeForOrderedObservation");
+  END_SET("ToMany_ToOne_KeyPathThroughACollectionRaises");
 }
 
 static void
@@ -1389,7 +1351,7 @@ main(int argc, char *argv[])
   ToMany_NotifyingArray();
   ToMany_KVCMediatedArrayWithHelpers_AggregateFunction();
 
-  ToMany_ToOne_ShouldDowngradeForOrderedObservation();
+  ToMany_ToOne_KeyPathThroughACollectionRaises();
   ObserverInformationShouldNotLeak();
 
   // NSArrayShouldNotBeObservable();


### PR DESCRIPTION
A key path that continues through an array or a set registers an observation
that can never fire, because the collection reports no change for a property of
the objects it holds. Observing list.name, where list holds one object, reports
nothing when that object's name changes.

_attachRestOfKeypath now hands the rest of the key path to the collection's own
addObserver:forKeyPath:options:context:, which raises, as it does when the same
key path is registered on the collection directly. An operator reads through the
collection rather than naming a property of the objects it holds, so it is still
registered.

macOS 26.5.2 raises for every form of this: through a dictionary, through a
plain array property, and through an ordered to-many property with mutation
helpers. It accepts an operator and notifies for it.

Two tests asserted that such a key path was accepted, one in
keypathRegistration.m and one in kvoToMany.m, and now assert the exception. The
second covered an ordered to-many property, which macOS refuses as well.

This changes Source/NSKVOSupport.m, as #727 does, so whichever lands second
needs a rebase.

Closes #707
