### PR TITLE
Fix: end a key value change on the observers it began on

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2026-08-10 Todd White <todd.white@thalion.global>
+
+	* Source/NSKVOInternal.h:
+	* Source/NSKVOSupport.m:
+	* Tests/base/NSKVOSupport/changeset.m:
+	End a key value change on the observers it began on, rather than on
+	those registered when it ends.
+
 2026-08-06 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Headers/GNUstepBase/NSData+GNUstepBase.h:

--- a/Source/NSKVOInternal.h
+++ b/Source/NSKVOInternal.h
@@ -167,6 +167,7 @@
   NSInteger             _dependencyDepth;
   NSMutableSet          *_existingDependentKeys;
   NSMutableSet          *_dependencyAncestorKeys;
+  NSMutableArray        *_changeSets;
   gs_mutex_t            _lock;
   gs_mutex_t            _changeLock;
 }
@@ -174,6 +175,14 @@
 - (instancetype) init;
 - (BOOL) isEmpty;
 - (NSArray *) observersForKey: (NSString *)key;
+
+/* The key observers a willChange locked, kept until the matching didChange
+ * unlocks exactly those.  Registration may change while a change is in
+ * progress, so the set cannot be worked out a second time.  The change lock is
+ * held across the pair, so only the thread holding it uses this.
+ */
+- (void) pushChangeSet: (NSArray *)set;
+- (NSArray *) popChangeSet;
 
 /* Held from a willChange to the matching didChange.  The change depth and the
  * pending change of each key path observer are reachable from both, so a

--- a/Source/NSKVOInternal.h
+++ b/Source/NSKVOInternal.h
@@ -182,7 +182,8 @@
  * held across the pair, so only the thread holding it uses this.
  */
 - (void) pushChangeSet: (NSArray *)set;
-- (NSArray *) popChangeSet;
+- (NSArray *) currentChangeSet;
+- (void) popChangeSet;
 
 /* Held from a willChange to the matching didChange.  The change depth and the
  * pending change of each key path observer are reachable from both, so a

--- a/Source/NSKVOSupport.m
+++ b/Source/NSKVOSupport.m
@@ -315,22 +315,25 @@ static NSDictionary *_kvoSettingChange = nil;
     {
       _changeSets = [[NSMutableArray alloc] initWithCapacity: 2];
     }
-  [_changeSets addObject: set];
+  /* A key with no observers still needs an entry, so that the didChange pops
+   * what this willChange pushed. */
+  [_changeSets addObject: (nil == set) ? (NSArray *)[NSArray array] : set];
 }
 
-- (NSArray *) popChangeSet
+/* Borrowed: the stack holds it until -popChangeSet. */
+- (NSArray *) currentChangeSet
 {
-  NSArray	*set;
-  NSUInteger	last = [_changeSets count];
+  NSUInteger	count = [_changeSets count];
 
-  if (0 == last)
+  return (0 == count) ? nil : [_changeSets objectAtIndex: count - 1];
+}
+
+- (void) popChangeSet
+{
+  if ([_changeSets count] > 0)
     {
-      return nil;
+      [_changeSets removeLastObject];
     }
-  last--;
-  set = AUTORELEASE(RETAIN([_changeSets objectAtIndex: last]));
-  [_changeSets removeObjectAtIndex: last];
-  return set;
 }
 
 - (void) dealloc
@@ -1171,8 +1174,7 @@ _dispatchWillChange(_NSKVOObservationInfo *observationInfo,
                     id notifyingObject, NSString *key,
                     DispatchChangeFunction fn, void *changeContext)
 {
-  NSArray        *observers;
-  NSMutableArray *locked;
+  NSArray *observers;
 
   if (nil == observationInfo)
     {
@@ -1180,23 +1182,21 @@ _dispatchWillChange(_NSKVOObservationInfo *observationInfo,
     }
   [observationInfo lockChange];
   observers = [observationInfo observersForKey:key];
-  locked = [NSMutableArray arrayWithCapacity: [observers count]];
+  /* Held until the matching didChange, which locks and unlocks this same
+   * array.  Registering or removing an observer replaces the array rather
+   * than changing it, so what is locked here cannot be added to or taken
+   * away from before it is unlocked. */
+  [observationInfo pushChangeSet: observers];
   for (_NSKVOKeyObserver *keyObserver in observers)
     {
       _NSKVOKeypathObserver *keypathObserver;
 
-      if (keyObserver.isRemoved)
-        {
-          continue;
-        }
-
-      // Skip any keypaths that are in the process of changing.
+      /* Every observer in the array is locked, including one already marked
+       * removed, so that the didChange has the same set to unlock.  Whether
+       * there is work to do is a separate question, below. */
       keypathObserver = keyObserver.keypathObserver;
       [keypathObserver lockChange];
-      /* Recorded before anything below can register or remove an observer:
-       * _dispatchDidChange unlocks what is recorded here, not what it finds. */
-      [locked addObject: keyObserver];
-      if ([keypathObserver pushWillChange])
+      if ([keypathObserver pushWillChange] && !keyObserver.isRemoved)
         {
           NSKeyValueObservingOptions options;
 
@@ -1222,9 +1222,11 @@ _dispatchWillChange(_NSKVOObservationInfo *observationInfo,
         }
 
       // This must happen regardless of whether we are currently notifying.
-      _removeNestedObserversAndOptionallyDependents(keyObserver, false);
+      if (!keyObserver.isRemoved)
+        {
+          _removeNestedObserversAndOptionallyDependents(keyObserver, false);
+        }
     }
-  [observationInfo pushChangeSet: locked];
   /* The matching -unlockChange calls are in _dispatchDidChange. */
 }
 
@@ -1252,7 +1254,7 @@ _dispatchDidChange(_NSKVOObservationInfo *observationInfo,
   /* Exactly what _dispatchWillChange locked, so that an observer registered
    * or removed while the change was in progress cannot leave a key path
    * observer locked, or unlock one that was never locked. */
-  observers = [observationInfo popChangeSet];
+  observers = [observationInfo currentChangeSet];
   index = [observers count];
   if (index > sizeof(held) / sizeof(held[0]))
     {
@@ -1295,6 +1297,7 @@ _dispatchDidChange(_NSKVOObservationInfo *observationInfo,
         }
       [keypathObserver unlockChange];
     }
+  [observationInfo popChangeSet];
   [observationInfo unlockChange];
 
   for (index = 0; index < count; index++)

--- a/Source/NSKVOSupport.m
+++ b/Source/NSKVOSupport.m
@@ -309,6 +309,30 @@ static NSDictionary *_kvoSettingChange = nil;
   GS_MUTEX_UNLOCK(_changeLock);
 }
 
+- (void) pushChangeSet: (NSArray *)set
+{
+  if (nil == _changeSets)
+    {
+      _changeSets = [[NSMutableArray alloc] initWithCapacity: 2];
+    }
+  [_changeSets addObject: set];
+}
+
+- (NSArray *) popChangeSet
+{
+  NSArray	*set;
+  NSUInteger	last = [_changeSets count];
+
+  if (0 == last)
+    {
+      return nil;
+    }
+  last--;
+  set = AUTORELEASE(RETAIN([_changeSets objectAtIndex: last]));
+  [_changeSets removeObjectAtIndex: last];
+  return set;
+}
+
 - (void) dealloc
 {
   if (![self isEmpty])
@@ -333,6 +357,7 @@ static NSDictionary *_kvoSettingChange = nil;
     }
   [_keyObserverMap release];
   [_existingDependentKeys release];
+  [_changeSets release];
 
   GS_MUTEX_DESTROY(_lock);
   GS_MUTEX_DESTROY(_changeLock);
@@ -1146,7 +1171,8 @@ _dispatchWillChange(_NSKVOObservationInfo *observationInfo,
                     id notifyingObject, NSString *key,
                     DispatchChangeFunction fn, void *changeContext)
 {
-  NSArray *observers;
+  NSArray        *observers;
+  NSMutableArray *locked;
 
   if (nil == observationInfo)
     {
@@ -1154,6 +1180,7 @@ _dispatchWillChange(_NSKVOObservationInfo *observationInfo,
     }
   [observationInfo lockChange];
   observers = [observationInfo observersForKey:key];
+  locked = [NSMutableArray arrayWithCapacity: [observers count]];
   for (_NSKVOKeyObserver *keyObserver in observers)
     {
       _NSKVOKeypathObserver *keypathObserver;
@@ -1166,6 +1193,9 @@ _dispatchWillChange(_NSKVOObservationInfo *observationInfo,
       // Skip any keypaths that are in the process of changing.
       keypathObserver = keyObserver.keypathObserver;
       [keypathObserver lockChange];
+      /* Recorded before anything below can register or remove an observer:
+       * _dispatchDidChange unlocks what is recorded here, not what it finds. */
+      [locked addObject: keyObserver];
       if ([keypathObserver pushWillChange])
         {
           NSKeyValueObservingOptions options;
@@ -1194,6 +1224,7 @@ _dispatchWillChange(_NSKVOObservationInfo *observationInfo,
       // This must happen regardless of whether we are currently notifying.
       _removeNestedObserversAndOptionallyDependents(keyObserver, false);
     }
+  [observationInfo pushChangeSet: locked];
   /* The matching -unlockChange calls are in _dispatchDidChange. */
 }
 
@@ -1218,7 +1249,10 @@ _dispatchDidChange(_NSKVOObservationInfo *observationInfo,
     {
       return;
     }
-  observers = [observationInfo observersForKey:key];
+  /* Exactly what _dispatchWillChange locked, so that an observer registered
+   * or removed while the change was in progress cannot leave a key path
+   * observer locked, or unlock one that was never locked. */
+  observers = [observationInfo popChangeSet];
   index = [observers count];
   if (index > sizeof(held) / sizeof(held[0]))
     {
@@ -1230,18 +1264,18 @@ _dispatchDidChange(_NSKVOObservationInfo *observationInfo,
     {
       _NSKVOKeyObserver     *keyObserver = [observers objectAtIndex: index];
       _NSKVOKeypathObserver *keypathObserver;
+      BOOL                   removed = keyObserver.isRemoved;
 
-      if (keyObserver.isRemoved)
+      if (!removed)
         {
-          continue;
+          // This must happen regardless of whether we are currently notifying.
+          _addNestedObserversAndOptionallyDependents(keyObserver, false);
         }
 
-      // This must happen regardless of whether we are currently notifying.
-      _addNestedObserversAndOptionallyDependents(keyObserver, false);
-
-      // Skip any keypaths that are in the process of changing.
+      /* The change depth is popped even for an observer removed during the
+       * change, because the willChange pushed it. */
       keypathObserver = keyObserver.keypathObserver;
-      if ([keypathObserver popDidChange])
+      if ([keypathObserver popDidChange] && !removed)
         {
           // Call into the change function, which does set-up for finalizing
           // the changes dictionary

--- a/Tests/base/NSKVOSupport/changeset.m
+++ b/Tests/base/NSKVOSupport/changeset.m
@@ -1,0 +1,161 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSKeyValueObserving.h>
+#import <Foundation/NSString.h>
+
+/* An observer may be registered or removed from inside a notification, and a
+ * prior notification is delivered while the change is in progress.  What is
+ * registered at the end of a change has to be what receives the next one.
+ */
+
+@interface Subject : NSObject
+{
+  int _value;
+  int _other;
+}
+@end
+
+@implementation Subject
+- (int) value { return _value; }
+- (void) setValue: (int)v { _value = v; }
+- (int) other { return _other; }
+- (void) setOther: (int)v { _other = v; }
+@end
+
+@interface Counter : NSObject
+{
+@public
+  int count;
+}
+@end
+
+@implementation Counter
+- (void) observeValueForKeyPath: (NSString *)keyPath
+		       ofObject: (id)object
+			 change: (NSDictionary *)change
+			context: (void *)context
+{
+  count++;
+}
+@end
+
+/* Registers or removes another observer while a change is in progress. */
+@interface Meddler : NSObject
+{
+@public
+  Subject  *subject;
+  Counter  *other;
+  NSString *key;
+  BOOL	    removes;
+  BOOL	    done;
+  int	    count;
+}
+@end
+
+@implementation Meddler
+- (void) observeValueForKeyPath: (NSString *)keyPath
+		       ofObject: (id)object
+			 change: (NSDictionary *)change
+			context: (void *)context
+{
+  count++;
+  if (done
+    || nil == [change objectForKey: NSKeyValueChangeNotificationIsPriorKey])
+    {
+      return;
+    }
+  done = YES;
+  if (removes)
+    {
+      [subject removeObserver: other forKeyPath: key];
+    }
+  else
+    {
+      [subject addObserver: other
+		forKeyPath: key
+		   options: NSKeyValueObservingOptionNew
+		   context: NULL];
+    }
+}
+@end
+
+int main()
+{
+  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
+  Subject		*subject;
+  Counter		*counter;
+  Meddler		*meddler;
+
+  /* Registered while the change is in progress. */
+  subject = AUTORELEASE([Subject new]);
+  counter = AUTORELEASE([Counter new]);
+  meddler = AUTORELEASE([Meddler new]);
+  meddler->subject = subject;
+  meddler->other = counter;
+  meddler->key = @"value";
+  meddler->removes = NO;
+  [subject addObserver: meddler
+	    forKeyPath: @"value"
+	       options: NSKeyValueObservingOptionNew
+		       | NSKeyValueObservingOptionPrior
+	       context: NULL];
+  [subject setValue: 1];
+  [subject setValue: 2];
+  PASS(counter->count > 0,
+    "an observer registered during a change is sent a later change")
+  [subject setValue: 3];
+  PASS(counter->count > 1,
+    "and every change after that one as well")
+  [subject removeObserver: meddler forKeyPath: @"value"];
+  [subject removeObserver: counter forKeyPath: @"value"];
+
+  /* Removed while the change is in progress.  The victim is registered first
+   * so that the change reaches it before the observer which removes it. */
+  subject = AUTORELEASE([Subject new]);
+  counter = AUTORELEASE([Counter new]);
+  meddler = AUTORELEASE([Meddler new]);
+  meddler->subject = subject;
+  meddler->other = counter;
+  meddler->key = @"value";
+  meddler->removes = YES;
+  [subject addObserver: counter
+	    forKeyPath: @"value"
+	       options: NSKeyValueObservingOptionNew
+	       context: NULL];
+  [subject addObserver: meddler
+	    forKeyPath: @"value"
+	       options: NSKeyValueObservingOptionNew
+		       | NSKeyValueObservingOptionPrior
+	       context: NULL];
+  [subject setValue: 1];
+  [subject setValue: 2];
+  PASS(0 == counter->count,
+    "an observer removed during a change is sent nothing")
+  PASS(meddler->count > 2,
+    "and the observer which removed it keeps receiving changes")
+  [subject removeObserver: meddler forKeyPath: @"value"];
+
+  /* A key other than the one being changed is unaffected. */
+  subject = AUTORELEASE([Subject new]);
+  counter = AUTORELEASE([Counter new]);
+  meddler = AUTORELEASE([Meddler new]);
+  meddler->subject = subject;
+  meddler->other = counter;
+  meddler->key = @"other";
+  meddler->removes = NO;
+  [subject addObserver: meddler
+	    forKeyPath: @"value"
+	       options: NSKeyValueObservingOptionNew
+		       | NSKeyValueObservingOptionPrior
+	       context: NULL];
+  [subject setValue: 1];
+  [subject setOther: 1];
+  PASS(counter->count > 0,
+    "an observer registered for another key during a change is sent its own")
+  [subject removeObserver: meddler forKeyPath: @"value"];
+  [subject removeObserver: counter forKeyPath: @"other"];
+
+  [arp release]; arp = nil;
+  return 0;
+}


### PR DESCRIPTION
_dispatchWillChange and _dispatchDidChange each called -observersForKey: and
filtered on isRemoved, so each decided for itself which key path observers to
act on. Registering or removing an observer while a change is in progress,
which a prior notification makes easy, puts those decisions out of step. The
did phase then runs -popDidChange on a key path observer that was never
pushed, leaving its change depth at -1 so that -pushWillChange never returns
YES again and that observer receives nothing further, and a key path observer
locked by the will phase stays locked when the did phase no longer finds it.

The will phase now records the key observers it locked and the did phase ends
exactly those, so the pairing no longer depends on registration holding still.
An observer removed during a change still receives nothing, but its change
depth is popped and its lock released.

Tests/base/NSKVOSupport/changeset.m

3 failed before, 0 after.
