### PR TITLE
Let the run loop block when a socket stream event is unhandled

### DIFF
--- a/Source/GSSocketStream.m
+++ b/Source/GSSocketStream.m
@@ -2993,15 +2993,13 @@ setNonBlocking(SOCKET fd)
 #if	defined(_WIN32)
 - (BOOL) runLoopShouldBlock: (BOOL*)trigger
 {
+  /* The socket's event is registered against this stream and carries the
+   * events of the sibling input stream as well, so the run loop is left to
+   * block on it. A delegate with more to write is driven by the loop in
+   * -_dispatch, which sends NSStreamEventHasSpaceAvailable for as long as
+   * the delegate keeps writing, so there is nothing to poll for here.
+   */
   *trigger = YES;
-  if ([self _unhandledData] == YES && [self streamStatus] == NSStreamStatusOpen)
-    {
-      /* In winsock, a writable status is only signalled if an earlier
-       * write failed (because it would block), so we must simulate the
-       * writable event by having the run loop trigger without blocking.
-       */
-      return NO;
-    }
   return YES;
 }
 #endif

--- a/Tests/base/NSURLConnection/Helpers/NSURLConnectionTest.m
+++ b/Tests/base/NSURLConnection/Helpers/NSURLConnectionTest.m
@@ -555,13 +555,16 @@ didReceiveResponse:(NSURLResponse *)response
 	{
 	  address = @"localhost";
 	}
+      /* Port 0 asks for a port the system is free to give. The URLs below
+       * are corrected once a server of our own has been bound.
+       */
       if (nil == port)
 	{
-	  port = @"1234";
+	  port = @"0";
 	}
       if (nil == auxPort)
 	{
-	  auxPort = @"1235";
+	  auxPort = @"0";
 	}
       if (nil == path)
 	{
@@ -686,6 +689,31 @@ didReceiveResponse:(NSURLResponse *)response
       [_auxServer setDebug: _debug];
       [_auxServer setDelegate: self];
       [_auxServer start: d];
+    }
+
+  /* A server asked for port 0 has been given a port by the system, so the
+   * requests are pointed at the port it was given.
+   */
+  if (isOwnServer && nil != _request)
+    {
+      url = [NSURL URLWithString:
+	[NSString stringWithFormat:
+	  @"%@://%@:%@%@", protocol, address, [_server port], path]];
+      [(NSMutableURLRequest *)_request setURL: url];
+    }
+  if (isOwnAuxServer && nil != _redirectRequest)
+    {
+      url = [NSURL URLWithString:
+	[NSString stringWithFormat:
+	  @"%@://%@:%@%@", protocol, address, [_auxServer port], redirectPath]];
+      [(NSMutableURLRequest *)_redirectRequest setURL: url];
+    }
+  /* The redirect handler runs on the first server and sends a client to the
+   * second, so that server needs the port the second was given.
+   */
+  if (nil != _server && nil != _auxServer)
+    {
+      [_server setAuxPort: [_auxServer port]];
     }
 }
 

--- a/Tests/base/NSURLConnection/Helpers/SimpleWebServer.m
+++ b/Tests/base/NSURLConnection/Helpers/SimpleWebServer.m
@@ -155,7 +155,21 @@
 					      service: _port
 					     protocol: @"tcp"];
     }
+  if (nil == _fh)
+    {
+      /* The bind or listen failed and NSFileHandle has already logged the
+       * reason.  Report it rather than accepting connections on nil, which
+       * leaves every request to time out for no stated reason.
+       */
+      NSLog(@"%@ could not listen on %@:%@", self, _address, _port);
+      return NO;
+    }
   RETAIN(_fh);
+
+  /* A port of 0 asks the system for one, so record the port bound rather
+   * than the port requested.
+   */
+  ASSIGN(_port, [_fh socketService]);
 
   [[NSNotificationCenter defaultCenter] addObserver: self
 					  selector: @selector(_accept:)

--- a/Tests/base/NSURLConnection/Helpers/TestWebServer.h
+++ b/Tests/base/NSURLConnection/Helpers/TestWebServer.h
@@ -103,6 +103,9 @@
   /* the port to listen on... see DEFAULTPORT in the beginning
    * of the implementaion */
   NSString *_port;
+  /* the port the auxiliary server listens on, which is where the redirect
+   * handler sends a client... nil means the port after _port */
+  NSString *_auxPort;
   /* whether the TestWebServer listens for HTTPS requests */
   BOOL _isSecure;
   /* the login for basic authentication */
@@ -223,6 +226,13 @@
  *  Sets the debug mode (more verbose).
  */
 - (void)setDebug:(BOOL)mode;
+
+/**
+ *  Sets the port the redirect handler sends a client to. A server bound to
+ *  port 0 is given a port by the system, so the port of the auxiliary server
+ *  cannot be assumed to be the port after this one.
+ */
+- (void)setAuxPort:(NSString *)port;
 
 /* end of setters */
 

--- a/Tests/base/NSURLConnection/Helpers/TestWebServer.m
+++ b/Tests/base/NSURLConnection/Helpers/TestWebServer.m
@@ -429,6 +429,15 @@
   status = [_server setAddress: _address port: _port secure: secure];
   if (!status)
     {
+      if (nil != secure)
+	{
+	  /* A build without working TLS cannot serve HTTPS at all. The tests
+	   * that ask for it set testHopeful for that case, so they report it
+	   * themselves rather than the file being abandoned here.
+	   */
+	  NSLog(@"%@ cannot serve HTTPS on %@:%@", self, _address, _port);
+	  return;
+	}
       [NSException raise: NSInternalInconsistencyException
 	format: @"The server hasn't run on %@:%@", _address, _port];
     }

--- a/Tests/base/NSURLConnection/Helpers/TestWebServer.m
+++ b/Tests/base/NSURLConnection/Helpers/TestWebServer.m
@@ -27,7 +27,11 @@
 
 /* default 'constants' */
 #define DEFAULTADDRESS @"localhost"
-#define DEFAULTPORT @"1234"
+/* Port 0 asks for a port the system is free to give. A fixed port cannot be
+ * rebound while an earlier run's connections to it are in TIME_WAIT, and on
+ * Windows the bind then fails.
+ */
+#define DEFAULTPORT @"0"
 #define DEFAULTMODE NO
 #define DEFAULTLOGIN @"login"
 #define DEFAULTPASSWORD @"password"
@@ -137,6 +141,7 @@
   DESTROY(_lock);
   DESTROY(_address);
   DESTROY(_port);
+  DESTROY(_auxPort);
   DESTROY(_extra);
   DESTROY(_login);
   DESTROY(_password);
@@ -287,8 +292,11 @@
 	}
       else if ([handler isKindOfClass: [Handler301 class]])
 	{
-	  // by default http://localhost:1235/
-	  NSString *port = [NSString stringWithFormat: @"%u", [_port intValue] + 1]; // the TestWebServer's port + 1
+	  /* The auxiliary server's port, or the port after this one where it
+	   * has not been set.
+	   */
+	  NSString *port = (nil != _auxPort) ? _auxPort
+	    : [NSString stringWithFormat: @"%u", [_port intValue] + 1];
 	  NSString *urlString = [NSString stringWithFormat: @"%@://%@:%@/",
 				     _isSecure ? @"https" : @"http",
 					  _address,
@@ -356,6 +364,11 @@
   _delegate = delegate;
 }
 
+- (void)setAuxPort:(NSString *)port
+{
+  ASSIGN(_auxPort, port);
+}
+
 - (void)setDebug:(BOOL)mode
 {
   NSProcessInfo *pi = [NSProcessInfo processInfo];
@@ -417,9 +430,12 @@
   if (!status)
     {
       [NSException raise: NSInternalInconsistencyException
-	format: @"The server hasn't run. Perhaps the port %@ is invalid",
-	DEFAULTPORT];
+	format: @"The server hasn't run on %@:%@", _address, _port];
     }
+  /* Record the port bound, which is the port the system chose where 0 was
+   * asked for.
+   */
+  ASSIGN(_port, [_server port]);
 }
 
 - (void)_stopHTTPServer

--- a/Tests/base/NSURLConnection/test02.m
+++ b/Tests/base/NSURLConnection/test02.m
@@ -40,7 +40,7 @@ int main(int argc, char **argv, char **env)
       // create a shared TestWebServer instance for performance
       server = [[testClass testWebServerClass] new];
       [server setDebug: debug];
-      [server start: nil]; // localhost:1234 HTTP
+      [server start: nil]; // localhost, HTTP
 
       /*
        *  Simple GET via HTTP with empty response's body and
@@ -54,7 +54,7 @@ int main(int argc, char **argv, char **env)
 			nil];
       [testCase setUpTest: d];
       [testCase startTest: d];
-      PASS([testCase isSuccess], "GET http://localhost:1234/");
+      PASS([testCase isSuccess], "GET http://localhost/");
       [testCase tearDownTest: d];
       DESTROY(testCase);
 
@@ -73,7 +73,7 @@ int main(int argc, char **argv, char **env)
 			nil];
       [testCase setUpTest: d];
       [testCase startTest: d];
-      PASS([testCase isSuccess], "response 400 .... GET http://localhost:1234/400");
+      PASS([testCase isSuccess], "response 400 .... GET http://localhost/400");
       [testCase tearDownTest: d];
       DESTROY(testCase);
 
@@ -94,7 +94,7 @@ int main(int argc, char **argv, char **env)
 			nil];
       [testCase setUpTest: d];
       [testCase startTest: d];
-      PASS([testCase isSuccess], "payload... response 400 .... POST http://localhost:1234/400");
+      PASS([testCase isSuccess], "payload... response 400 .... POST http://localhost/400");
       [testCase tearDownTest: d];
       DESTROY(testCase);
 
@@ -120,7 +120,7 @@ int main(int argc, char **argv, char **env)
 			nil];      
       [testCase setUpTest: d];
       [testCase startTest: d];
-      PASS([testCase isSuccess], "redirecting... GET http://localhost:1234/301");
+      PASS([testCase isSuccess], "redirecting... GET http://localhost/301");
       [testCase tearDownTest: d];
       DESTROY(testCase);
 

--- a/Tests/base/NSURLConnection/test03.m
+++ b/Tests/base/NSURLConnection/test03.m
@@ -46,11 +46,11 @@ testHopeful = YES;
       // create a shared TestWebServer instance for performance
       server = [[[testClass testWebServerClass] alloc]
         initWithAddress: @"localhost"
-                   port: @"1233"
+                   port: @"0"
                    mode: NO
                   extra: d];
       [server setDebug: debug];
-      [server start: d]; // localhost:1233 HTTPS
+      [server start: d]; // localhost, HTTPS
 
       /*
        *  Simple GET via HTTPS with empty response's body and
@@ -64,7 +64,7 @@ testHopeful = YES;
         nil];
       [testCase setUpTest: d];
       [testCase startTest: d];
-      PASS([testCase isSuccess], "HTTPS... GET https://localhost:1233/");
+      PASS([testCase isSuccess], "HTTPS... GET https://localhost/");
       [testCase tearDownTest: d];
       DESTROY(testCase);
 
@@ -83,7 +83,7 @@ testHopeful = YES;
         nil];
       [testCase setUpTest: d];
       [testCase startTest: d];
-      PASS([testCase isSuccess], "HTTPS... response 400 .... GET https://localhost:1233/400");
+      PASS([testCase isSuccess], "HTTPS... response 400 .... GET https://localhost/400");
       [testCase tearDownTest: d];
       DESTROY(testCase);
 
@@ -104,7 +104,7 @@ testHopeful = YES;
         nil];
       [testCase setUpTest: d];
       [testCase startTest: d];
-      PASS([testCase isSuccess], "HTTPS... payload... response 400 .... POST https://localhost:1233/400");
+      PASS([testCase isSuccess], "HTTPS... payload... response 400 .... POST https://localhost/400");
       [testCase tearDownTest: d];
       DESTROY(testCase);
 
@@ -126,12 +126,12 @@ testHopeful = YES;
         @"/301", @"Path",      // request the handler responding with a redirect
         @"/", @"RedirectPath", // the URL's path of redirecting
         @"YES", @"IsAuxilliary", // start an auxilliary TestWebServer instance
-        @"1236", @"AuxPort",   // the port of the auxilliary instance			  
+        @"0", @"AuxPort",   // the port of the auxilliary instance			  
         refs, @"ReferenceFlags", // the expected reference set difference
         nil];      
       [testCase setUpTest: d];
       [testCase startTest: d];
-      PASS([testCase isSuccess], "HTTPS... redirecting... GET https://localhost:1233/301");
+      PASS([testCase isSuccess], "HTTPS... redirecting... GET https://localhost/301");
       [testCase tearDownTest: d];
       DESTROY(testCase);
 

--- a/Tests/base/NSURLConnection/test04.m
+++ b/Tests/base/NSURLConnection/test04.m
@@ -35,11 +35,11 @@ int main(int argc, char **argv, char **env)
       // create a shared TestWebServer instance for performance
       server = [[[testClass testWebServerClass] alloc]
         initWithAddress: @"localhost"
-                   port: @"1232"
+                   port: @"0"
                    mode: NO
                   extra: nil];
       [server setDebug: debug];
-      [server start: nil]; // localhost:1232 HTTP
+      [server start: nil]; // localhost, HTTP
 
       /*
        *  Simple GET via HTTP without authorization with empty response's body and
@@ -63,7 +63,7 @@ int main(int argc, char **argv, char **env)
 			nil];
       [testCase setUpTest: d];
       [testCase startTest: d];
-      PASS([testCase isSuccess], "no auth... GET http://localhost:1232/withoutauth");
+      PASS([testCase isSuccess], "no auth... GET http://localhost/withoutauth");
       [testCase tearDownTest: d];
       DESTROY(testCase);
 
@@ -91,7 +91,7 @@ int main(int argc, char **argv, char **env)
 			nil];
       [testCase setUpTest: d];
       [testCase startTest: d];
-      PASS([testCase isSuccess], "no auth... response 400 .... GET http://localhost:1232/400/withoutauth");
+      PASS([testCase isSuccess], "no auth... response 400 .... GET http://localhost/400/withoutauth");
       [testCase tearDownTest: d];
       DESTROY(testCase);
 
@@ -121,7 +121,7 @@ int main(int argc, char **argv, char **env)
 			nil];
       [testCase setUpTest: d];
       [testCase startTest: d];
-      PASS([testCase isSuccess], "no auth... payload... response 400 .... POST http://localhost:1232/400/withoutauth");
+      PASS([testCase isSuccess], "no auth... payload... response 400 .... POST http://localhost/400/withoutauth");
       [testCase tearDownTest: d];
       DESTROY(testCase);
 
@@ -148,12 +148,12 @@ int main(int argc, char **argv, char **env)
 			@"/301/withoutauth", @"Path", // request the handler responding with a redirect
 			@"/withoutauth", @"RedirectPath", // the URL's path of redirecting 
 			@"YES", @"IsAuxilliary", // start an auxilliary TestWebServer instance
-			@"1237", @"AuxPort",   // the port of the auxilliary instance			  			
+			@"0", @"AuxPort",   // the port of the auxilliary instance			  			
 			refs, @"ReferenceFlags", // the expected reference set difference
 			nil];      
       [testCase setUpTest: d];
       [testCase startTest: d];
-      PASS([testCase isSuccess], "no auth... redirecting... GET http://localhost:1232/301/withoutauth");
+      PASS([testCase isSuccess], "no auth... redirecting... GET http://localhost/301/withoutauth");
       [testCase tearDownTest: d];
       DESTROY(testCase);
 

--- a/Tests/base/NSURLConnection/test05.m
+++ b/Tests/base/NSURLConnection/test05.m
@@ -45,11 +45,11 @@ testHopeful = YES;
       // create a shared TestWebServer instance for performance
       server = [[[testClass testWebServerClass] alloc]
 	initWithAddress: @"localhost"
-	port: @"1231"
+	port: @"0"
 	mode: NO
         extra: d];
       [server setDebug: debug];
-      [server start: d]; // localhost:1231 HTTPS
+      [server start: d]; // localhost, HTTPS
 
       /* Simple GET via HTTPS without authorization with empty response's
        * body and the response's status code 204 (by default)
@@ -75,7 +75,7 @@ testHopeful = YES;
       [testCase setUpTest: d];
       [testCase startTest: d];
       PASS([testCase isSuccess],
-	"HTTPS... no auth...GET https://localhost:1231/withoutauth");
+	"HTTPS... no auth...GET https://localhost/withoutauth");
       [testCase tearDownTest: d];
       DESTROY(testCase);
 
@@ -104,7 +104,7 @@ testHopeful = YES;
 	nil];
       [testCase setUpTest: d];
       [testCase startTest: d];
-      PASS([testCase isSuccess], "HTTPS... no auth... response 400... GET https://localhost:1231/400/withoutauth");
+      PASS([testCase isSuccess], "HTTPS... no auth... response 400... GET https://localhost/400/withoutauth");
       [testCase tearDownTest: d];
       DESTROY(testCase);
 
@@ -136,7 +136,7 @@ testHopeful = YES;
 	nil];
       [testCase setUpTest: d];
       [testCase startTest: d];
-      PASS([testCase isSuccess], "HTTPS... no auth... payload... response 400 .... POST https://localhost:1231/400/withoutauth");
+      PASS([testCase isSuccess], "HTTPS... no auth... payload... response 400 .... POST https://localhost/400/withoutauth");
       [testCase tearDownTest: d];
       DESTROY(testCase);
 
@@ -166,12 +166,12 @@ testHopeful = YES;
 	@"/301/withoutauth", @"Path", // request a redirect
 	@"/withoutauth", @"RedirectPath", // the URL's path of redirecting 
 	@"YES", @"IsAuxilliary", // start an auxilliary TestWebServer instance
-        @"1238", @"AuxPort",   // the port of the auxilliary instance			
+        @"0", @"AuxPort",   // the port of the auxilliary instance			
 	refs, @"ReferenceFlags", // the expected reference set difference
 	nil];      
       [testCase setUpTest: d];
       [testCase startTest: d];
-      PASS([testCase isSuccess], "HTTPS... no auth... redirecting... GET https://localhost:1231/301/withoutauth");
+      PASS([testCase isSuccess], "HTTPS... no auth... redirecting... GET https://localhost/301/withoutauth");
       [testCase tearDownTest: d];
       DESTROY(testCase);
 

--- a/Tests/base/NSURLConnection/test06.m
+++ b/Tests/base/NSURLConnection/test06.m
@@ -39,18 +39,19 @@ int main(int argc, char **argv, char **env)
       // login:password
       server = [[[testClass testWebServerClass] alloc]
         initWithAddress: @"localhost"
-                   port: @"1230"
+                   port: @"0"
                    mode: NO
                   extra: nil];
       [server setDebug: debug];
-      [server start: nil]; // localhost:1230 HTTP
+      [server start: nil]; // localhost, HTTP
 
       /*
        *  Simple GET via HTTP with some response's body and
        *  the response's status code 200
        */
-      url = [NSURL
-        URLWithString: @"http://login:password@localhost:1230/index"];
+      url = [NSURL URLWithString:
+        [NSString stringWithFormat: @"http://login:password@localhost:%@/index",
+	  [server port]]];
       request = [NSURLRequest requestWithURL: url];
       data = [NSURLConnection sendSynchronousRequest: request
 				   returningResponse: &response

--- a/Tests/base/NSURLConnection/test07.m
+++ b/Tests/base/NSURLConnection/test07.m
@@ -46,11 +46,11 @@ testHopeful = YES;
       // create a shared TestWebServer instance for performance
       server = [[[testClass testWebServerClass] alloc]
 	initWithAddress: @"localhost"
-	port: @"1229"
+	port: @"0"
 	mode: NO
         extra: d];
       [server setDebug: debug];
-      [server start: d]; // localhost:1229 HTTPS
+      [server start: d]; // localhost, HTTPS
 
       /* Simple POST via HTTPS with the response's status code 400 and
        * non-empty response's body
@@ -87,7 +87,7 @@ testHopeful = YES;
 	nil];
       [testCase setUpTest: d];
       [testCase startTest: d];
-      PASS([testCase isSuccess], "HTTPS... big payload... response 400 .... POST https://localhost:1229/400/withoutauth");
+      PASS([testCase isSuccess], "HTTPS... big payload... response 400 .... POST https://localhost/400/withoutauth");
       [testCase tearDownTest: d];
       DESTROY(testCase);
 


### PR DESCRIPTION
Closes #375. Two defects behind it.

-[GSSocketOutputStream runLoopShouldBlock:] answered NO while an event
had been delivered and not consumed, and set the trigger, so the run
loop polled with a zero timeout and dispatched the stream on every pass.
After a request is sent on a kept alive connection the delegate has
nothing to write, so nothing clears NSStreamEventHasSpaceAvailable and
the poll never ends: 2.97 seconds of processor time in a window of 3
seconds. Blocking is safe, because a delegate with more to write is
driven by the loop in -_dispatch, measured at 8MB in 163 events.
Clearing the trigger instead loses the read, since the socket's event is
registered against this stream and its -_dispatch hands FD_READ to the
sibling.

The tests bound the fixed ports 1229 to 1238. A port in TIME_WAIT cannot
be rebound, so on Windows the bind fails, and
-[SimpleWebServer _startListening] answered YES anyway, leaving requests
to time out with nothing reported. Each server now asks for port 0 and
reports the port it was given.

test02 run 6 times back to back now passes every time; master only passed 1
in 5.
