### PR TITLE
Fix: initialise a process with the environment it was started with

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2026-08-10 Todd White <todd.white@thalion.global>
+
+	* Source/NSProcessInfo.m:
+	* Tests/base/NSProcessInfo/initialise.m:
+	Use the process environment when a process is initialised without
+	one, and pass the environment given to
+	GSInitializeProcessAndroidWithArgs() on to the initialisation.
+
 2026-08-06 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Headers/GNUstepBase/NSData+GNUstepBase.h:

--- a/Source/NSProcessInfo.m
+++ b/Source/NSProcessInfo.m
@@ -415,6 +415,7 @@ _gnu_process_args(int argc, char *argv[], char *env[])
     NSMutableArray	*keys = [NSMutableArray new];
     NSMutableArray	*values = [NSMutableArray new];
     NSStringEncoding	enc = GSPrivateDefaultCStringEncoding();
+    BOOL		haveEnvironment = NO;
 
 #if defined(_WIN32)
     if (fallbackInitialisation == NO)
@@ -462,10 +463,26 @@ _gnu_process_args(int argc, char *argv[], char *env[])
 		  }
 	      }
 	    FreeEnvironmentStringsW(base);
+	    haveEnvironment = YES;
 	    env = 0;	// Suppress standard code.
 	  }
       }
 #endif
+    if (env == 0 && haveEnvironment == NO)
+      {
+	/* No environment was supplied, so we use the one the process was
+	 * started with rather than recording that it has none.
+	 */
+#if defined(_WIN32)
+	extern char	**_environ;
+
+	env = _environ;
+#else
+	extern char	**environ;
+
+	env = environ;
+#endif
+      }
     if (env != 0)
       {
 	i = 0;
@@ -1747,7 +1764,7 @@ GSInitializeProcessAndroidWithArgs(JNIEnv *env, jobject context, int argc, char 
   // initialize process
   [procLock lock];
   fallbackInitialisation = YES;
-  _gnu_process_args(argc, argv, NULL);
+  _gnu_process_args(argc, argv, envp);
   [procLock unlock];
 
   jclass contextCls = (*env)->GetObjectClass(env, context);

--- a/Source/NSProcessInfo.m
+++ b/Source/NSProcessInfo.m
@@ -415,10 +415,12 @@ _gnu_process_args(int argc, char *argv[], char *env[])
     NSMutableArray	*keys = [NSMutableArray new];
     NSMutableArray	*values = [NSMutableArray new];
     NSStringEncoding	enc = GSPrivateDefaultCStringEncoding();
-    BOOL		haveEnvironment = NO;
 
 #if defined(_WIN32)
-    if (fallbackInitialisation == NO)
+    /* Also used when the caller supplied no environment, so that a process
+     * initialised that way has the one it was started with.
+     */
+    if (fallbackInitialisation == NO || 0 == env)
       {
 	unichar	*base;
 
@@ -463,26 +465,20 @@ _gnu_process_args(int argc, char *argv[], char *env[])
 		  }
 	      }
 	    FreeEnvironmentStringsW(base);
-	    haveEnvironment = YES;
 	    env = 0;	// Suppress standard code.
 	  }
       }
-#endif
-    if (env == 0 && haveEnvironment == NO)
+#else
+    if (0 == env)
       {
 	/* No environment was supplied, so we use the one the process was
 	 * started with rather than recording that it has none.
 	 */
-#if defined(_WIN32)
-	extern char	**_environ;
-
-	env = _environ;
-#else
 	extern char	**environ;
 
 	env = environ;
-#endif
       }
+#endif
     if (env != 0)
       {
 	i = 0;

--- a/Tests/base/NSProcessInfo/initialise.m
+++ b/Tests/base/NSProcessInfo/initialise.m
@@ -1,0 +1,36 @@
+#import "Testing.h"
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSProcessInfo.h>
+#import <Foundation/NSString.h>
+
+#include <stdlib.h>
+
+/* GSInitializeProcess() is what a program uses when the library cannot pick
+ * the arguments up for itself, which is the case for a library loaded into a
+ * host that has its own main().  An Android activity is one such host.
+ */
+int main()
+{
+  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
+  NSString		*key = @"AN_UNUSUAL_ENVIRONMENT_KEY";
+  char			*argv[] = { (char *)"initialise", 0 };
+  NSDictionary		*env;
+
+  putenv((char *)"AN_UNUSUAL_ENVIRONMENT_KEY=hello");
+
+  GSInitializeProcess(1, argv, 0);
+
+  env = [[NSProcessInfo processInfo] environment];
+  PASS([env count] > 0,
+    "a process initialised without an environment has the one it started with")
+  PASS_EQUAL([env objectForKey: key], @"hello",
+    "and a variable set before initialisation is in it")
+
+  PASS_EQUAL([[NSProcessInfo processInfo] processName], @"initialise",
+    "the process name comes from the arguments supplied")
+
+  [arp release]; arp = nil;
+  return 0;
+}

--- a/Tests/base/NSProcessInfo/initialise.m
+++ b/Tests/base/NSProcessInfo/initialise.m
@@ -15,8 +15,16 @@ int main()
 {
   NSAutoreleasePool	*arp = [NSAutoreleasePool new];
   NSString		*key = @"AN_UNUSUAL_ENVIRONMENT_KEY";
-  char			*argv[] = { (char *)"initialise", 0 };
+  NSString		*executable;
+  char			*argv[2];
   NSDictionary		*env;
+
+  /* The zero'th argument has to be somewhere the executable can be found:
+   * the library works out its own location from it.
+   */
+  executable = [[[NSProcessInfo processInfo] arguments] objectAtIndex: 0];
+  argv[0] = (char *)[executable UTF8String];
+  argv[1] = 0;
 
   putenv((char *)"AN_UNUSUAL_ENVIRONMENT_KEY=hello");
 


### PR DESCRIPTION
A process initialised through GSInitializeProcess() or
GSInitializeProcessAndroidWithArgs() with no environment array gets an empty
environment dictionary, so [[NSProcessInfo processInfo] environment] is empty
and GNUSTEP_CONFIG_FILE, and everything else read from the environment, has no
effect. GSInitializeProcessAndroidWithArgs() also takes an envp argument and
then calls _gnu_process_args() with NULL, discarding it. An Android activity
has no main(), so that is how every GNUstep application on Android starts, and
such an application cannot be given a configuration file at all.

_gnu_process_args() now falls back to the process environment when it is given
none, and GSInitializeProcessAndroidWithArgs() passes on the envp it was called
with. On Windows the existing wide-character environment still takes
precedence.

Tests/base/NSProcessInfo/initialise.m

1 failed before, 0 after.
