### PR TITLE
Accept either library name as the android framework soname

### DIFF
--- a/.github/scripts/android/base.sh
+++ b/.github/scripts/android/base.sh
@@ -149,15 +149,17 @@ for R in "$GS_BASE"/Tests/base/*/Resources; do
   fi
 done
 
-# tools-make#76: check the framework soname is the versioned name and not a
-# stray argument, since a bad one only shows up as a load failure on device.
+# tools-make#76: check the framework soname is a library name and not a stray
+# argument off the link line, since a bad one only shows up as a load failure
+# on device.  Either the versionless or the versioned name is a library name;
+# which one the rule records is tools-make's to decide.
 for fw in "$GS_BASE"/Tests/base/*/Resources/*.framework; do
   [ -d "$fw" ] || continue
   so=$(find "$fw" -name 'lib*.so.*.*' -type f | head -1)
   [ -n "$so" ] || continue
   sn=$("$TOOLCHAIN/bin/llvm-readelf" -d "$so" | sed -n 's/.*SONAME.*\[\(.*\)\]/\1/p')
   echo "    $(basename "$fw") SONAME $sn"
-  case "$sn" in lib*.so.*) ;; *) echo "unexpected SONAME: $sn"; exit 1 ;; esac
+  case "$sn" in lib*.so|lib*.so.*) ;; *) echo "unexpected SONAME: $sn"; exit 1 ;; esac
 done
 
 say "base tools"


### PR DESCRIPTION
The check added with tools-make#76 required the interface versioned name, which pins a decision that belongs to tools-make. tools-make#77 records the versionless name on android, since the package manager looks for lib/<abi>/lib<name>.so inside an apk and copies what it finds to lib<name>.so, so a versioned soname names a file that is never installed.

The check exists to catch a stray argument taken off the link line, which is what a framework recorded before tools-make#76 and which shows up only as a load failure on device. It accepts a library name in either form now, and still rejects an empty soname and one that begins with a dash.

With this it does not matter which of the two lands first.
