### PR TITLE
Fix: do not look up the locale maps as localized resources

### DIFF
--- a/Source/NSBundle.m
+++ b/Source/NSBundle.m
@@ -1831,9 +1831,8 @@ GSPrivateInfoDictionary(NSString *rootPath)
 
       /* The Locale aliases map converts canonical names to old-style names
        */
-      file = [_gnustep_bundle pathForResource: @"Locale"
-                                       ofType: @"aliases"
-                                  inDirectory: @"Languages"];
+      file = GSPrivateResourcePath(@"Locale", @"aliases",
+        [_gnustep_bundle bundlePath], @"Languages", NOT_LOCALIZED);
       if (file != nil)
         {
           NSDictionary  *d;
@@ -1850,9 +1849,8 @@ GSPrivateInfoDictionary(NSString *rootPath)
        * and converts ISO 639-2 names to the preferred ISO 639-1 names where
        * an ISO 639-1 name exists.
        */
-      file = [_gnustep_bundle pathForResource: @"Locale"
-                                       ofType: @"canonical"
-                                  inDirectory: @"Languages"];
+      file = GSPrivateResourcePath(@"Locale", @"canonical",
+        [_gnustep_bundle bundlePath], @"Languages", NOT_LOCALIZED);
       if (file != nil)
         {
           NSDictionary  *d;


### PR DESCRIPTION
+[NSBundle initialize] looks up Locale.aliases and Locale.canonical with
-pathForResource:ofType:inDirectory:, which passes a nil localization, so
_find_paths reads NSLanguages from the shared user defaults. Both files are
single global maps in Languages rather than localized resources, and
_find_paths already takes NOT_LOCALIZED for that case. This changes the two
lookups to the non-localized form, which removes the only NSUserDefaults call
in +[NSBundle initialize].

That call is how #734 happens. On Android every file read passes through
+[NSBundle assetForPath:withMode:], so reading the info dictionary in
+[NSUserDefaults initialize] sends the first message to NSBundle, and
_find_paths then re-enters +standardUserDefaults. The shared instance is built
there, before bundleIdentifier and argumentsDictionary are assigned, so the
application domain is missing from the search list and NSArgumentDomain stays
empty.

Measured on Android x86_64 with a configuration file in use:
Tests/base/NSUserDefaults goes from 63 passed and 22 failed to 85 passed and 0
failed, and Tests/base/NSURL from 387 to 1723 passed. The whole suite is 13448
passed and 6 failed either way.

This removes the re-entrancy on this path. A first message to NSBundle from
elsewhere during that window could still reach a resource lookup.

Closes #734
