### PR TITLE
CI: install findutils in the Rocky Linux containers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ env:
   RPM_PACKAGES: >-
     which
     gzip
+    findutils
     git
     cmake
     clang


### PR DESCRIPTION
The Rocky Linux 8 job has been passing without running a single test. The rockylinux:8 image does not ship findutils, so gnustep-tests cannot run find(1) to build its list of test directories. The list comes back empty, gnustep-tests prints "No tests found" and exits 0. Every run inside GitHub's 90 day log retention shows this. rockylinux:9 ships find, which is why only the Rocky Linux 8 job is affected.

findutils is added to RPM_PACKAGES.

Once the tests run, the job reports 2 failed assertions, both at Tests/base/NSURLSession/uploadTaskTests.m:68, where the request body received by the test server does not match the body that was sent. Rocky Linux 9 runs the same set green, so the failure is specific to Rocky Linux 8. It is not caused by this change, but this change does make the job red until it is resolved.

Proven on a branch that cuts the matrix down to the Rocky Linux 8 job alone: https://github.com/DTW-Thalion/libs-base/actions/runs/31408302809

0 tests ran before. 115 directories and 13475 assertions after, with the 2 failures named above.
