### PR TITLE
tests: skip unsupported string encodings and return 0 from simpleTaskTests

### DIFF
--- a/Tests/base/NSString/NSString_tests.h
+++ b/Tests/base/NSString/NSString_tests.h
@@ -79,12 +79,17 @@ test_encodings_helper(NSStringEncoding encoding,
 	  encodings++;
 	}
     }
-  PASS(encodings != 0 && encoding == *encodings,
-    "String encoding %d is supported", encoding);
-  if (NO == testPassed)
+  if (0 == encodings || encoding != *encodings)
     {
+      /* Which encodings exist is a property of the platform's iconv, not of
+       * gnustep-base: bionic supports far fewer of them than glibc does.
+       */
+      START_SET("string encoding")
+      SKIP("string encoding is not supported on this platform")
+      END_SET("string encoding")
       return;
     }
+  PASS(YES, "String encoding %d is supported", encoding);
   
   enc = [[NSString localizedNameOfStringEncoding: encoding] UTF8String];
 

--- a/Tests/base/NSURLSession/simpleTaskTests.m
+++ b/Tests/base/NSURLSession/simpleTaskTests.m
@@ -1000,6 +1000,7 @@ main(int argc, char *argv[])
     [server release];
     [countLock release];
   }
+  return 0;
 }
 
 #else


### PR DESCRIPTION
Two test fixture corrections, found running the suite on Android.

Tests/base/NSString/NSString_tests.h: test_encodings_helper recorded a failure
when the requested encoding is absent from +availableStringEncodings. Which
encodings exist is a property of the platform's iconv rather than of
gnustep-base, and bionic offers 16 of them where glibc offers 68. The helper
now skips that case, which is what locale.m and regex.m already do for a
missing ICU. Where the encoding is supported the path is unchanged, and
Tests/base/NSString stays at 2023 passed and 0 failed on Linux.

Tests/base/NSURLSession/simpleTaskTests.m: main falls off the end without
returning, so the exit status is whatever the return register holds. On Android
it came out as 252, 253, 254 and 255 over repeated runs, and gnustep-tests
reports a non-zero exit as a failed file even though all 117 assertions pass.
uploadTaskTests.m already returns 0. Ubuntu clang 18.1.3 emits no warning here
and returns 0, while the Android NDK clang 21 warns and does not, so the
omission is latent on other platforms.
