### PR TITLE
Fix getwd argument mismatch and NSThread define guard

### DIFF
--- a/Source/NSFileManager.m
+++ b/Source/NSFileManager.m
@@ -1330,7 +1330,7 @@ static gs_mutex_t       classLock = GS_MUTEX_INIT_STATIC;
   if (getcwd(path, PATH_MAX-1) == 0)
     return nil;
 #else
-  if (getwd(path) == 0)
+  if (getcwd(path, PATH_MAX) == 0)
     return nil;
 #endif /* HAVE_GETCWD */
   currentDir = [self stringWithFileSystemRepresentation: path

--- a/Source/NSThread.m
+++ b/Source/NSThread.m
@@ -39,7 +39,7 @@
 
 // Dummy implementatation
 // cleaner than IFDEF'ing the code everywhere
-#ifndef HAVE_PTHREAD_SPIN_LOCK
+#if !defined(HAVE_PTHREAD_SPIN_LOCK) && !defined(__DEFINED_pthread_spinlock_t)
 typedef volatile int pthread_spinlock_t;
 int pthread_spin_init(pthread_spinlock_t *lock, int pshared)
 {


### PR DESCRIPTION
The spinlock define guard is required for emscripten portability, since emscripten already defines this type.