### PR TITLE
Fix app bundle resource lookup on Android

### DIFF
--- a/Source/NSBundle.m
+++ b/Source/NSBundle.m
@@ -1698,6 +1698,63 @@ GSPrivateInfoDictionary(NSString *rootPath)
   return info;
 }
 
+/* Load the language alias and canonical maps used by altLang().
+ *
+ * The maps are resources of the gnustep-base library bundle, but that bundle
+ * is not always present (on Android the library resources are packaged as
+ * application assets rather than being installed in a library domain), so we
+ * fall back to searching the main bundle for them.
+ *
+ * NB. This must not be called before the resources of the bundle being
+ * searched are readable: on Android that is only the case once the asset
+ * manager has been set, which is why +initialize does not call this there.
+ */
+static void
+loadLanguageMaps(void)
+{
+  NSString	*rootPath;
+  NSString	*file;
+
+  /* A nil rootPath makes GSPrivateResourcePath() search the main bundle,
+   * which is what we want when there is no library bundle.
+   */
+  rootPath = [_gnustep_bundle bundlePath];
+
+  /* The Locale aliases map converts canonical names to old-style names
+   */
+  file = GSPrivateResourcePath(@"Locale", @"aliases",
+    rootPath, @"Languages", NOT_LOCALIZED);
+  if (file != nil)
+    {
+      NSDictionary  *d;
+
+      d = [[NSDictionary alloc] initWithContentsOfFile: file];
+      if ([d count] > 0)
+	{
+	  ASSIGN(langAliases, d);
+	}
+      [d release];
+    }
+
+  /* The Locale canonical map converts old-style names to ISO 639 names
+   * and converts ISO 639-2 names to the preferred ISO 639-1 names where
+   * an ISO 639-1 name exists.
+   */
+  file = GSPrivateResourcePath(@"Locale", @"canonical",
+    rootPath, @"Languages", NOT_LOCALIZED);
+  if (file != nil)
+    {
+      NSDictionary  *d;
+
+      d = [[NSDictionary alloc] initWithContentsOfFile: file];
+      if ([d count] > 0)
+	{
+	  ASSIGN(langCanonical, d);
+	}
+      [d release];
+    }
+}
+
 @implementation NSBundle
 
 + (void) atExit
@@ -1729,7 +1786,6 @@ GSPrivateInfoDictionary(NSString *rootPath)
   if (self == [NSBundle class])
     {
       NSAutoreleasePool *pool = [NSAutoreleasePool new];
-      NSString          *file;
       const char	*mode;
       NSDictionary	*env;
       NSString		*str;
@@ -1848,39 +1904,13 @@ GSPrivateInfoDictionary(NSString *rootPath)
       _gnustep_bundle = RETAIN([self bundleForLibrary: @"gnustep-base"
 					      version: _base_version]);
 
-      /* The Locale aliases map converts canonical names to old-style names
+#ifndef __ANDROID__
+      /* Load the language maps. On Android no bundle resources are readable
+       * until the asset manager has been set, so this is done in
+       * +setJavaAssetManager:withJNIEnv: instead.
        */
-      file = GSPrivateResourcePath(@"Locale", @"aliases",
-        [_gnustep_bundle bundlePath], @"Languages", NOT_LOCALIZED);
-      if (file != nil)
-        {
-          NSDictionary  *d;
-
-          d = [[NSDictionary alloc] initWithContentsOfFile: file];
-          if ([d count] > 0)
-            {
-              ASSIGN(langAliases, d);
-            }
-          [d release];
-        }
-
-      /* The Locale canonical map converts old-style names to ISO 639 names
-       * and converts ISO 639-2 names to the preferred ISO 639-1 names where
-       * an ISO 639-1 name exists.
-       */
-      file = GSPrivateResourcePath(@"Locale", @"canonical",
-        [_gnustep_bundle bundlePath], @"Languages", NOT_LOCALIZED);
-      if (file != nil)
-        {
-          NSDictionary  *d;
-
-          d = [[NSDictionary alloc] initWithContentsOfFile: file];
-          if ([d count] > 0)
-            {
-              ASSIGN(langCanonical, d);
-            }
-          [d release];
-        }
+      loadLanguageMaps();
+#endif
 
 #if 0
       _loadingBundle = [self mainBundle];
@@ -3550,8 +3580,24 @@ IF_NO_ARC(
   // get native asset manager (may be shared across multiple threads)
   _assetManager = AAssetManager_fromJava(env, _jassetManager);
 
-  // clean main bundle path cache in case it was accessed before
-  [_mainBundle cleanPathCache];
+  /* Any resource lookup made before the asset manager was available failed
+   * and cached that failure, so the whole cache has to go: the entries are
+   * not necessarily those of the main bundle, and the main bundle may not
+   * even have been created yet, in which case -cleanPathCache would be a
+   * no-op and the stale entries would make every later lookup fail.
+   */
+  [pathCacheLock lock];
+  [pathCache removeAllObjects];
+  [pathCacheLock unlock];
+
+  /* Ensure the main bundle exists, as assets are located relative to its
+   * resource path, and discard its info dictionary and localizations, which
+   * may have been cached while its resources were unreadable.
+   */
+  [[self mainBundle] cleanPathCache];
+
+  // now that bundle resources are readable, load the language maps
+  loadLanguageMaps();
 }
 
 + (AAsset *) assetForPath: (NSString *)path


### PR DESCRIPTION
`+[NSBundle initialize]` looks the Locale maps up using the gnustep-base library bundle's path, which is nil on Android because the library resources are not installed in a library domain there.  Since #735 that lookup is a `GSPrivateResourcePath()` call, which searches the main bundle when it is given a nil root path (the earlier `-pathForResource:` was sent to a nil bundle and did nothing).

The main bundle's resources are Android assets and are unreadable until `+setJavaAssetManager:withJNIEnv:` has run, so the lookup failed and `bundle_directory_readable()` cached the failure.  That cache is only undone by `-cleanPathCache`, which is sent to `_mainBundle` and did nothing because no main bundle had been created yet, leaving the process unable to find any resource at all: Info.plist, localizations and the CA certificate bundle were all missing for the rest of the run.

Move the map loading into `loadLanguageMaps()` and call it on Android from `+setJavaAssetManager:withJNIEnv:`, once the assets are readable, instead of from `+initialize`.  Searching the main bundle when there is no library bundle is the intended fallback there, so the maps are also found where the library resources are packaged as application assets.

Discard the whole path cache, rather than the main bundle's entries, once the asset manager is available, and create the main bundle at that point, since assets are located relative to its resource path.