### PR TITLE
Fix: read a whole request in the test HTTP server

### DIFF
--- a/Tests/base/NSURLSession/Helpers/HTTPServer.m
+++ b/Tests/base/NSURLSession/Helpers/HTTPServer.m
@@ -60,6 +60,53 @@ NSString (ServerAdditions)
 }
 @end
 
+/* The length of the complete request at the front of data, or 0 when the whole
+ * request has not arrived yet.  A request is complete once the blank line
+ * ending the headers has been read along with as many body bytes as
+ * Content-Length asks for.  A request without Content-Length has no body.
+ */
+static NSUInteger
+requestLength(NSData *data)
+{
+  NSRange            end;
+  NSString          *headers;
+  NSUInteger         bodyStart;
+  __block NSUInteger contentLength = 0;
+
+  end = [data rangeOfData:[NSData dataWithBytes:"\r\n\r\n" length:4]
+                  options:0
+                    range:NSMakeRange(0, [data length])];
+  if (NSNotFound == end.location)
+    {
+      return 0;
+    }
+  bodyStart = NSMaxRange(end);
+
+  headers = [[NSString alloc]
+    initWithData:[data subdataWithRange:NSMakeRange(0, end.location)]
+        encoding:NSASCIIStringEncoding];
+  [headers enumerateLinesUsingBlock2:^(NSString  *line,
+                                       NSUInteger lineEndIndex, BOOL *stop) {
+    NSRange range = [line rangeOfString:@":"];
+
+    if (NSNotFound != range.location
+        && NSOrderedSame == [[line substringToIndex:range.location]
+             caseInsensitiveCompare:@"Content-Length"])
+      {
+        contentLength = (NSUInteger)
+          [[line substringFromIndex:range.location + 1] integerValue];
+        *stop = YES;
+      }
+  }];
+
+  if ([data length] < bodyStart + contentLength)
+    {
+      return 0;
+    }
+
+  return bodyStart + contentLength;
+}
+
 @implementation Route
 {
   NSString           *_method;
@@ -225,7 +272,8 @@ NSString (ServerAdditions)
  * until the peer closes or an error occurs. */
 - (void) handleClientSocket: (NSNumber *)clientSocketNumber
 {
-  int clientSocket = [clientSocketNumber intValue];
+  int            clientSocket = [clientSocketNumber intValue];
+  NSMutableData *pending = [NSMutableData data];
 
   while (!_stop)
     {
@@ -238,8 +286,25 @@ NSString (ServerAdditions)
 
           if (bytesRead > 0)
             {
-              NSData *data = [NSData dataWithBytes: buffer length: bytesRead];
-              [self handleConnectionData: data forSocket: clientSocket];
+              NSUInteger length;
+
+              [pending appendBytes: buffer length: bytesRead];
+
+              /* One read is not one request.  The peer may send the headers
+               * and the body in separate segments, and a body larger than the
+               * buffer above always arrives in more than one read, so pass a
+               * request to the routes only once all of its body is here.
+               */
+              while ((length = requestLength(pending)) > 0)
+                {
+                  NSData *data;
+
+                  data = [pending subdataWithRange: NSMakeRange(0, length)];
+                  [self handleConnectionData: data forSocket: clientSocket];
+                  [pending replaceBytesInRange: NSMakeRange(0, length)
+                                     withBytes: NULL
+                                        length: 0];
+                }
             }
           else
             {

--- a/Tests/base/NSURLSession/Resources/largeBody.txt
+++ b/Tests/base/NSURLSession/Resources/largeBody.txt
@@ -52,3 +52,111 @@ Etiam ante lacus, aliquam id sem non, ullamcorper interdum libero. Sed fringilla
 dui sed est vehicula, vitae sollicitudin mauris tristique. Praesent ut arcu ut
 neque sollicitudin finibus. Vestibulum lacus risus, egestas vel lorem eget,
 pellentesque scelerisque lectus.
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas volutpat justo
+in aliquet venenatis. Aliquam eu odio volutpat, euismod turpis a, accumsan leo.
+Aliquam mauris urna, dictum a ex vel, fermentum faucibus enim. Donec eu massa
+ipsum. Vestibulum diam metus, dictum mattis urna vel, dignissim pretium magna.
+Phasellus quis mattis felis. Morbi non dapibus nunc. Fusce id ligula fringilla,
+varius tortor et, vulputate arcu. Quisque justo dolor, bibendum et imperdiet
+ultricies, posuere vel elit. Aliquam vel risus et sapien malesuada tempor.
+Aenean lorem metus, rutrum ut massa non, ultrices tincidunt neque. Nullam
+viverra rhoncus sem et convallis.
+
+Sed id ligula non mauris lacinia mattis. Donec commodo tortor sed aliquet
+commodo. Curabitur auctor, nibh eu dignissim gravida, lacus eros tincidunt
+metus, ac fermentum mauris ex vitae magna. Vestibulum sed egestas elit, eu
+placerat enim. Vivamus ullamcorper sollicitudin ullamcorper. Mauris consequat
+quam et purus malesuada, quis euismod nisl scelerisque. Sed vestibulum dictum
+nisi a viverra. Ut rutrum aliquam porta. Pellentesque est augue, ullamcorper vel
+ultricies quis, posuere non turpis. Aenean suscipit nulla massa, vel venenatis
+felis molestie ut. Morbi in lorem quam. Quisque sed facilisis neque, et mattis
+ligula. Nam non placerat odio, ac sollicitudin dolor. Donec elit neque, rhoncus
+at risus fermentum, ultrices hendrerit massa. Nulla volutpat, urna id molestie
+scelerisque, ligula est laoreet mauris, eget maximus leo purus id mi.
+
+Aenean arcu metus, ornare eget est sit amet, vehicula accumsan enim. Morbi ante
+diam, faucibus nec tempus molestie, vulputate auctor massa. Curabitur posuere
+iaculis pulvinar. Fusce id ligula at justo iaculis accumsan eu sed velit.
+Quisque condimentum augue non lobortis finibus. In quis interdum ligula, a
+varius ex. Vestibulum tristique orci eget velit lacinia, at lacinia lorem
+pretium. Sed ut varius mi. Vivamus elementum luctus arcu, vitae porta felis
+cursus nec.
+
+Etiam sed nisl eu nulla scelerisque fermentum. Praesent blandit eros at lacus
+blandit auctor. Sed in eros sapien. Quisque ac laoreet nisi, a fringilla nunc.
+Sed auctor eros non mauris elementum vestibulum. Aenean vel urna orci.
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia
+curae; In sed blandit nibh. Aenean condimentum, lorem a tincidunt consequat,
+nulla nulla ornare lorem, eu cursus sapien mi aliquam arcu. Duis porttitor mi et
+ultricies porta. Donec tempus posuere lorem sit amet tincidunt. Nam nec purus
+sit amet sem accumsan consectetur. Ut a nisl volutpat, egestas diam non, feugiat
+mi.
+
+Cras sed risus eget ligula tincidunt luctus. Vestibulum ut sapien dictum,
+sagittis elit vel, semper diam. Curabitur tristique ullamcorper lacus, quis
+finibus ex rutrum vel. Phasellus non blandit nisl, id tincidunt augue. Integer
+commodo metus at augue fringilla, sit amet posuere lectus iaculis. In nunc
+lacus, pulvinar scelerisque faucibus ut, fermentum ac ante. Duis in ante
+faucibus, ullamcorper est vel, convallis lacus. Nulla fermentum, nisi eget
+sollicitudin sodales, augue felis gravida est, id luctus sem augue non turpis.
+Sed a lorem vel diam maximus malesuada ut ut leo. Fusce venenatis, tellus a
+scelerisque dictum, metus elit vehicula purus, id gravida libero libero vitae
+arcu. Curabitur a cursus metus. Aenean efficitur rhoncus ante vitae imperdiet.
+Etiam ante lacus, aliquam id sem non, ullamcorper interdum libero. Sed fringilla
+dui sed est vehicula, vitae sollicitudin mauris tristique. Praesent ut arcu ut
+neque sollicitudin finibus. Vestibulum lacus risus, egestas vel lorem eget,
+pellentesque scelerisque lectus.
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas volutpat justo
+in aliquet venenatis. Aliquam eu odio volutpat, euismod turpis a, accumsan leo.
+Aliquam mauris urna, dictum a ex vel, fermentum faucibus enim. Donec eu massa
+ipsum. Vestibulum diam metus, dictum mattis urna vel, dignissim pretium magna.
+Phasellus quis mattis felis. Morbi non dapibus nunc. Fusce id ligula fringilla,
+varius tortor et, vulputate arcu. Quisque justo dolor, bibendum et imperdiet
+ultricies, posuere vel elit. Aliquam vel risus et sapien malesuada tempor.
+Aenean lorem metus, rutrum ut massa non, ultrices tincidunt neque. Nullam
+viverra rhoncus sem et convallis.
+
+Sed id ligula non mauris lacinia mattis. Donec commodo tortor sed aliquet
+commodo. Curabitur auctor, nibh eu dignissim gravida, lacus eros tincidunt
+metus, ac fermentum mauris ex vitae magna. Vestibulum sed egestas elit, eu
+placerat enim. Vivamus ullamcorper sollicitudin ullamcorper. Mauris consequat
+quam et purus malesuada, quis euismod nisl scelerisque. Sed vestibulum dictum
+nisi a viverra. Ut rutrum aliquam porta. Pellentesque est augue, ullamcorper vel
+ultricies quis, posuere non turpis. Aenean suscipit nulla massa, vel venenatis
+felis molestie ut. Morbi in lorem quam. Quisque sed facilisis neque, et mattis
+ligula. Nam non placerat odio, ac sollicitudin dolor. Donec elit neque, rhoncus
+at risus fermentum, ultrices hendrerit massa. Nulla volutpat, urna id molestie
+scelerisque, ligula est laoreet mauris, eget maximus leo purus id mi.
+
+Aenean arcu metus, ornare eget est sit amet, vehicula accumsan enim. Morbi ante
+diam, faucibus nec tempus molestie, vulputate auctor massa. Curabitur posuere
+iaculis pulvinar. Fusce id ligula at justo iaculis accumsan eu sed velit.
+Quisque condimentum augue non lobortis finibus. In quis interdum ligula, a
+varius ex. Vestibulum tristique orci eget velit lacinia, at lacinia lorem
+pretium. Sed ut varius mi. Vivamus elementum luctus arcu, vitae porta felis
+cursus nec.
+
+Etiam sed nisl eu nulla scelerisque fermentum. Praesent blandit eros at lacus
+blandit auctor. Sed in eros sapien. Quisque ac laoreet nisi, a fringilla nunc.
+Sed auctor eros non mauris elementum vestibulum. Aenean vel urna orci.
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia
+curae; In sed blandit nibh. Aenean condimentum, lorem a tincidunt consequat,
+nulla nulla ornare lorem, eu cursus sapien mi aliquam arcu. Duis porttitor mi et
+ultricies porta. Donec tempus posuere lorem sit amet tincidunt. Nam nec purus
+sit amet sem accumsan consectetur. Ut a nisl volutpat, egestas diam non, feugiat
+mi.
+
+Cras sed risus eget ligula tincidunt luctus. Vestibulum ut sapien dictum,
+sagittis elit vel, semper diam. Curabitur tristique ullamcorper lacus, quis
+finibus ex rutrum vel. Phasellus non blandit nisl, id tincidunt augue. Integer
+commodo metus at augue fringilla, sit amet posuere lectus iaculis. In nunc
+lacus, pulvinar scelerisque faucibus ut, fermentum ac ante. Duis in ante
+faucibus, ullamcorper est vel, convallis lacus. Nulla fermentum, nisi eget
+sollicitudin sodales, augue felis gravida est, id luctus sem augue non turpis.
+Sed a lorem vel diam maximus malesuada ut ut leo. Fusce venenatis, tellus a
+scelerisque dictum, metus elit vehicula purus, id gravida libero libero vitae
+arcu. Curabitur a cursus metus. Aenean efficitur rhoncus ante vitae imperdiet.
+Etiam ante lacus, aliquam id sem non, ullamcorper interdum libero. Sed fringilla
+dui sed est vehicula, vitae sollicitudin mauris tristique. Praesent ut arcu ut
+neque sollicitudin finibus. Vestibulum lacus risus, egestas vel lorem eget,
+pellentesque scelerisque lectus.


### PR DESCRIPTION
The HTTP server the NSURLSession tests run against treats one read as one request. handleClientSocket: passes the bytes of a single 4096 byte recv() to handleConnectionData:forSocket:, which takes everything after the blank line as the body without consulting Content-Length. Whether the body is complete therefore depends on how the sender happens to segment the request, and a body larger than the buffer can never be complete. Resources/largeBody.txt is 3642 bytes, so the large upload case fitted in one read on most platforms and failed on Rocky Linux 8, where uploadTaskTests.m:68 reported that HTTPBody did not match what was sent.

handleClientSocket: now accumulates what it reads and hands a request to the routes only once the headers and Content-Length bytes of body have arrived, consuming exactly that much of the buffer so a reused connection still works. largeBody.txt grows to 10926 bytes, which is larger than one read, so the case is exercised everywhere rather than by accident.

Tests/base/NSURLSession/uploadTaskTests.m:68, reached twice through /largeUploadOK.

With the larger fixture and the old server, 2 assertions failed. With the fix, 0 failed and the set went from 115 to 117 passed.
