### PR TITLE
Fix: do not loop forever looking for an executable with no PATH

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-08-10 Todd White <todd.white@thalion.global>
+
+	* Source/NSBundle.m:
+	* Tests/base/NSTask/nopath.m:
+	Do not loop forever looking for an executable when the environment
+	has no PATH.
+
 2026-08-06 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Headers/GNUstepBase/NSData+GNUstepBase.h:

--- a/Source/NSBundle.m
+++ b/Source/NSBundle.m
@@ -304,6 +304,15 @@ AbsolutePathOfExecutable(NSString *path, BOOL atLaunch, NSString **err)
       pathArray = [pathlist componentsSeparatedByString: @":"];
 #endif
       pathArray = AUTORELEASE([pathArray mutableCopy]);
+      if (nil == pathArray)
+	{
+	  /* Neither PATH nor Path is in the environment, so the only
+	   * directory to search is the one added below.  Without an array
+	   * here -indexOfObject: answers 0 rather than NSNotFound and the
+	   * loop removing '.' never ends.
+	   */
+	  pathArray = [NSMutableArray arrayWithCapacity: 1];
+	}
 
       /* The directory value '.' can be replaced by either the
        * path to the current directory or the launch directory

--- a/Tests/base/NSTask/nopath.m
+++ b/Tests/base/NSTask/nopath.m
@@ -1,0 +1,39 @@
+#import "Testing.h"
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSError.h>
+#import <Foundation/NSProcessInfo.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSTask.h>
+
+/* A launch path with no directory in it is looked up in PATH, and a process
+ * can be started with no PATH at all.
+ */
+int main()
+{
+  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
+  NSProcessInfo		*info = [NSProcessInfo processInfo];
+  NSTask		*task = AUTORELEASE([NSTask new]);
+  NSError		*err = nil;
+  BOOL			 launched;
+
+  if (NO == [info respondsToSelector: @selector(setValue:inEnvironment:)])
+    {
+      [arp release];
+      return 0;
+    }
+  [info setValue: nil inEnvironment: @"PATH"];
+  [info setValue: nil inEnvironment: @"Path"];
+  PASS_EQUAL([[info environment] objectForKey: @"PATH"], nil,
+    "PATH can be removed from the environment")
+
+  [task setLaunchPath: @"gnustep-a-program-which-is-not-installed"];
+  launched = [task launchAndReturnError: &err];
+  PASS(NO == launched,
+    "a program which is not on PATH does not launch when PATH is unset")
+  PASS(err != nil, "and the failure is reported")
+
+  [arp release]; arp = nil;
+  return 0;
+}


### PR DESCRIPTION
A program whose environment has no PATH hangs on its first use of
NSUserDefaults. AbsolutePathOfExecutable() in NSBundle.m reads PATH, and with
neither PATH nor Path set both componentsSeparatedByString: and mutableCopy are
sent to nil, so the path array is nil. indexOfObject: then answers 0 rather
than NSNotFound and the loop that removes "." from the array never ends.
UserDirsParseXDG() reaches it through NSTask while looking for xdg-user-dir, so
nothing has to launch a task for a program to hit this.

It reproduces on master with any test tool: env -i ./obj/general never returns,
and env -i PATH=/usr/bin:/bin ./obj/general passes.

The array is now created when there is no PATH, leaving the working directory
as the only place searched, which is what the code already adds.

Tests/base/NSTask/nopath.m

Before the change that test does not complete; after it, 3 assertions pass.
