### PR TITLE
Do not write a shared second on every request for the time

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2026-08-11 Todd White <todd.white@thalion.global>
+
+	* Source/NSCalendarDate.m: Read the second that GSPrivateTimeNow
+	records before writing it, and write it only when it has
+	changed, so that every thread asking for the time does not
+	dirty the line it sits in.  The read and the write are relaxed
+	atomic operations.
+
 2026-08-10 Todd White <todd.white@thalion.global>
 
 	* Source/NSProcessInfo.m:

--- a/Source/NSCalendarDate.m
+++ b/Source/NSCalendarDate.m
@@ -318,17 +318,26 @@ GSPrivateTimeNow(void)
  * system time to make sure we don't have a temporary glitch.
  */
 {
+  /* One value shared by every thread that asks for the time.  It is read
+   * before it is written, and written only when the second it holds has
+   * changed, so the line it sits in stays clean between one second and the
+   * next.
+   */
   static int	old = 0;
+  int		prev = __atomic_load_n(&old, __ATOMIC_RELAXED);
 
-  if (old == 0)
+  if (prev == 0)
     {
-      old = tp.tv_sec;
+      __atomic_store_n(&old, (int)tp.tv_sec, __ATOMIC_RELAXED);
     }
   else
     {
-      int	diff = tp.tv_sec - old;
+      int	diff = tp.tv_sec - prev;
 
-      old = tp.tv_sec;
+      if (prev != (int)tp.tv_sec)
+	{
+	  __atomic_store_n(&old, (int)tp.tv_sec, __ATOMIC_RELAXED);
+	}
       if (diff < -1 || diff > 3000)
 	{
 	  time_t	now = (time_t)tp.tv_sec;


### PR DESCRIPTION
GSPrivateTimeNow keeps one static int, so that a system clock which jumps can be noticed, and wrote it on every call. Every thread that asks for the time therefore dirties the same cache line, and the value changes only once a second.

It is now read before it is written, and written only when the second has changed. Both are relaxed atomic operations, which also settles the data race on that int. On x86 each is a plain move.

ns per -[NSDate date] on 32 cores, median of 5 interleaved runs: 1 thread 60.5 against 60.6, 4 threads 211.4 against 60.8, 8 threads 413.9 against 62.7, 24 threads 886.1 against 123.7. 

Callers include +[NSDate date], -timeIntervalSinceNow, 5 sleep paths in NSThread, NSProcessInfo, and NSRunLoop on every iteration.

NSDate, NSCalendarDate, NSRunLoop, NSThread, NSTimeZone and NSTimer give 350 passed and 5 dashed hopes before and after.
