### PR TITLE
CI: cancel a run that a newer push has superseded

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   android:
     strategy:

--- a/.github/workflows/gcc-4.9.yml
+++ b/.github/workflows/gcc-4.9.yml
@@ -8,6 +8,10 @@ permissions:
   contents: read
   packages: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,10 @@ on:
         description: "tools-windows-msvc branch (leave empty to use latest pre-built release)"
         required: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   APT_PACKAGES: >-
     git

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   netbsd:
     name: ${{ matrix.name }}


### PR DESCRIPTION
CI runs on commits that a newer push has already replaced. Of the last 192 push runs of this workflow on master, 80 were superseded before they finished, at a median of 5.5 minutes in with 34.9 minutes still to run. Across all 640 jobs of those runs, 11355 runner minutes were spent and 7266 of them ran after supersession. 6560 of those wasted minutes belong to the 4 Windows jobs.

Each workflow gets a concurrency group keyed on the workflow and the ref, so a run still in progress is cancelled when a newer push to the same ref starts one.

On master this means a superseded commit is no longer tested on its own. 42 of the 79 superseded runs were merges of a pull request that had already had a full run of its own; the rest were direct pushes. Restricting cancel-in-progress to pull requests leaves master untouched, but only 1 of the last 200 pull request runs was superseded, so that saves almost nothing.

7266 runner minutes over 90 days of master pushes, out of 28224.
