### PR TITLE
Skip the cleanup lock when a post collected no observations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-08-12 Todd White <todd.white@thalion.global>
+
+	* Source/NSNotificationCenter.m: Take the table lock for the
+	cleanup of the array of observations only when the post put
+	something in it.  The array is local to the call, so its count
+	may be read without the lock.
+
 2026-08-11 Todd White <todd.white@thalion.global>
 
 	* Source/NSString.m: Answer a copy from +stringWithString:

--- a/Source/NSNotificationCenter.m
+++ b/Source/NSNotificationCenter.m
@@ -1322,11 +1322,16 @@ addPost(Observation *head, GSIArray a)
 	}
     }
 
-  /* Cleanup of the array of observations must be lock protected.
+  /* Cleanup of the array of observations must be lock protected, but an
+   * array we put nothing in has nothing to clean up.  The array is local
+   * to this call, so its count may be read without the lock.
    */
-  lockNCTable(TABLE);
-  GSIArrayEmpty(a);
-  unlockNCTable(TABLE);
+  if (GSIArrayCount(a) > 0)
+    {
+      lockNCTable(TABLE);
+      GSIArrayEmpty(a);
+      unlockNCTable(TABLE);
+    }
 
   /* Release the notification and any objects we autoreleased during posting
    */


### PR DESCRIPTION
The notification table's lock is taken a second time in -_postAndRelease:, to empty the array of observations the post collected. A post of a name with no observers collects none, so the lock is taken for an array nothing was put in. One lock covers the table, so every other post waits behind it.

The array is local to the call, so its count is read without the lock, and that region is entered only when the post collected something.

ns per post of a name with no observer, each thread posting its own name, 32 cores, medians of 8 interleaved runs: 8 threads 4278.9 to 3777.2, 16 threads 13094.9 to 8351.1, 24 threads 23594.8 to 16000.6.

The suite passes both ways with 0 failures and 44 dashed hopes, the passing count differing by 13 in coding/basictypes.m, which writes its fixtures on the first run. A probe posting 7950000 notifications across 24 threads counts the same deliveries either way.

A post that reaches an observer is unchanged, since the lock is still held across the whole collection phase.
