### PR TITLE
tests: mark three environment assumptions hopeful where they do not hold

### DIFF
--- a/Tests/base/NSData/additions.m
+++ b/Tests/base/NSData/additions.m
@@ -46,7 +46,13 @@ int main()
 
   data = [ref gzipped: 9];
   length = [data length];
+  /* zlib does not guarantee that a higher compression level produces a
+   * smaller result, and for this input it does not: level 5 gives 6068 bytes
+   * and level 9 gives 6089 with the zlib built for Android.
+   */
+  testHopeful = YES;
   PASS(length < last, "Compression 9 is smaller than 5");
+  testHopeful = NO;
   last = length;
   PASS_EQUAL([data gunzipped], ref, "gunzipped 9 matches reference");
 

--- a/Tests/base/NSString/tilde.m
+++ b/Tests/base/NSString/tilde.m
@@ -43,9 +43,19 @@ int main()
     "multiple slashes removed");
 #endif
 
+  /* The path is only left alone where it is outside the home directory.
+   * Android reports the home directory of a process with no JNI context as
+   * "/", and so does a POSIX account whose pw_dir is "/", and every absolute
+   * path is inside that.
+   */
+  if ([NSHomeDirectory() isEqual: @"/"] == YES)
+    {
+      testHopeful = YES;
+    }
   PASS_EQUAL([@"//////Documents///" stringByAbbreviatingWithTildeInPath],
     @"/Documents",
     "multiple slashes removed without tilde replacement");
+  testHopeful = NO;
 
   PASS_EQUAL([@".//////Documents///" stringByAbbreviatingWithTildeInPath],
     @"./Documents",

--- a/Tests/base/NSURL/basic.m
+++ b/Tests/base/NSURL/basic.m
@@ -151,10 +151,24 @@ int main()
   url = [NSURL fileURLWithPath: @"/usr"];
   str = [url path];
   PASS_EQUAL(str, @"/usr", "Path of file URL /usr is /usr");
+  /* The trailing slash is appended only for a path that exists and is a
+   * directory, so both of these need /usr to be one.  Android has no /usr.
+   */
+  {
+    BOOL	isDir = NO;
+
+    if ([[NSFileManager defaultManager] fileExistsAtPath: @"/usr"
+					     isDirectory: &isDir] == NO
+      || NO == isDir)
+      {
+	testHopeful = YES;
+      }
+  }
   PASS_EQUAL([url description], @"file:///usr/",
     "File URL /usr is file:///usr/");
   PASS_EQUAL([url resourceSpecifier], @"/usr/",
     "resourceSpecifier of /usr is /usr/");
+  testHopeful = NO;
 #endif
 
   PASS_EXCEPTION([[NSURL alloc] initFileURLWithPath: nil isDirectory: YES],


### PR DESCRIPTION
Three tests assert something about the machine they run on rather than about
gnustep-base, and fail where the assumption does not hold. They came up while
running the suite on Android, but none is Android specific.

NSData/additions.m asserts that gzip level 9 produces a smaller result than
level 5. zlib does not guarantee that. For the Lorum input it is false: 6068
bytes at level 5 against 6089 at level 9.

NSString/tilde.m asserts that an absolute path outside the home directory keeps
its leading slash. Where the home directory is "/", no absolute path is outside
it. That is any account whose pw_dir is "/", including root.

NSURL/basic.m asserts a trailing slash on the file URL for /usr. The slash is
appended only for a path that exists and is a directory.

Each is marked hopeful only where the assumption fails, so it still reports a
pass wherever it holds. The guards test for the condition, not the platform.

Measured on Linux before and after, unchanged: NSData 140 passed, NSString 2023
passed with 17 dashed hopes, NSURL 1725 passed, no failures.
