### PR TITLE
Fix: NULL pw_gecos, the home directory fallback and TMPDIR

### DIFF
--- a/Source/NSPathUtilities.m
+++ b/Source/NSPathUtilities.m
@@ -1980,7 +1980,8 @@ NSHomeDirectoryForUser(NSString *loginName)
     {
       s = [[NSProcessInfo processInfo] androidFilesDir];
     }
-#elif !defined(_WIN32)
+#endif
+#if !defined(_WIN32)
 #if     defined(HAVE_GETPWNAM_R)
   if (nil == s)
     {
@@ -2094,12 +2095,10 @@ NSFullUserName(void)
       struct passwd *p;
       char buf[BUFSIZ*10];
 
-      if (getpwnam_r([userName cString], &pw, buf, sizeof(buf), &p) == 0)
+      if (getpwnam_r([userName cString], &pw, buf, sizeof(buf), &p) == 0
+	&& p != 0 && pw.pw_gecos != 0 && *pw.pw_gecos)
         {
-	  if (*pw.pw_gecos)
-	    {
-              userName = [NSString stringWithUTF8String: pw.pw_gecos];
-	    }
+          userName = [NSString stringWithUTF8String: pw.pw_gecos];
         }
 #endif /* HAVE_PW_GECOS_IN_PASSWD */
 #else
@@ -2248,8 +2247,8 @@ NSTemporaryDirectory(void)
 #endif
 
   /*
-   * If the user has supplied a directory name in the TEMP or TMP
-   * environment variable, attempt to use that unless we already
+   * If the user has supplied a directory name in the TEMP, TMP or
+   * TMPDIR environment variable, attempt to use that unless we already
    * have a temporary directory specified.
    */
   if (baseTempDirName == nil)
@@ -2260,23 +2259,27 @@ NSTemporaryDirectory(void)
       if (baseTempDirName == nil)
 	{
 	  baseTempDirName = [env objectForKey: @"TMP"];
-	  if (baseTempDirName == nil)
-	    {
+	}
+      if (baseTempDirName == nil)
+	{
+	  baseTempDirName = [env objectForKey: @"TMPDIR"];
+	}
+      if (baseTempDirName == nil)
+	{
 #if	defined(__CYGWIN__)
 #warning Basing temporary directory in /cygdrive/c; any reason?
-	      baseTempDirName = @"/cygdrive/c/";
+	  baseTempDirName = @"/cygdrive/c/";
 #elif	defined(_WIN32)
-	      baseTempDirName = @"C:\\";
+	  baseTempDirName = @"C:\\";
 #elif   defined(__APPLE__)
-	      /*
-	       * Create temporary directory on /var/tmp since /tmp is
-	       * cleaned regularly on Darwin by default
-	       */
-	      baseTempDirName = @"/var/tmp";
+	  /*
+	   * Create temporary directory on /var/tmp since /tmp is
+	   * cleaned regularly on Darwin by default
+	   */
+	  baseTempDirName = @"/var/tmp";
 #else
-	      baseTempDirName = @"/tmp";
+	  baseTempDirName = @"/tmp";
 #endif
-	    }
 	}
     }
 


### PR DESCRIPTION
NSFullUserName dereferences pw.pw_gecos without testing it, and ignores the
result pointer from getpwnam_r. bionic sets pw_gecos to NULL, so the call
segfaults. The getpwnam branch below already tests the pointer, and the same
file uses the fuller test at around line 1991. Tests/base/Functions goes from a
crash after 1 test to 229 passed.

NSHomeDirectoryForUser used #elif for the Android branch, which left the POSIX
getpwnam_r fallback out of the build. androidFilesDir is nil in any process
without a JNI context, so a tool, a daemon or a test binary got nil back.
Android now tries its own answer first and falls through to the fallback,
which answers / on bionic.

NSTemporaryDirectory consults TEMP and TMP but not TMPDIR, which is the POSIX
name and the one Android sets. It fell back to /tmp, which does not exist
there, and the root is mounted read-only. The nesting is flattened rather than
deepened.

The first two sit on the general POSIX paths rather than in Android specific
code. Measured on Android x86_64: Tests/base/NSPathUtilities 164 passed and 0
failed, Tests/base/Functions 229 passed and 0 failed.
