### PR TITLE
CI: build the library in parallel on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -369,7 +369,7 @@ jobs:
             CONFIGURE_OPTS="$CONFIGURE_OPTS --host=$HOST"
           fi
           ./configure $CONFIGURE_OPTS
-          make && make install
+          make -j$(nproc) && make install
 
       - name: Run tests
         continue-on-error: ${{ matrix.allow-test-failures || false }}


### PR DESCRIPTION
The Windows library build is serial. Every other platform builds in parallel: the Linux jobs use make -j$(nproc), NetBSD uses gmake -j"$(sysctl -n hw.ncpu)" and the GCC 4.9 job uses make -j$(nproc). The Windows step has been plain make since the matrix was added in 2021, and it accounts for 4.8 to 8.4 minutes of each of the 4 Windows jobs.

The step becomes make -j$(nproc) && make install. nproc is /usr/bin/nproc in the MSYS2 environment of all 4 Windows configurations and reports 4 processors on windows-2025 and on windows-11-arm. gnustep-tests already builds each test directory with make -j 4 on Windows, so parallel make is relied on there already.

Measured on a branch running only the Windows x64 MinGW GCC job, against that same job on master the same day: https://github.com/DTW-Thalion/libs-base/actions/runs/31410455391

Build source took 7.6 minutes before and 4.2 after. 13182 assertions passed before and 13190 after, with 0 failures either way. The test phase moved from 19.4 to 20.7 minutes, which is runner variance rather than an effect of this change.
