### PR TITLE
Let a thread reuse the key value slots it has already looked up

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 2026-08-11 Todd White <todd.white@thalion.global>
 
+	* Source/NSKeyValueCoding+Caching.m: Let each thread keep the
+	slots it has most recently used, so that valueForKey: reads the
+	shared table, and takes its lock, only for a class and key that
+	thread has not seen.  A slot is added to the shared table once
+	and never removed, so a pointer to one stays valid.
+
+2026-08-11 Todd White <todd.white@thalion.global>
+
 	* Source/NSCalendarDate.m: Read the second that GSPrivateTimeNow
 	records before writing it, and write it only when it has
 	changed, so that every thread asking for the time does not

--- a/Source/NSKeyValueCoding+Caching.m
+++ b/Source/NSKeyValueCoding+Caching.m
@@ -87,6 +87,31 @@ static void inline _KVCCacheSlotRelease(const void *ptr)
 #import "GNUstepBase/GSIMap.h"
 #import "GSPThread.h"
 
+/* A slot is added to the shared table once and never removed from it, so a
+ * pointer to one stays valid for the life of the process and each thread can
+ * keep a few of them to itself.  A thread that finds the slot it wants here
+ * reads nothing the other threads write.
+ */
+#define KVC_THREAD_CACHE_SIZE 8
+
+struct _KVCThreadCache
+{
+  struct _KVCCacheSlot *slots[KVC_THREAD_CACHE_SIZE];
+};
+
+static gs_thread_key_t  kvcThreadCacheKey;
+/* Read without the lock and written under it, so the flag is reached through
+ * atomic operations.  The release pairs with the acquire below, which is what
+ * publishes the key itself to a thread that finds the flag set.
+ */
+static BOOL             kvcThreadCacheKeyReady = NO;
+
+static void
+_KVCThreadCacheFree(void *cache)
+{
+  free(cache);
+}
+
 /*
  * Templating for poor people:
  * We need to call IMP with the correct function signature and box
@@ -578,15 +603,44 @@ valueForKeyWithCaching(id obj, NSString *aKey)
   static GSIMapTable_t  cacheTable = {};
   static gs_mutex_t     cacheTableLock = GS_MUTEX_INIT_STATIC;
 
+  struct _KVCThreadCache *threadCache = NULL;
+  unsigned int           threadCacheIndex = 0;
+
   Class cls = object_getClass(obj);
   // Fill out the required fields for hashing
   struct _KVCCacheSlot slot = {.cls = cls, .hash = [aKey hash]};
+
+  if (__atomic_load_n(&kvcThreadCacheKeyReady, __ATOMIC_ACQUIRE))
+    {
+      threadCache = GS_THREAD_KEY_GET(kvcThreadCacheKey);
+      threadCacheIndex = (unsigned int)
+        (((uintptr_t) cls ^ (uintptr_t) slot.hash) % KVC_THREAD_CACHE_SIZE);
+      if (threadCache != NULL)
+        {
+          cachedSlot = threadCache->slots[threadCacheIndex];
+          if (cachedSlot != NULL
+            && cachedSlot->cls == cls
+            && cachedSlot->hash == slot.hash
+            && cachedSlot->version == objc_method_cache_version)
+            {
+              return cachedSlot->get(cachedSlot, obj);
+            }
+          cachedSlot = NULL;
+        }
+    }
 
   GS_MUTEX_LOCK(cacheTableLock);
   if (cacheTable.zone == 0)
     {
       // TODO: Tweak initial capacity
       GSIMapInitWithZoneAndCapacity(&cacheTable, NSDefaultMallocZone(), 64);
+    }
+  if (!__atomic_load_n(&kvcThreadCacheKeyReady, __ATOMIC_RELAXED))
+    {
+      if (GS_THREAD_KEY_INIT(kvcThreadCacheKey, _KVCThreadCacheFree))
+        {
+          __atomic_store_n(&kvcThreadCacheKeyReady, YES, __ATOMIC_RELEASE);
+        }
     }
   node = GSIMapNodeForKey(&cacheTable, (GSIMapKey) (void *) &slot);
   GS_MUTEX_UNLOCK(cacheTableLock);
@@ -632,6 +686,28 @@ valueForKeyWithCaching(id obj, NSString *aKey)
       GS_MUTEX_LOCK(cacheTableLock);
       memcpy(cachedSlot, &slot, sizeof(struct _KVCCacheSlot));
       GS_MUTEX_UNLOCK(cacheTableLock);
+    }
+
+  if (__atomic_load_n(&kvcThreadCacheKeyReady, __ATOMIC_ACQUIRE))
+    {
+      if (threadCache == NULL)
+        {
+          threadCache = GS_THREAD_KEY_GET(kvcThreadCacheKey);
+          if (threadCache == NULL)
+            {
+              threadCache = calloc(1, sizeof(struct _KVCThreadCache));
+              if (threadCache != NULL)
+                {
+                  GS_THREAD_KEY_SET(kvcThreadCacheKey, threadCache);
+                }
+            }
+          threadCacheIndex = (unsigned int)
+            (((uintptr_t) cls ^ (uintptr_t) slot.hash) % KVC_THREAD_CACHE_SIZE);
+        }
+      if (threadCache != NULL)
+        {
+          threadCache->slots[threadCacheIndex] = cachedSlot;
+        }
     }
 
   return cachedSlot->get(cachedSlot, obj);


### PR DESCRIPTION
valueForKeyWithCaching takes a static mutex on every call, to read a table that is only ever added to, so every valueForKey: in a process serialises on one lock whatever object it is sent to.

A slot is added to that table once and never removed, so a pointer to one stays valid and a thread can keep the last few it used. A thread that finds the slot it wants takes no lock. The flag saying the per thread key exists is read outside the lock that creates it, so it is read and written atomically.

ns per -[NSObject valueForKey:] on distinct objects, one per thread, 32 cores, median of 3 interleaved runs: 1 thread 33.2 to 25.0, 8 threads 829.1 to 34.5, 24 threads 1860.3 to 55.0.

KVC, NSKVOSupport, NSObject, NSPredicate and NSSortDescriptor give 932 passed before and after. A 16 thread probe over 3 classes and 3 keys checks every value returned and finds no mismatch, and ThreadSanitizer reports nothing here.

Two things to note: it rests on slots never being removed, which nothing enforces, and the update at the end of the function still writes over a slot another thread may be reading, which is there already.
