### PR TITLE
Android: start a packaged tool from the directory it is installed in

### DIFF
--- a/Source/Additions/NSTask+GNUstepBase.m
+++ b/Source/Additions/NSTask+GNUstepBase.m
@@ -181,6 +181,24 @@ executablePath(NSFileManager *mgr, NSString *path)
     {
       return path;
     }
+#if	defined(__ANDROID__)
+  /* A package may carry an executable file only as lib/<abi>/lib<name>.so, so
+   * a tool installed from one is named lib<name>.so rather than <name>.  A
+   * tool built and installed outside a package keeps its own name and is found
+   * above.
+   */
+  {
+    NSString	*dir = [path stringByDeletingLastPathComponent];
+    NSString	*name = [path lastPathComponent];
+
+    path = [dir stringByAppendingPathComponent:
+      [NSString stringWithFormat: @"lib%@.so", name]];
+    if ([mgr isExecutableFileAtPath: path])
+      {
+	return path;
+      }
+  }
+#endif
 #endif
   return nil;
 }

--- a/Source/GSPrivate.h
+++ b/Source/GSPrivate.h
@@ -568,6 +568,16 @@ GSPrivateStrExternalize(GSStr s) GS_ATTRIB_PRIVATE;
 NSString *
 GSPrivateSymbolPath(Class theClass) GS_ATTRIB_PRIVATE;
 
+#if	defined(__ANDROID__)
+/* GSPrivateAndroidToolsDirectory() returns the directory this library was
+ * loaded from, which on Android is the directory a package's executable files
+ * are installed into and the only directory a tool may be started from.
+ * Returns nil where the library's own location cannot be determined.
+ */
+NSString *
+GSPrivateAndroidToolsDirectory(void) GS_ATTRIB_PRIVATE;
+#endif
+
 /* Combining class for composite unichars
  */
 unsigned char

--- a/Source/NSPathUtilities.m
+++ b/Source/NSPathUtilities.m
@@ -858,7 +858,27 @@ ExtractValuesFromConfig(NSDictionary *config)
     @GNUSTEP_TARGET_NETWORK_USERS_DIR);
   ASSIGN_DEFAULT_PATH(gnustepLocalUsersDir,
     @GNUSTEP_TARGET_LOCAL_USERS_DIR);
+
 }
+
+#if	defined(__ANDROID__)
+NSString *
+GSPrivateAndroidToolsDirectory(void)
+{
+  static NSString	*dir = nil;
+
+  if (nil == dir)
+    {
+      NSString	*path = GSPrivateSymbolPath([NSProcessInfo class]);
+
+      if ([path length] > 0)
+	{
+	  dir = [[path stringByDeletingLastPathComponent] copy];
+	}
+    }
+  return dir;
+}
+#endif
 
 static void
 addDefaults(NSString *defs, NSMutableDictionary *conf)
@@ -2958,6 +2978,21 @@ L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\GNUstep",
 		}
 	    }
 
+#if	defined(__ANDROID__)
+	  /* Android mounts the directory an application may write with the
+	   * noexec option, and installs the executable files a package carries
+	   * into a directory of its own whose name is settled when the package
+	   * is installed.  A layout cannot name that directory, so it is added
+	   * here: it is the directory this library was loaded from.  It comes
+	   * first because a file of the same name below it is on the writable
+	   * directory and cannot be started.  The directories below are kept,
+	   * because a tool built and installed outside a package is in one of
+	   * them.
+	   */
+	  ADD_PLATFORM_PATH(NSSystemDomainMask,
+	    GSPrivateAndroidToolsDirectory());
+#endif
+
 	  ADD_PLATFORM_PATH(NSUserDomainMask, gnustepUserTools);
 	  if (full)
 	    ADD_PATH(NSUserDomainMask, gnustepUserTools, full);
@@ -2999,6 +3034,11 @@ L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\GNUstep",
 		  full = [part stringByAppendingPathComponent: library_combo];
 		}
 	    }
+
+#if	defined(__ANDROID__)
+	  ADD_PLATFORM_PATH(NSSystemDomainMask,
+	    GSPrivateAndroidToolsDirectory());
+#endif
 
 	  ADD_PLATFORM_PATH(NSUserDomainMask, gnustepUserAdminTools);
 	  if (full)

--- a/Source/NSProcessInfo.m
+++ b/Source/NSProcessInfo.m
@@ -1797,9 +1797,41 @@ GSInitializeProcessAndroidWithArgs(JNIEnv *env, jobject context, int argc, char 
   GS_JNI_CHECK(env, assetManagerJava);
   [NSBundle setJavaAssetManager:assetManagerJava withJNIEnv:env];
 
+  // a process started with execve gets the platform's default linker search
+  // path, which does not include the directory the package's own libraries
+  // are in, so a tool started from here is given it
+  {
+    NSProcessInfo	*info = [NSProcessInfo processInfo];
+    NSString		*dir = GSPrivateAndroidToolsDirectory();
+    NSString		*existing;
+
+    existing = [[info environment] objectForKey: @"LD_LIBRARY_PATH"];
+    if ([dir length] > 0)
+      {
+	if ([existing length] > 0)
+	  {
+	    dir = [NSString stringWithFormat: @"%@:%@", dir, existing];
+	  }
+	[info setValue: dir inEnvironment: @"LD_LIBRARY_PATH"];
+      }
+  }
+
   // clean up our NSTemporaryDirectory() if it exists
   NSString *tempDirName = [_androidCacheDir stringByAppendingPathComponent: @"tmp"];
   [[NSFileManager defaultManager] removeItemAtPath:tempDirName error:NULL];
+
+  // a tool started from here has no context of its own, so it would take its
+  // temporary directory from the environment and use a different one; ports
+  // are named within that directory, so the two would never meet
+  {
+    NSProcessInfo	*info = [NSProcessInfo processInfo];
+    NSString		*tmp = NSTemporaryDirectory();
+
+    if ([tmp length] > 0)
+      {
+	[info setValue: tmp inEnvironment: @"TMPDIR"];
+      }
+  }
 }
 #endif
 

--- a/Tests/base/NSPathUtilities/toolsdirectory.m
+++ b/Tests/base/NSPathUtilities/toolsdirectory.m
@@ -1,0 +1,40 @@
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+
+int main()
+{
+  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
+  NSArray		*dirs;
+
+  dirs = NSSearchPathForDirectoriesInDomains(GSToolsDirectory,
+    NSAllDomainsMask, YES);
+  PASS([dirs count] > 0, "there is at least one tools directory");
+
+#ifdef __ANDROID__
+  {
+    NSFileManager	*mgr = [NSFileManager defaultManager];
+    NSEnumerator	*e = [dirs objectEnumerator];
+    NSString		*dir;
+    BOOL		 found = NO;
+
+    /* Every tools directory is the one the library itself was loaded from,
+     * because that is the only directory a tool can be started from.
+     */
+    while (nil != (dir = [e nextObject]))
+      {
+	NSString	*lib;
+
+	lib = [dir stringByAppendingPathComponent: @"libgnustep-base.so"];
+	if ([mgr isReadableFileAtPath: lib])
+	  {
+	    found = YES;
+	  }
+      }
+    PASS(found == YES,
+      "a tools directory holds the gnustep-base library");
+  }
+#endif
+
+  [arp release];
+  return 0;
+}

--- a/Tests/base/NSTask/toolpath.m
+++ b/Tests/base/NSTask/toolpath.m
@@ -1,0 +1,38 @@
+#import <Foundation/Foundation.h>
+#import <GNUstepBase/NSTask+GNUstepBase.h>
+#import "Testing.h"
+
+int main()
+{
+  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
+  NSString		*path;
+
+  path = [NSTask launchPathForTool: @"this-tool-does-not-exist"];
+  PASS(path == nil, "launchPathForTool: answers nil for an unknown tool");
+
+  /* A test binary has no JNI context on Android, so the package directory
+   * contributes nothing and the tool directories answer, as on every other
+   * platform.
+   */
+  path = [NSTask launchPathForTool: @"gdnc"];
+  if (nil == path)
+    {
+      testHopeful = YES;
+      PASS(NO, "gdnc is installed and found");
+      testHopeful = NO;
+    }
+  else
+    {
+      /* Windows carries an extension: the answer there is gdnc.EXE, or any
+       * other of +[NSTask executableExtensions].
+       */
+      PASS([[[path lastPathComponent] stringByDeletingPathExtension]
+	isEqual: @"gdnc"],
+	"launchPathForTool: answers a path ending in the tool name");
+      PASS([[NSFileManager defaultManager] isExecutableFileAtPath: path],
+	"the path it answers is executable");
+    }
+
+  [arp release];
+  return 0;
+}


### PR DESCRIPTION
An application cannot start gdnc, gpbs or any other tool on Android.
+[NSTask launchPathForTool:] searches the tool directories a filesystem layout
gives, which are inside the writable data directory, and Android refuses execve
there for any application targeting API 29 or higher:
https://developer.android.com/about/versions/10/behavior-changes-10

A package carries an executable file only as lib/<abi>/lib<name>.so, installed
into one directory whose name is settled when the package is installed:
https://developer.android.com/ndk/guides/abis
A layout cannot name that directory, but the library is installed into it too,
so GSPrivateSymbolPath() names it, which is the mechanism a config file
location beginning './' already uses.

That directory is added ahead of the layout's, which are kept so a tool built
and installed outside a package is still found. executablePath() tries
lib<name>.so as it tries the extensions Windows adds. A tool started this way
is given the directory on LD_LIBRARY_PATH, which execve does not provide, and
the process temporary directory, within which a port is named.

Tests/base/NSPathUtilities/toolsdirectory and Tests/base/NSTask/toolpath cover
a process that has no package.
