### PR TITLE
Answer a method signature without a lock and without retaining it

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 2026-08-11 Todd White <todd.white@thalion.global>
 
+	* Source/NSMethodSignature.m: Answer a set of types that has been
+	seen before from a table read without the cache lock, and keep
+	every signature for the life of the process rather than counting
+	references to it, which is what its cache already does.
+
+2026-08-11 Todd White <todd.white@thalion.global>
+
 	* Source/NSCalendarDate.m: Read the second that GSPrivateTimeNow
 	records before writing it, and write it only when it has
 	changed, so that every thread asking for the time does not

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,12 +5,19 @@
 	something in it.  The array is local to the call, so its count
 	may be read without the lock.
 
-2026-08-11 Todd White <todd.white@thalion.global>
+2026-08-12 Todd White <todd.white@thalion.global>
 
-	* Source/NSMethodSignature.m: Answer a set of types that has been
-	seen before from a table read without the cache lock, and keep
-	every signature for the life of the process rather than counting
-	references to it, which is what its cache already does.
+	* Source/NSMethodSignature.m:
+	* Source/GSInvocation.h:
+	* Source/NSDistantObject.m:
+	* Source/NSInvocation.m: Answer a set of types that has been seen
+	before from a table read without the cache lock, and keep a
+	cached signature for the life of the process rather than counting
+	references to it, which is what the cache already does.  Limit how
+	many sets of types may be cached, answering an uncached signature
+	past the limit rather than failing, and use an uncached signature
+	for types which came from a connection or an archive, so that a
+	peer cannot fill the cache.
 
 2026-08-11 Todd White <todd.white@thalion.global>
 

--- a/Source/GSInvocation.h
+++ b/Source/GSInvocation.h
@@ -67,6 +67,11 @@ typedef struct	{
 @end
 
 @interface NSMethodSignature (GNUstep)
+/* Answers a signature which is not put in the cache and is deallocated like
+ * any other object.  For types which came from outside the process, so that
+ * a peer or an archive cannot fill the cache.
+ */
++ (NSMethodSignature*) _uncachedSignatureWithObjCTypes: (const char*)t;
 - (const char*) methodType;
 - (NSArgumentInfo*) methodInfo;
 @end

--- a/Source/NSDistantObject.m
+++ b/Source/NSDistantObject.m
@@ -764,9 +764,10 @@ GS_ROOT_CLASS @interface	GSDistantObjectPlaceHolder
 	      const char	*types;
 
 	      types = [m methodType];
-	      /* Create a local method signature.
+	      /* Create a local method signature.  The types came from the
+	       * other end of the connection, so it is not cached.
 	       */
-	      m = [NSMethodSignature signatureWithObjCTypes: types];
+	      m = [NSMethodSignature _uncachedSignatureWithObjCTypes: types];
 	    }
 	  if (m != nil)
 	    {

--- a/Source/NSInvocation.m
+++ b/Source/NSInvocation.m
@@ -757,7 +757,9 @@ _arg_addr(NSInvocation *inv, int index)
   unsigned int		i;
 
   [aCoder decodeValueOfObjCType: @encode(char*) at: &types];
-  newSig = [NSMethodSignature signatureWithObjCTypes: types];
+  /* The types came out of the archive, so the signature is not cached.
+   */
+  newSig = [NSMethodSignature _uncachedSignatureWithObjCTypes: types];
   NSZoneFree(NSDefaultMallocZone(), (void*)types);
 
   DESTROY(self);

--- a/Source/NSMethodSignature.m
+++ b/Source/NSMethodSignature.m
@@ -35,6 +35,7 @@
 #define	EXPOSE_NSMethodSignature_IVARS	1
 
 #import "Foundation/NSMethodSignature.h"
+#import "Foundation/NSAutoreleasePool.h"
 #import "Foundation/NSException.h"
 #import "Foundation/NSCoder.h"
 
@@ -560,6 +561,15 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
  */
 #define SIGNATURE_SLOTS 1024
 
+/* An entry is never removed from the cache, so the number of sets of types
+ * which may be cached is limited.  Past the limit a signature is built and
+ * answered without being cached, which is what happened before there was a
+ * cache at all.  The busiest program in the base test suite caches 18.
+ */
+#define SIGNATURE_LIMIT 4096
+
+static unsigned		cachedSignatures = 0;
+
 struct signature_slot
 {
   const char		*types;
@@ -581,6 +591,12 @@ signatureSlotFor(const char *types)
   hash ^= hash >> 15;
   return (unsigned)(hash & (SIGNATURE_SLOTS - 1));
 }
+
+/* A signature which is not in the cache is owned by whoever asked for it, so
+ * it counts references where a cached one does not.
+ */
+@interface GSUncachedMethodSignature : NSMethodSignature
+@end
 
 @implementation NSMethodSignature
 
@@ -691,7 +707,11 @@ signatureSlotFor(const char *types)
 	}
 
       node = GSIMapNodeForKey(&cacheTable, (GSIMapKey)t);
-      if (node == 0)
+      if (node == 0 && cachedSignatures >= SIGNATURE_LIMIT)
+	{
+	  sig = nil;		// built without the lock below
+	}
+      else if (node == 0)
 	{
 	  char	*buf;
 	  int	len = strlen(t) + 1;
@@ -699,6 +719,7 @@ signatureSlotFor(const char *types)
 	  sig = [[self alloc] _initWithObjCTypes: t];
 	  buf = malloc(len);
 	  memcpy(buf, t, len);
+	  cachedSignatures++;
 
 	  /* We suppress the static analyser warning about the
 	   * intentional leak (until end of execution) of the cache
@@ -734,7 +755,19 @@ signatureSlotFor(const char *types)
   NS_ENDHANDLER
   GS_MUTEX_UNLOCK(cacheTableLock);
 
+  if (sig == nil)
+    {
+      return [self _uncachedSignatureWithObjCTypes: t];
+    }
   return sig;
+}
+
++ (NSMethodSignature*) _uncachedSignatureWithObjCTypes: (const char*)t
+{
+  NSMethodSignature	*sig;
+
+  sig = [[GSUncachedMethodSignature alloc] _initWithObjCTypes: t];
+  return AUTORELEASE(sig);
 }
 
 - (NSArgumentInfo) argumentInfoAtIndex: (NSUInteger)index
@@ -807,9 +840,10 @@ signatureSlotFor(const char *types)
   return _numArgs;
 }
 
-/* Every signature is created by +signatureWithObjCTypes: and kept by its
- * cache for the life of the process, so one is never deallocated and the
- * count of references to it need not be kept.
+/* A signature in the cache is kept for the life of the process, so it is
+ * never deallocated and the count of references to it need not be kept.  One
+ * which is not in the cache is a GSUncachedMethodSignature, which counts them
+ * as any other object does.
  */
 - (id) retain
 {
@@ -909,4 +943,37 @@ signatureSlotFor(const char *types)
 {
   return _methodTypes;
 }
+@end
+
+@implementation GSUncachedMethodSignature
+
+/* The superclass does not count references, since a signature in the cache is
+ * kept for the life of the process, so this class does the counting itself
+ * rather than by a call to super.
+ */
+- (id) retain
+{
+  NSIncrementExtraRefCount(self);
+  return self;
+}
+
+- (oneway void) release
+{
+  if (NSDecrementExtraRefCountWasZero(self))
+    {
+      [self dealloc];
+    }
+}
+
+- (id) autorelease
+{
+  [NSAutoreleasePool addObject: self];
+  return self;
+}
+
+- (NSUInteger) retainCount
+{
+  return NSExtraRefCount(self) + 1;
+}
+
 @end

--- a/Source/NSMethodSignature.m
+++ b/Source/NSMethodSignature.m
@@ -551,6 +551,37 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
   return typePtr;
 }
 
+/* A signature is built once for a given set of types and then kept for the
+ * life of the process, so a set of types that has been seen before can be
+ * answered from a small table that is only ever added to.  Each entry is
+ * published with a release and read with an acquire, and neither an entry nor
+ * the key it holds is ever freed, so a reader may hold either.  A set of types
+ * that collides with another simply misses and takes the slower path.
+ */
+#define SIGNATURE_SLOTS 1024
+
+struct signature_slot
+{
+  const char		*types;
+  NSMethodSignature	*signature;
+};
+
+static struct signature_slot *signatureSlots[SIGNATURE_SLOTS];
+
+static inline unsigned
+signatureSlotFor(const char *types)
+{
+  uintptr_t	hash = 5381;
+  const char	*p = types;
+
+  while (*p != '\0')
+    {
+      hash = (hash << 5) + hash + (unsigned char)*p++;
+    }
+  hash ^= hash >> 15;
+  return (unsigned)(hash & (SIGNATURE_SLOTS - 1));
+}
+
 @implementation NSMethodSignature
 
 - (id) _initWithObjCTypes: (const char*)t
@@ -638,9 +669,18 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
 {
   GSIMapNode node;
   NSMethodSignature	*sig;
+  struct signature_slot	*slot;
+  unsigned		index;
 
   static GSIMapTable_t cacheTable = {};
   static gs_mutex_t cacheTableLock = GS_MUTEX_INIT_STATIC;
+
+  index = signatureSlotFor(t);
+  slot = __atomic_load_n(&signatureSlots[index], __ATOMIC_ACQUIRE);
+  if (slot != NULL && strcmp(slot->types, t) == 0)
+    {
+      return slot->signature;
+    }
 
   GS_MUTEX_LOCK(cacheTableLock);
   NS_DURING
@@ -668,10 +708,22 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
 	  [[clang::suppress]]
 #endif
 	  GSIMapAddPair(&cacheTable, (GSIMapKey)buf, (GSIMapVal)(id)sig);
+
+	  /* buf and sig both outlive the process, so the table in front of
+	   * the map may hold them.
+	   */
+	  slot = (struct signature_slot*)
+	    malloc(sizeof(struct signature_slot));
+	  if (slot != NULL)
+	    {
+	      slot->types = buf;
+	      slot->signature = sig;
+	      __atomic_store_n(&signatureSlots[index], slot, __ATOMIC_RELEASE);
+	    }
 	}
       else
 	{
-	  sig = RETAIN(node->value.obj);
+	  sig = node->value.obj;
 	}
     }
   NS_HANDLER
@@ -682,7 +734,7 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
   NS_ENDHANDLER
   GS_MUTEX_UNLOCK(cacheTableLock);
 
-  return AUTORELEASE(sig);
+  return sig;
 }
 
 - (NSArgumentInfo) argumentInfoAtIndex: (NSUInteger)index
@@ -753,6 +805,29 @@ next_arg(const char *typePtr, NSArgumentInfo *info, char *outTypes)
 - (NSUInteger) numberOfArguments
 {
   return _numArgs;
+}
+
+/* Every signature is created by +signatureWithObjCTypes: and kept by its
+ * cache for the life of the process, so one is never deallocated and the
+ * count of references to it need not be kept.
+ */
+- (id) retain
+{
+  return self;
+}
+
+- (oneway void) release
+{
+}
+
+- (id) autorelease
+{
+  return self;
+}
+
+- (NSUInteger) retainCount
+{
+  return UINT_MAX;
 }
 
 - (void) dealloc


### PR DESCRIPTION
+signatureWithObjCTypes: took a static mutex on every call and answered RETAIN of the cached signature, so a caller queued for one lock and then wrote to the reference count of one shared object.

A set of types seen before is answered from a table of published entries, read with an acquire and written with a release. A cached signature is kept for the life of the process, so its retain, release and autorelease do nothing. The cache holds at most 4096 sets of types; past that a signature is built, answered autoreleased and not cached. Types decoded from a connection or an archive take that uncached path.

ns per fetch, medians of 3 interleaved runs: 1 thread 70.7 to 55.5, 8 threads 1778.1 to 59.8, 24 threads 6805.6 to 104.6. The ARC path at 24 threads is 7003.0 to 135.4.

A probe building 200000 sets of types past the limit leaves resident memory where it was; master grows by 40 MB.

Replacing an entry orphans 16 bytes, bounded by the limit at 48 KB. Over releasing a cached signature is not noticed.
