### PR TITLE
Answer a copy from stringWithString: rather than always building one

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-08-11 Todd White <todd.white@thalion.global>
+
+	* Source/NSString.m: Answer a copy from +stringWithString:
+	rather than allocating a string and initialising it from the
+	argument, so that a string which may be shared is shared.  A
+	subclass keeps the earlier path.
+
 2026-08-10 Todd White <todd.white@thalion.global>
 
 	* Source/NSProcessInfo.m:

--- a/Source/NSString.m
+++ b/Source/NSString.m
@@ -1375,6 +1375,15 @@ register_printf_atsign ()
   if (NULL == aString)
     [NSException raise: NSInvalidArgumentException
       format: @"[NSString+stringWithString:]: NULL string"];
+  if (self == NSStringClass)
+    {
+      /* Each concrete string class settles in -copyWithZone: whether it may
+       * be shared, and answers a full copy where it may not, so a copy is
+       * both what this method promises and the cheapest thing that keeps
+       * that promise.
+       */
+      return AUTORELEASE([aString copy]);
+    }
   obj = [self allocWithZone: NSDefaultMallocZone()];
   obj = [obj initWithString: aString];
   return AUTORELEASE(obj);


### PR DESCRIPTION
+[NSString stringWithString:] allocated a string and initialised it from the argument, so a string that could have been shared was rebuilt character by character. Each concrete string class already settles in -copyWithZone: whether it may be shared, and answers a full copy where it may not, which is what a string initialised with freeWhenDone NO needs.

NSString itself now answers [aString copy]. A subclass keeps the earlier path, so [NSMutableString stringWithString:] still answers something mutable that accepts -appendString:.

Measured against Apple Foundation on macOS 26: +stringWithString: answers the argument itself for an immutable argument, constant or tagged, and copies for a mutable one. -initWithString: answers the argument as well, but -copyWithZone: here is written in terms of -initWithString: and depends on it copying, so it is untouched.

ns per call, 5 interleaved runs: 122.9 to 28.6, with -copy of the same literal at 16.8.

NSString, NSMutableString, NSAttributedString, NSPropertyList and NSKeyedArchiver give 2278 passed and 17 dashed hopes before and after.

Draft: matches Apple's observed behaviour, which the documentation does not state.
