### PR TITLE
Fix incompatible function pointer calls

### DIFF
--- a/Source/Additions/GSObjCRuntime.m
+++ b/Source/Additions/GSObjCRuntime.m
@@ -1982,7 +1982,7 @@ GSAutoreleasedBuffer(unsigned size)
   static Class	buffer_class = 0;
   static Class	autorelease_class;
   static SEL	autorelease_sel;
-  static id	(*autorelease_imp)(Class, SEL, id);
+  static void	(*autorelease_imp)(Class, SEL, id);
   static int	instance_size;
   static int	offset;
   NSObject	*o;
@@ -1994,7 +1994,7 @@ GSAutoreleasedBuffer(unsigned size)
       offset = instance_size % ALIGN;
       autorelease_class = [NSAutoreleasePool class];
       autorelease_sel = @selector(addObject:);
-      autorelease_imp = (id (*)(Class, SEL, id))
+      autorelease_imp = (void (*)(Class, SEL, id))
         [autorelease_class methodForSelector: autorelease_sel];
     }
   o = (NSObject*)NSAllocateObject(buffer_class,
@@ -2333,4 +2333,3 @@ GSObjCPrint(void *base, void *item)
       fprintf(fptr, "}\n");
     }
 }
-

--- a/Source/NSAutoreleasePool.m
+++ b/Source/NSAutoreleasePool.m
@@ -429,19 +429,21 @@ pop_pool_from_cache(struct autorelease_thread_vars *tv)
 
 + (id) new
 {
-  static IMP	allocImp = 0;
-  static IMP	initImp = 0;
+  typedef id (*GSAllocIMP)(id, SEL, NSZone *);
+  typedef id (*GSInitIMP)(id, SEL);
+  static GSAllocIMP	allocImp = 0;
+  static GSInitIMP	initImp = 0;
   id		arp;
 
   if (0 == allocImp)
     {
-      allocImp
-	= [NSAutoreleasePool methodForSelector: @selector(allocWithZone:)];
-      initImp
-	= [NSAutoreleasePool instanceMethodForSelector: @selector(init)];
+      allocImp = (GSAllocIMP)
+	[NSAutoreleasePool methodForSelector: @selector(allocWithZone:)];
+      initImp = (GSInitIMP)
+	[NSAutoreleasePool instanceMethodForSelector: @selector(init)];
     }
-  arp = (*allocImp)(self, @selector(allocWithZone:), NSDefaultMallocZone());
-  return (*initImp)(arp, @selector(init));
+  arp = allocImp(self, @selector(allocWithZone:), NSDefaultMallocZone());
+  return initImp(arp, @selector(init));
 }
 
 #ifdef ARC_RUNTIME
@@ -735,4 +737,3 @@ pop_pool_from_cache(struct autorelease_thread_vars *tv)
 }
 
 @end
-

--- a/Source/NSDictionary.m
+++ b/Source/NSDictionary.m
@@ -831,7 +831,7 @@ static SEL	appSel;
 
       for (i = 0; i < c; i++)
 	{
-	  k[i] = (*nxtObj)(e, nxtSel);
+	  k[i] = ((id (*)(id, SEL))nxtObj)(e, nxtSel);
 	  NSAssert (k[i], NSInternalInconsistencyException);
 	}
       result = [[NSArray_class allocWithZone: NSDefaultMallocZone()]
@@ -862,7 +862,7 @@ static SEL	appSel;
 
       for (i = 0; i < c; i++)
 	{
-	  k[i] = (*nxtObj)(e, nxtSel);
+	  k[i] = ((id (*)(id, SEL))nxtObj)(e, nxtSel);
 	}
       result = [[NSArray_class allocWithZone: NSDefaultMallocZone()]
 	initWithObjects: k count: c];

--- a/Source/NSObject.m
+++ b/Source/NSObject.m
@@ -140,6 +140,8 @@ static IMP autorelease_imp;
 
 static SEL finalize_sel;
 static IMP finalize_imp;
+
+typedef void (*GSVoidMethodIMP)(id, SEL);
 static Class	NSConstantStringClass;
 
 @class	NSDataMalloc;
@@ -800,7 +802,7 @@ callCXXConstructors(Class aClass, id anObject)
       constructor = class_getMethodImplementation(aClass, cxx_construct);
       if (calledConstructor != constructor)
         {
-          constructor(anObject, cxx_construct);
+          ((GSVoidMethodIMP)constructor)(anObject, cxx_construct);
         }
     }
   return constructor;
@@ -869,7 +871,7 @@ NSDeallocateObject(id anObject)
 
       /* Call the default finalizer to handle C++ destructors.
        */
-      (*finalize_imp)(anObject, finalize_sel);
+      ((GSVoidMethodIMP)finalize_imp)(anObject, finalize_sel);
 
 #ifndef OBJC_CAP_ARC
       if (GSPrivateMarkedAssociations(anObject, NO))
@@ -1894,7 +1896,8 @@ static id gs_weak_load(id obj)
 	  release_count, retain_count];
     }
 
-  (*autorelease_imp)(autorelease_class, autorelease_sel, self);
+  ((void (*)(id, SEL, id))autorelease_imp)
+    (autorelease_class, autorelease_sel, self);
   return self;
 }
 


### PR DESCRIPTION
1. We should be casting all IMPs to the correct function pointer signature since anything else would be UB
2. autorelease_imp can be a void function pointer

This has worked fine on most platforms, however, WebAssembly indirect calls require an exact signature match, so I'll need this fixed.