### PR TITLE
Read the XDG system defaults for the well known directories

### DIFF
--- a/Source/NSPathUtilities.m
+++ b/Source/NSPathUtilities.m
@@ -606,8 +606,24 @@ ExtractValuesFromConfig(NSDictionary *config)
 
   /* Check for user subdirectories.  Ones from the GNUstep file are added
    * second, so they override the XDG ones.
+   *
+   * Setting GNUSTEP_XDG_USER_DIRS to NO in the GNUstep configuration file
+   * turns the XDG lookup off, leaving the builtin names and the GNUSTEP_
+   * keys below.  An absent key leaves the lookup on.
    */
-  xdg = UserDirsParseXDG();
+  {
+    NSString	*useXDG = [c objectForKey: @"GNUSTEP_XDG_USER_DIRS"];
+
+    if (nil == useXDG || YES == [useXDG boolValue])
+      {
+	xdg = UserDirsParseXDG();
+      }
+    else
+      {
+	xdg = nil;
+      }
+  }
+  [c removeObjectForKey: @"GNUSTEP_XDG_USER_DIRS"];
   ASSIGN_IF_SET(gnustepUserDesktop, xdg, @"XDG_DESKTOP_DIR");
   ASSIGN_IF_SET(gnustepUserDesktop, c, @"GNUSTEP_DESKTOP_DIR");
   ASSIGN_IF_SET(gnustepUserDocuments, xdg, @"XDG_DOCUMENTS_DIR");

--- a/Source/NSPathUtilities.m
+++ b/Source/NSPathUtilities.m
@@ -2619,7 +2619,7 @@ if (domainMask & mask) \
 
       case NSDesktopDirectory:
 	{
-	  ADD_PATH(NSUserDomainMask, gnustepUserHome, @"Desktop");
+	  ADD_PATH(NSUserDomainMask, gnustepUserHome, gnustepUserDesktop);
 	}
 	break;
 

--- a/Source/NSPathUtilities.m
+++ b/Source/NSPathUtilities.m
@@ -1761,20 +1761,92 @@ ParseConfigurationFile(NSString *fileName, NSMutableDictionary *dict,
 static NSMutableDictionary *
 UserDirsParseXDG()
 {
+  NSDictionary		*env;
   NSMutableDictionary	*info;
+  NSMutableDictionary	*user;
+  NSArray		*configDirs;
   NSArray		*keys;
   NSString		*fileName;
   NSString		*userName;
   NSString		*home;
+  NSString		*dirs;
+  unsigned		count;
+
+  env = [[NSProcessInfo processInfo] environment];
 
   /* For XDG let the standard environment variable take precedence over
    * GNUstep specific rules.
    */
-  if (nil == (home = [[[NSProcessInfo processInfo] environment]
-    objectForKey: @"HOME"]))
+  if (nil == (home = [env objectForKey: @"HOME"]))
     {
       home = NSHomeDirectory();
     }
+
+  info = [NSMutableDictionary dictionary];
+
+  /* The system wide defaults are held in user-dirs.defaults in each of the
+   * directories listed in XDG_CONFIG_DIRS, /etc/xdg where that is not set.
+   * They name a subdirectory of the home directory and omit the XDG_ prefix
+   * and the _DIR suffix, so DESKTOP=Desktop there is XDG_DESKTOP_DIR set to
+   * $HOME/Desktop here.  An earlier directory in the list takes precedence,
+   * so the list is read backwards, and the user's own file read after these
+   * overrides all of them.
+   */
+  if (0 == [(dirs = [env objectForKey: @"XDG_CONFIG_DIRS"]) length])
+    {
+      dirs = @"/etc/xdg";
+    }
+  configDirs = [dirs componentsSeparatedByString: @":"];
+  count = [configDirs count];
+  while (count-- > 0)
+    {
+      NSMutableDictionary	*defaults;
+      NSString			*dir = [configDirs objectAtIndex: count];
+      NSArray			*names;
+
+      if (0 == [dir length])
+	{
+	  continue;
+	}
+      fileName = [dir stringByAppendingPathComponent: @"user-dirs.defaults"];
+
+      /* A system file is not owned by the user running the program, so no
+       * owner is given to check against.  ParseConfigurationFile() still
+       * refuses a file which anyone other than its owner may write.
+       */
+      defaults = [NSMutableDictionary dictionary];
+      if (NO == ParseConfigurationFile(fileName, defaults, nil))
+	{
+	  continue;
+	}
+      names = [defaults allKeys];
+      GS_FOR_IN(NSString*, name, names)
+	NSString	*value = [defaults objectForKey: name];
+
+	if ([value length] > 0)
+	  {
+	    /* The specification gives these relative to the home directory,
+	     * but take an absolute path or the $HOME form as written.
+	     */
+	    if ([value isEqualToString: @"$HOME"])
+	      {
+		value = home;
+	      }
+	    else if ([value hasPrefix: @"$HOME/"])
+	      {
+		value = [home stringByAppendingPathComponent:
+		  [value substringFromIndex: 6]];
+	      }
+	    else if (NO == [value isAbsolutePath])
+	      {
+		value = [home stringByAppendingPathComponent: value];
+	      }
+	    [info setObject: value
+		     forKey: [NSString stringWithFormat: @"XDG_%@_DIR", name]];
+	  }
+      GS_END_FOR(names)
+    }
+
   fileName = [home stringByAppendingPathComponent: @".config"];
   fileName = [fileName stringByAppendingPathComponent: @"user-dirs.dirs"];
 
@@ -1782,10 +1854,10 @@ UserDirsParseXDG()
    * to extract the key/value pairs from it.
    */
   userName = NSUserName();
-  info = [NSMutableDictionary dictionary];
-  if (NO == ParseConfigurationFile(fileName, info, userName))
+  user = [NSMutableDictionary dictionary];
+  if (YES == ParseConfigurationFile(fileName, user, userName))
     {
-      [info removeAllObjects];
+      [info addEntriesFromDictionary: user];
     }
 
   /* Now map XDG name/value pairs to GNUstep names with absolute


### PR DESCRIPTION
Addresses #701 

The user's own $HOME/.config/user-dirs.dirs was read, but not the system
wide user-dirs.defaults, which is where a user with no file of their own
gets these values. It is looked for in each directory named by
XDG_CONFIG_DIRS, /etc/xdg where that is unset, and it names a
subdirectory of the home directory without the XDG_ prefix and the _DIR
suffix. An earlier directory in XDG_CONFIG_DIRS takes precedence over a
later one, and the user's own file takes precedence over both.

The system file is parsed with no owner to check against, since it
belongs to root rather than to the user; ParseConfigurationFile() still
refuses a file which anyone other than its owner may write.

Setting GNUSTEP_XDG_USER_DIRS to NO in the GNUstep configuration file
turns the lookup off. An absent key leaves it on.

NSDesktopDirectory answered a hardcoded "Desktop", so the desktop value
from XDG or from GNUSTEP_DESKTOP_DIR was assigned and never read. It now
reads gnustepUserDesktop, as the other user directories do.

Both files are read at each launch, so a change takes effect without a
rebuild. base/NSPathUtilities, NSFileManager and NSBundle are 369 passed
and 0 failed, before and after.
