### PR TITLE
Free node strings the old dictionary does not own

### DIFF
--- a/Source/NSXMLNode.m
+++ b/Source/NSXMLNode.m
@@ -88,6 +88,44 @@ cleanup_namespaces(xmlNodePtr node, xmlNsPtr ns)
     }
 }
 
+/* Move one string of a node to the document the node is joining.
+ * A parser interns short strings in the dictionary of the document it builds
+ * and allocates the rest, so a string reached from a node is owned either by
+ * that dictionary or by the node itself.  Replacing an allocated one without
+ * freeing it loses it, and freeing one the dictionary owns would free it
+ * twice, so which it is has to be asked.
+ */
+static const xmlChar *
+adoptString(const xmlChar *str, xmlDocPtr oldDoc, xmlDocPtr doc, int mode)
+{
+  int	owned;
+
+  if (str == NULL)
+    {
+      return NULL;
+    }
+  owned = (oldDoc != NULL && oldDoc->dict != NULL)
+    ? xmlDictOwns(oldDoc->dict, str) : 0;
+
+  if (mode == 1)
+    {
+      const xmlChar *adopted = xmlDictLookup(doc->dict, str, -1);
+
+      if (0 == owned && adopted != str)
+        {
+          xmlFree((xmlChar *)str);
+        }
+      return adopted;
+    }
+  if (mode == 2 && owned)
+    {
+      /* The dictionary of the old document is about to go, and the new
+       * document has none to put the string in. */
+      return xmlStrdup(str);
+    }
+  return str;
+}
+
 /* Recursively set document pointer for a node tree.
  * This is needed when we can't use xmlDOMWrapAdoptNode due to bugs.
  * Also handles string adoption from old dictionary to new dictionary.
@@ -123,20 +161,8 @@ setTreeDoc(xmlNodePtr node, xmlDocPtr doc)
   /* Adopt or copy strings based on mode */
   if (node->type == XML_TEXT_NODE)
     {
-      if (node->content != NULL)
-        {
-          if (adoptStr == 1)
-            {
-              /* Adopt into new dict */
-              node->content
-		= (xmlChar *)xmlDictLookup(doc->dict, node->content, -1);
-            }
-          else if (adoptStr == 2)
-            {
-              /* Copy out of old dict */
-              node->content = xmlStrdup(node->content);
-            }
-        }
+      node->content
+	= (xmlChar *)adoptString(node->content, oldDoc, doc, adoptStr);
     }
   
   if (node->type == XML_ELEMENT_NODE)
@@ -145,36 +171,16 @@ setTreeDoc(xmlNodePtr node, xmlDocPtr doc)
       xmlNsPtr ns;
       
       /* Adopt or copy element name */
-      if (node->name != NULL)
-        {
-          if (adoptStr == 1)
-            {
-              node->name = xmlDictLookup(doc->dict, node->name, -1);
-            }
-          else if (adoptStr == 2)
-            {
-              node->name = xmlStrdup(node->name);
-            }
-        }
-      
+      node->name = adoptString(node->name, oldDoc, doc, adoptStr);
+
       /* Update attributes */
       for (attr = node->properties; attr != NULL; attr = attr->next)
         {
           attr->doc = doc;
-          
+
           /* Adopt or copy attribute name */
-          if (attr->name != NULL)
-            {
-              if (adoptStr == 1)
-                {
-                  attr->name = xmlDictLookup(doc->dict, attr->name, -1);
-                }
-              else if (adoptStr == 2)
-                {
-                  attr->name = xmlStrdup(attr->name);
-                }
-            }
-          
+          attr->name = adoptString(attr->name, oldDoc, doc, adoptStr);
+
           /* Recursively handle attribute value nodes */
           if (attr->children)
             setTreeDoc(attr->children, doc);
@@ -185,31 +191,8 @@ setTreeDoc(xmlNodePtr node, xmlDocPtr doc)
         {
           gsUpdateNsDoc(ns, doc);
           
-          if (adoptStr)
-            {
-              if (ns->href != NULL)
-                {
-                  if (adoptStr == 1)
-                    {
-                      ns->href = xmlDictLookup(doc->dict, ns->href, -1);
-                    }
-                  else if (adoptStr == 2)
-                    {
-                      ns->href = xmlStrdup(ns->href);
-                    }
-                }
-              if (ns->prefix != NULL)
-                {
-                  if (adoptStr == 1)
-                    {
-                      ns->prefix = xmlDictLookup(doc->dict, ns->prefix, -1);
-                    }
-                  else if (adoptStr == 2)
-                    {
-                      ns->prefix = xmlStrdup(ns->prefix);
-                    }
-                }
-            }
+          ns->href = adoptString(ns->href, oldDoc, doc, adoptStr);
+          ns->prefix = adoptString(ns->prefix, oldDoc, doc, adoptStr);
         }
     }
   

--- a/Tests/base/NSXMLNode/detachedStrings.m
+++ b/Tests/base/NSXMLNode/detachedStrings.m
@@ -1,0 +1,57 @@
+/* Detaching a node moves it to a document of its own, and the strings of its
+   subtree move with it.  A parser puts short strings in the dictionary of the
+   document it builds and allocates the rest, so both kinds have to survive the
+   move and the release of the document they were parsed into.
+*/
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSXMLDocument.h>
+#import <Foundation/NSXMLElement.h>
+#import <Foundation/NSXMLNode.h>
+#import <GNUstepBase/GNUstep.h>
+
+#import "Testing.h"
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSString      *source =
+    @"<document type=\"com.apple.InterfaceBuilder3.Cocoa.XIB\">"
+     "<objects id=\"a\" customClass=\"NSObject\">text of the element</objects>"
+     "</document>";
+  NSData        *data = [source dataUsingEncoding: NSUTF8StringEncoding];
+  NSXMLDocument *doc;
+  NSXMLElement  *root;
+  NSXMLNode     *child;
+
+  doc = [[NSXMLDocument alloc] initWithData: data options: 0 error: NULL];
+  PASS(doc != nil, "a document is parsed from data");
+
+  root = [doc rootElement];
+  PASS_EQUAL([[root attributeForName: @"type"] stringValue],
+    @"com.apple.InterfaceBuilder3.Cocoa.XIB",
+    "an attribute value longer than the parser interns is read back");
+
+  child = [root childAtIndex: 0];
+  [child retain];
+  [child detach];
+  DESTROY(doc);
+
+  /* Everything below reads strings that were parsed into the document just
+     released. */
+  PASS_EQUAL([child name], @"objects",
+    "a detached node keeps its name once the document is released");
+  PASS_EQUAL([[(NSXMLElement *)child attributeForName: @"id"] stringValue],
+    @"a", "a detached node keeps a short attribute value");
+  PASS_EQUAL([[(NSXMLElement *)child attributeForName: @"customClass"]
+    stringValue], @"NSObject",
+    "a detached node keeps an attribute value the parser allocated");
+  PASS_EQUAL([child stringValue], @"text of the element",
+    "a detached node keeps its text");
+
+  [child release];
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Detaching a node moves it to a document of its own, and setTreeDoc replaces the
strings of its subtree with entries in the dictionary of that document. A parser
interns short strings and allocates the rest, so a replaced string is owned
either by the old dictionary or by the node. Replacing an allocated one without
freeing it loses it.

setTreeDoc now asks xmlDictOwns which it is: a string the old dictionary owns is
left to it, one it does not own is freed once replaced. That covers the text
content, the element name, the attribute name, and the namespace href and
prefix.

libxml2 2.9.14 parsing and freeing the same document with no GNUstep in the
process leaks nothing.

Parsing alone does not leak either. A node has to be wrapped first, so
-rootElement is enough. The document in the report leaks 53 bytes in 3
allocations, its three attribute values too long to intern.

No test in the suite can fail on a leak.
Tests/base/NSXMLNode/detachedStrings.m covers the hazard the fix introduces
instead: a detached node's strings stay valid once the document they were parsed
into is released.

Closes #721
