### PR TITLE
Add the missing Romansh alias for Switzerland

### DIFF
--- a/Resources/Languages/Locale.aliases
+++ b/Resources/Languages/Locale.aliases
@@ -299,6 +299,7 @@
     qu = Quechua;
     raj = Rajasthani;
     rm = Romansh;
+    rm_CH = SwitzerlandRomansh;
     rn = Rundi;
     ro = Romanian;
     ru = Russian;


### PR DESCRIPTION
Locale.aliases maps rm to Romansh and carries the Swiss variants of
German, French and Italian, but has no entry for rm_CH, the fourth
official language of Switzerland. ICU knows both rm and rm_CH, and
GSLanguagesFromLocale() turns rm_CH into the pair rm_CH and rm, so the
regional name was the only part missing.

Checked by reading the file as a property list before and after: 389
entries with rm_CH unresolved, 390 with it resolving to
SwitzerlandRomansh, and the file still parses.

Raised by @ivucica in #28. The rest of that issue, the four Swiss
language files, is left for the discussion there.
