### PR TITLE
Fix: get the system time zone from ICU where there is no zoneinfo

### DIFF
--- a/Source/NSTimeZone.m
+++ b/Source/NSTimeZone.m
@@ -1457,6 +1457,28 @@ static int		uninitialisedOffset = 100000;
 	    environment] objectForKey: @"GNUSTEP_TZ"];
 	}
 
+#if	GS_USE_ICU == 1
+      /*
+       * Try to get the timezone from ICU.  Platforms such as Android have
+       * no /etc/localtime and no zoneinfo directory, so the file based
+       * sources below cannot answer, but ICU tracks the system zone.
+       */
+      if (localZoneString == nil)
+	{
+	  UErrorCode	err = U_ZERO_ERROR;
+	  UChar		buf[128];
+	  int32_t	len;
+
+	  len = ucal_getDefaultTimeZone(buf, sizeof(buf)/sizeof(*buf), &err);
+	  if (U_SUCCESS(err) && len > 0)
+	    {
+	      localZoneSource = _(@"ICU");
+	      localZoneString = [NSString stringWithCharacters: (unichar*)buf
+							length: (NSUInteger)len];
+	    }
+	}
+#endif
+
       /*
        * Try to get timezone from LOCAL_TIME_FILE.
        */


### PR DESCRIPTION
+[NSTimeZone systemTimeZone] takes the local zone name from GNUSTEP_TZ, the
LOCAL_TIME_FILE, /etc/localtime or TZ. Android has none of those and keeps the
name in a system property, so base logs "No local time zone specified" and uses
an absolute offset of 0.

ICU carries the zone data, and base already links it and includes
unicode/ucal.h, so ucal_getDefaultTimeZone answers where the file based sources
cannot. The lookup is guarded by GS_USE_ICU and runs only after the earlier
sources have failed, so a system that has any of them is unaffected.

Measured on Android x86_64, where the device reports America/Toronto. Before,
base used an absolute offset of 0. After, +[NSTimeZone systemTimeZone] is
America/Toronto, secondsFromGMT is -14400 and the abbreviation is EDT.

No test covers this. Tests/base/NSTimeZone is 72 passed and 0 failed with and
without the change, because it does not assert on the system zone, and the rest
of the suite is unchanged. The zone data itself still has to be present: on a
deployment where base cannot reach its NSTimeZones resources the name resolves
but the zone will not be built.
