### PR TITLE
tests: skip the external host tests where there is no route out

### DIFF
--- a/Tests/base/NSStream/socket.m
+++ b/Tests/base/NSStream/socket.m
@@ -11,6 +11,12 @@
 #define	SSL_SUPPORTED	1 /* Assume Apple supports it */
 #endif
 
+/* How long to wait for a host outside this machine. A connection which is
+ * going to work does not need 30 seconds, and a runner with no route out
+ * should not spend that long finding out.
+ */
+#define	WAIT	10.0
+
 static NSOutputStream *defaultOutput = nil;
 static NSInputStream *defaultInput = nil;
 static int byteCount = 0;
@@ -28,8 +34,10 @@ static BOOL     done = NO;
   static uint8_t buffer[4096];
   static BOOL doneWrite = NO;
   int readSize;
-NSLog(@"Got %ld on %p", (long int)streamEvent, theStream);
-  switch (streamEvent) 
+
+  NSDebugMLLog(@"NSStream", @"Got %ld on %p",
+    (long int)streamEvent, theStream);
+  switch (streamEvent)
     {
     case NSStreamEventOpenCompleted: 
       {
@@ -120,7 +128,14 @@ int main()
   //name = @"localhost";
   host = [NSHost hostWithName: name];
 
-#if 1
+  START_SET("NSStream to an external host")
+  /* -hostWithName: answers a host whatever the name, so the test for a
+   * machine with no route out is whether an address was found for it.
+   */
+  if (nil == [host address])
+    {
+      SKIP("no address for www.google.com, so there is no route out")
+    }
   li = [[Listener new] autorelease];
   [NSStream getStreamsToHost: host port: 80
     inputStream: &defaultInput outputStream: &defaultOutput];
@@ -131,8 +146,8 @@ int main()
   [defaultOutput scheduleInRunLoop: rl forMode: NSDefaultRunLoopMode];
   [defaultInput open];
   [defaultOutput open];
-  
-  d = [NSDate dateWithTimeIntervalSinceNow: 30];
+
+  d = [NSDate dateWithTimeIntervalSinceNow: WAIT];
   while (done == NO && [d timeIntervalSinceNow] > 0.0)
     {
       [rl runMode: NSDefaultRunLoopMode beforeDate: d];
@@ -143,11 +158,13 @@ int main()
   PASS(byteCount>0, "read www.google.com");
   [defaultInput setDelegate: nil];
   [defaultOutput setDelegate: nil];
-#endif
+  END_SET("NSStream to an external host")
 
   START_SET("NSStream SSL")
     if (!SSL_SUPPORTED)
       SKIP("NSStream SSL functions not supported\nThe GNU TLS library was not provided when GNUstep-base was configured/built.")
+    if (nil == [host address])
+      SKIP("no address for www.google.com, so there is no route out")
     done = NO;
     byteCount = 0;
     defaultInput = nil;
@@ -173,7 +190,7 @@ int main()
     [defaultInput open];
     [defaultOutput open];
 
-    d = [NSDate dateWithTimeIntervalSinceNow: 30];
+    d = [NSDate dateWithTimeIntervalSinceNow: WAIT];
     while (done == NO && [d timeIntervalSinceNow] > 0.0)
       {
 	[rl runMode: NSDefaultRunLoopMode beforeDate: d];


### PR DESCRIPTION
One of the 3 slow tests in #448. socket.m connects to www.google.com on
port 80 and again on 443, giving the run loop 30 seconds each time.

Measured with the name changed to one that does not resolve: master takes
61 seconds and reports 2 failures. -hostWithName: answers a host whatever
the name is, so the check here is whether -address is nil. When it is,
the 2 sets skip and the file takes 1 second. With the network present the
file passes 38 tests, as before.

The wait is 10 seconds rather than 30. The per event NSLog in the stream
delegate is now NSDebugMLLog.

base/NSURL/test00.m and base/NSURL/test02.m are unchanged. test00 waits
on purpose, and test02 runs in under a second here.
